### PR TITLE
feat(newBox): add rich-text editor for newBox & set Editor Type to topic

### DIFF
--- a/controllers/topic.go
+++ b/controllers/topic.go
@@ -26,6 +26,7 @@ type NewTopicForm struct {
 	Title  string `json:"title"`
 	Body   string `json:"body"`
 	NodeId string `json:"nodeId"`
+	EditorType string `json:"editorType"`
 }
 
 func (c *APIController) GetTopics() {
@@ -145,7 +146,7 @@ func (c *APIController) AddTopic() {
 	if err != nil {
 		panic(err)
 	}
-	title, body, nodeId := form.Title, form.Body, form.NodeId
+	title, body, nodeId, editorType := form.Title, form.Body, form.NodeId, form.EditorType
 
 	topic := object.Topic{
 		//Id:            util.IntToString(object.GetTopicId()),
@@ -162,6 +163,7 @@ func (c *APIController) AddTopic() {
 		FavoriteCount: 0,
 		Content:       body,
 		Deleted:       false,
+		EditorType:    editorType,
 	}
 
 	balance := object.GetMemberBalance(memberId)

--- a/object/topic.go
+++ b/object/topic.go
@@ -39,7 +39,7 @@ type Topic struct {
 	TabTopTime      string   `xorm:"varchar(40)" json:"tabTopTime"`
 	NodeTopTime     string   `xorm:"varchar(40)" json:"nodeTopTime"`
 	Deleted         bool     `xorm:"bool" json:"-"`
-
+	EditorType      string   `xorm:"varchar(40)" json:"editorType"`
 	Content string `xorm:"mediumtext" json:"content"`
 }
 

--- a/web/package.json
+++ b/web/package.json
@@ -9,6 +9,7 @@
     "@testing-library/user-event": "^7.1.2",
     "ali-oss": "^6.9.1",
     "antd": "^4.3.0",
+    "braft-editor": "^2.3.9",
     "browser-image-size": "^1.1.0",
     "codemirror": "^5.54.0",
     "i18next": "^19.6.0",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -252,7 +252,9 @@
     "Hottest Nodes": "最热节点",
     "Publish": "发布主题",
     "New Topic": "创作新主题",
-    "Already enabled Markdown": "已启用Markdown"
+    "Already enabled Markdown": "已启用Markdown",
+    "Switch editor": "切换编辑器",
+    "richtext": "富文本"
   },
   "fav":
   {

--- a/web/src/main/NewNodeTopicBox.js
+++ b/web/src/main/NewNodeTopicBox.js
@@ -88,10 +88,9 @@ class NewNodeTopicBox extends React.Component {
   }
 
   publishTopic() {
-    if (!this.isOkToSubmit()) {
+    if (!this.isOkToSubmit() || !this.state.nodeInfo) {
       return;
     }
-
     this.updateFormField("nodeId", this.state.nodeInfo.id)
     this.updateFormField("nodeName", this.state.nodeInfo.name)
 

--- a/web/src/main/richTextEditor.js
+++ b/web/src/main/richTextEditor.js
@@ -1,0 +1,59 @@
+import React from "react";
+import BraftEditor from "braft-editor";
+import "braft-editor/dist/index.css";
+
+export default class Editor extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      editorState: BraftEditor.createEditorState(null),
+      contentStyle: {
+        height: this.props.height ? this.props.height : "350px",
+      },
+    };
+  }
+
+  fetchEditorContent() {
+    return new Promise((resolve, reject) => {
+      const data = "this is a server";
+      resolve(data);
+    });
+  }
+
+  async componentDidMount() {
+    // Assume here to get the editor content in html format from the server
+    const htmlContent = await this.fetchEditorContent();
+    // Use BraftEditor.createEditorState to convert html strings to editorState data needed by the editor
+    this.setState({
+      editorState: "",
+    });
+  }
+
+  handleEditorValueSend(text) {
+    //call father compoents function
+    this.props.onBeforeChange(text);
+  }
+
+  handleEditorChange = (editorState) => {
+    this.setState({
+      editorState,
+    });
+    const htmlContent = editorState.toHTML();
+    this.handleEditorValueSend(htmlContent);
+  };
+
+  render() {
+    const { editorState, contentStyle } = this.state;
+    return (
+      <div className="my-component">
+        <BraftEditor
+          value={editorState}
+          onChange={this.handleEditorChange}
+          onSave={this.submitContent}
+          language={this.language}
+          contentStyle={contentStyle}
+        />{" "}
+      </div>
+    );
+  }
+}


### PR DESCRIPTION
Fix: https://github.com/casbin/casbin-forum/issues/99

Support rich-text editor for the topic now.


![image](https://user-images.githubusercontent.com/36698124/106295527-8669f800-628b-11eb-9765-91250685f6d1.png)

preview:

![image](https://user-images.githubusercontent.com/36698124/106295664-b1544c00-628b-11eb-982e-b13911905a39.png)


And I think we should add a field `editor_type` to record the currently used editor:

![image](https://user-images.githubusercontent.com/36698124/106295909-f9736e80-628b-11eb-9abe-254d29a4380d.png)
