### PR TITLE
fix(footer): fix the onlineMember number error

### DIFF
--- a/object/basic.go
+++ b/object/basic.go
@@ -68,10 +68,7 @@ func GetForumVersion() string {
 }
 
 func GetHighestOnlineNum() int {
-	if highestOnlineNum != 0 {
-		return highestOnlineNum
-	}
-
+	
 	info := BasicInfo{Id: "HighestOnlineNum"}
 	existed, err := adapter.engine.Get(&info)
 	if err != nil {
@@ -229,11 +226,7 @@ func UpdateLatestSyncedRecordId(id int) bool {
 
 // GetOnlineMemberNum returns online member num.
 func GetOnlineMemberNum() int {
-	if onlineMemberNum == 0 {
-		UpdateOnlineMemberNum()
-		return onlineMemberNum
-	}
-
+	UpdateOnlineMemberNum()
 	return onlineMemberNum
 }
 


### PR DESCRIPTION
fix:[issue#106](https://github.com/casbin/casbin-forum/issues/106)
ref: [PR #6e3a3](https://github.com/casbin/casbin-forum/pull/87/commits/6e3a32bf4c0e5c89a3577f43ec14e471b95ee7f9)

I test in my local environment. `OnlineStatus` filed works as I expected. So it might be the API can't get it correctly. I'm not sure that the problem will be solved. Maybe I should check the online `log/database` to solve it.

I think the reason why the number of people online has remained unchanged is that the original code has been reading global variables from memory. (I'm not sure if it works online)

There is old code in [PR#6e3a3](https://github.com/casbin/casbin-forum/pull/87/commits/6e3a32bf4c0e5c89a3577f43ec14e471b95ee7f9) in `object/basic.go`[line 71](https://github.com/casbin/casbin-forum/pull/87/commits/6e3a32bf4c0e5c89a3577f43ec14e471b95ee7f9#diff-d6e7604d9281ed79af505b8dd115f1c2dc60ac8b43f00deda4ebc3949bff1716R71)

```go
func GetHighestOnlineNum() int {
	if highestOnlineNum != 0 {
		return highestOnlineNum
	}
...
```

[CR#r556300375](https://github.com/casbin/casbin-forum/pull/87/commits/6e3a32bf4c0e5c89a3577f43ec14e471b95ee7f9#r556300375)

This `if` statement makes the same value return all the time. So I think this may cause the result we got always `41`.(this number comes from memory)
