### PR TITLE
Issue #106 fix show online number bug

### DIFF
--- a/controllers/account.go
+++ b/controllers/account.go
@@ -273,7 +273,7 @@ func (c *APIController) Signout() {
 
 	member := c.GetSessionUser()
 	util.LogInfo(c.Ctx, "API: [%s] signed out", member)
-
+	object.UpdateMemberOnlineStatus(member, false, util.GetCurrentTime())
 	c.SetSessionUser("")
 
 	resp = Response{Status: "ok", Msg: "success", Data: member}

--- a/object/basic.go
+++ b/object/basic.go
@@ -229,11 +229,7 @@ func UpdateLatestSyncedRecordId(id int) bool {
 
 // GetOnlineMemberNum returns online member num.
 func GetOnlineMemberNum() int {
-	if onlineMemberNum == 0 {
-		UpdateOnlineMemberNum()
-		return onlineMemberNum
-	}
-
+	UpdateOnlineMemberNum()
 	return onlineMemberNum
 }
 


### PR DESCRIPTION
feat: 修改​在线用户数显示异常
Issue #106 

在contrellers/account.go文件line:276 
signout函数中添加退出登录时修改对应的OnilneStatus字段的value（登出 true --> false）

在object/basic.go文件中
函数GetOnlineMemberNum中，每次访问都会根据OnilneStatus字段获取在线人数并更新onlineMemberNum。而非只在onlineMemberNum等于0时更新人数。