### PR TITLE
fix : AdminNode page error when db has no node data

### DIFF
--- a/web/src/TopicPage.js
+++ b/web/src/TopicPage.js
@@ -36,8 +36,7 @@ class TopicPage extends React.Component {
       tab: lastTabOpen ? lastTabOpen : rootTabId,
       tabs: [],
       tabInfo: null,
-      nodes: [],
-      tab: "all"
+      nodes: []
     };
     const params = new URLSearchParams(this.props.location.search);
     if (params.get("tab") !== null) {

--- a/web/src/admin/AdminNode.js
+++ b/web/src/admin/AdminNode.js
@@ -83,7 +83,7 @@ class AdminNode extends React.Component {
     NodeBackend.getNodesAdmin()
       .then((res) => {
         this.setState({
-          nodes: res,
+          nodes: res ? res : [],
         });
       });
   }
@@ -937,7 +937,7 @@ class AdminNode extends React.Component {
               this.state.nodes.map(node => this.renderNodes(node)) :
               <div className="cell" style={{textAlign: "center", height: "100px", lineHeight: "100px"}}>
                 {
-                  this.state.nodes === null ?
+                  this.state.nodes === null || this.state.nodes.length ===0 ?
                     i18next.t("node:No node yet") : i18next.t("loading:Data is loading...")
                 }
               </div>


### PR DESCRIPTION
- fixed by ensuring `this.state.nodes` is not null or undefined.
- remove duplicated `tab`
