### PR TITLE
feat(edit): add OSS upload for rich-text editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Backend | RESTful API backend for Casbin-forum | Golang + Beego + MySQL | https:
     ```shell
     go get github.com/casbin/casbin-forum
     ```
+    or
+    ```shell
+    git clone https://github.com/casbin/casbin-forum
+    ```
 
 - Custom settings:
     Casbin-forum currently allows some user-defined items, and the customized files are located in `web/src/main/custom/`.
@@ -223,8 +227,12 @@ Backend | RESTful API backend for Casbin-forum | Golang + Beego + MySQL | https:
 
     ```shell
     cd web
+    ## npm
     npm install
     npm run start
+    ## yarn
+    yarn install
+    yarn run start
     ```
 
 - Open browser:

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -703,6 +703,8 @@
     "Please input plane ID": "Please input plane ID",
     "Please input plane name": "Please input plane name",
     "Please sign out before sign up": "Please sign out before sign up",
-    "Please sign out before sign in": "Please sign out before sign in"
+    "Please sign out before sign in": "Please sign out before sign in",
+    "Adding image failed": "Adding image failed",
+    "Add file failed": "Add file failed"
   }
 }

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -705,6 +705,8 @@
     "Please input plane ID": "请填写位面ID",
     "Please input plane name": "请填写位面名称",
     "Please sign out before sign up": "注册前请先登出",
-    "Please sign out before sign in": "登录前请先登出"
+    "Please sign out before sign in": "登录前请先登出",
+    "Adding image failed": "添加图片文件失败",
+    "Add file failed": "添加文件失败"
   }
 }

--- a/web/src/main/Tools.js
+++ b/web/src/main/Tools.js
@@ -61,7 +61,7 @@ export function uploadMdFile(addMsg) {
   timestamp = Date.parse(new Date());
 
   /* eslint-disable */ inlineAttachment.prototype.uploadFile = function (file) {
-    if (file.size > 6291456) {
+    if (file.size > 1024 * 1024 * 6) {
       alert("File size exceeds 6MB");
       return;
     }
@@ -76,7 +76,6 @@ export function uploadMdFile(addMsg) {
     newClient
       .multipartUpload(`${filePath}`, file)
       .then((res) => {
-        console.log("upload success");
         this.onFileUploadResponse(file.name, encodeURI(mdUrl));
         uploadStatus = true;
         FileBackend.addFileRecord({
@@ -87,14 +86,17 @@ export function uploadMdFile(addMsg) {
         });
       })
       .catch((error) =>
-        Setting.showMessage("error", `Adding image failed：${error}`)
+        Setting.showMessage(
+          "error",
+          i18next.t("Adding image failed") + `：${error}`
+        )
       );
   };
 }
 
 // upload file through files page
 export function uploadFile(file) {
-  if (file.size > 6291456) {
+  if (file.size > 1024 * 1024 * 6) {
     alert("File size exceeds 6MB");
     return;
   }
@@ -111,11 +113,9 @@ export function uploadFile(file) {
   let filePath = `${path}/${fileType.fileType}/${fileName}`; //path
   newClient
     .multipartUpload(`${filePath}`, file)
-    .then((res) => {
-      console.log("upload success");
-    })
+    .then((res) => {})
     .catch((error) =>
-      Setting.showMessage("error", `Add file failed：${error}`)
+      Setting.showMessage("error", i18next.t("Add file failed") + `：${error}`)
     );
 
   return FileBackend.addFileRecord({
@@ -135,7 +135,7 @@ export function uploadAvatar(file, redirectUrl) {
   url = Setting.OSSUrl;
   timestamp = Date.parse(new Date());
   fileName = timestamp + "." + fileType.ext;
-  if (file.size > 2097152) {
+  if (file.size > 2 * 1024 * 1024) {
     alert("File size exceeds 2MB");
     return;
   }
@@ -144,21 +144,23 @@ export function uploadAvatar(file, redirectUrl) {
   newClient
     .multipartUpload(`${filePath}`, file)
     .then((res) => {
-      console.log("upload success");
       MemberBackend.updateMemberAvatar(`${url}/avatar/${fileName}`).then(
         () => (window.location.href = `${redirectUrl}?success=true`)
       );
     })
     .catch((error) =>
-      Setting.showMessage("error", `Adding image failed：${error}`)
+      Setting.showMessage(
+        "error",
+        i18next.t("Adding image failed") + `：${error}`
+      )
     );
 }
 
 export function myUploadFn(param) {
   const errorFn = (response) => {
-    // 上传发生错误时调用param.error
+    // call the erroFn when the upload process failed.
     param.error({
-      msg: "unable to upload.",
+      msg: i18next.t("Adding image failed"),
     });
   };
   const successFn = (response) => {
@@ -179,8 +181,7 @@ export function myUploadFn(param) {
     filePath,
     fileName,
     size,
-    originalFileName,
-    uploadStatus = false;
+    originalFileName;
 
   newClient = Setting.OSSClient;
   path = Setting.OSSFileUrl;
@@ -195,12 +196,9 @@ export function myUploadFn(param) {
 
   let mdUrl = `${url}/${fileType.fileType}/${fileName}`;
   filePath = `${path}/${fileType.fileType}/${fileName}`; //path
-
   newClient
     .multipartUpload(`${filePath}`, param.file)
     .then((res) => {
-      console.log("upload success");
-      // this.onFileUploadResponse(file.name, encodeURI(mdUrl));
       uploadStatus = true;
       FileBackend.addFileRecord({
         fileName: originalFileName,
@@ -212,6 +210,9 @@ export function myUploadFn(param) {
     })
     .catch((error) => {
       errorFn();
-      return Setting.showMessage("error", `Adding image failed：${error}`);
+      return Setting.showMessage(
+        "error",
+        i18next.t("Adding image failed") + `：${error}`
+      );
     });
 }

--- a/web/src/main/richTextEditor.js
+++ b/web/src/main/richTextEditor.js
@@ -1,6 +1,7 @@
 import React from "react";
 import BraftEditor from "braft-editor";
 import "braft-editor/dist/index.css";
+import { myUploadFn } from "./Tools";
 
 export default class Editor extends React.Component {
   constructor(props) {
@@ -42,17 +43,25 @@ export default class Editor extends React.Component {
     this.handleEditorValueSend(htmlContent);
   };
 
+  ValidateFn = (file) => {
+    return file.size < 6291456;
+  };
+
   render() {
     const { editorState, contentStyle } = this.state;
+    const UploadFn = myUploadFn;
     return (
       <div className="my-component">
         <BraftEditor
           value={editorState}
           onChange={this.handleEditorChange}
-          onSave={this.submitContent}
           language={this.language}
           contentStyle={contentStyle}
-        />{" "}
+          media={{
+            uploadFn: UploadFn,
+            validateFn: this.ValidateFn,
+          }}
+        />
       </div>
     );
   }

--- a/web/src/main/richTextEditor.js
+++ b/web/src/main/richTextEditor.js
@@ -44,7 +44,8 @@ export default class Editor extends React.Component {
   };
 
   ValidateFn = (file) => {
-    return file.size < 6291456;
+    //file should be less than 6MB
+    return file.size < 1024 * 1024 * 6;
   };
 
   render() {


### PR DESCRIPTION
Fix: #99 

* Support for uploading pictures to OSS in `rich-text` editor, and keep the same format for the file uploaded.

![image](https://user-images.githubusercontent.com/36698124/107125554-a9c52080-68e5-11eb-891b-e67560b74c50.png)


After post to topic:

![image](https://user-images.githubusercontent.com/36698124/107125579-c95c4900-68e5-11eb-8f72-84ac4e2aea61.png)


