### PR TITLE
fix(UI): fixed the issue of antd polluting the global style

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1,4 +1,4 @@
-@import '~antd/dist/antd.css';
+@import '~antd/lib/back-top/style/index.css';
 
 /*.App {*/
 /*  text-align: center;*/


### PR DESCRIPTION
I certainly sure that `3rd-party login panel has style issues` caused by `antd` global style issue.

Here are some references:

* [https://zhuanlan.zhihu.com/p/50796186](https://zhuanlan.zhihu.com/p/50796186)
* [https://juejin.cn/post/6844904116288749581](https://juejin.cn/post/6844904116288749581)

And I think the **simplest** way to solve this issue is just changing the way we import the `antd` style:

[ant-design/issues/9363#issuecomment-490545432](https://github.com/ant-design/ant-design/issues/9363#issuecomment-490545432)

And it works, even I roll back to the commit which is before of `fix 3rd-party` commit #116 :


`back-to-top` works well, and the global style is not polluted:

![image](https://user-images.githubusercontent.com/36698124/105191578-3778e000-5b72-11eb-8695-03008f47be60.png)

![image](https://user-images.githubusercontent.com/36698124/105191758-68591500-5b72-11eb-8913-bfbeb4a27971.png)




