### PR TITLE
feat: support re-edit content with old editor & support richText in new replyBox

### DIFF
--- a/controllers/topic.go
+++ b/controllers/topic.go
@@ -23,9 +23,9 @@ import (
 )
 
 type NewTopicForm struct {
-	Title  string `json:"title"`
-	Body   string `json:"body"`
-	NodeId string `json:"nodeId"`
+	Title      string `json:"title"`
+	Body       string `json:"body"`
+	NodeId     string `json:"nodeId"`
 	EditorType string `json:"editorType"`
 }
 
@@ -411,7 +411,7 @@ func (c *APIController) EditContent() {
 		if err != nil {
 			panic(err)
 		}
-		id, title, content, nodeId := form.Id, form.Title, form.Content, form.NodeId
+		id, title, content, nodeId, editorType := form.Id, form.Title, form.Content, form.NodeId, form.EditorType
 		if !object.CheckModIdentity(memberId) && !object.CheckNodeModerator(memberId, nodeId) && object.GetTopicAuthor(id) != memberId {
 			resp = Response{Status: "fail", Msg: "Unauthorized."}
 			c.Data["json"] = resp
@@ -420,9 +420,10 @@ func (c *APIController) EditContent() {
 		}
 
 		topic := object.Topic{
-			Id:      id,
-			Title:   title,
-			Content: content,
+			Id:         id,
+			Title:      title,
+			Content:    content,
+			EditorType: editorType,
 		}
 		res := object.UpdateTopicWithLimitCols(id, &topic)
 
@@ -433,7 +434,7 @@ func (c *APIController) EditContent() {
 		if err != nil {
 			panic(err)
 		}
-		id, content := form.Id, form.Content
+		id, content, editorType := form.Id, form.Content, form.EditorType
 		if !object.CheckModIdentity(memberId) && object.GetReplyAuthor(id) != memberId {
 			resp = Response{Status: "fail", Msg: "Unauthorized."}
 			c.Data["json"] = resp
@@ -442,8 +443,9 @@ func (c *APIController) EditContent() {
 		}
 
 		reply := object.Reply{
-			Id:      id,
-			Content: content,
+			Id:         id,
+			Content:    content,
+			EditorType: editorType,
 		}
 		res := object.UpdateReplyWithLimitCols(id, &reply)
 

--- a/controllers/type.go
+++ b/controllers/type.go
@@ -85,15 +85,17 @@ type updateTopicNode struct {
 }
 
 type editTopic struct {
-	Id      int    `json:"id"`
-	Title   string `json:"title"`
-	NodeId  string `json:"nodeId"`
-	Content string `json:"content"`
+	Id         int    `json:"id"`
+	Title      string `json:"title"`
+	NodeId     string `json:"nodeId"`
+	Content    string `json:"content"`
+	EditorType string `json:"editorType"`
 }
 
 type editReply struct {
-	Id      int    `json:"id"`
-	Content string `json:"content"`
+	Id         int    `json:"id"`
+	Content    string `json:"content"`
+	EditorType string `json:"editorType"`
 }
 
 type getResetPasswordMember struct {

--- a/object/reply.go
+++ b/object/reply.go
@@ -25,8 +25,8 @@ type Reply struct {
 	CreatedTime string `xorm:"varchar(40)" json:"createdTime"`
 	Deleted     bool   `xorm:"bool" json:"-"`
 	ThanksNum   int    `xorm:"int" json:"thanksNum"`
-
-	Content string `xorm:"mediumtext" json:"content"`
+	EditorType  string `xorm:"varchar(40)" json:"editorType"`
+	Content     string `xorm:"mediumtext" json:"content"`
 }
 
 // GetReplyCount returns all replies num so far, both deleted and not deleted.

--- a/web/src/main/EditBox.js
+++ b/web/src/main/EditBox.js
@@ -46,7 +46,7 @@ class EditBox extends React.Component {
           id: 1,
         },
       ],
-      placeholder: i18next.t("new:markdowm"),
+      placeholder: "",
     };
   }
 
@@ -63,8 +63,10 @@ class EditBox extends React.Component {
       form["nodeId"] = this.state.editObject?.nodeId;
     }
     form["content"] = this.state.editObject?.content;
+    form["editorType"] = this.state.editObject?.editorType;
     this.setState({
       form: form,
+      placeholder: i18next.t(`new:${this.state.editObject?.editorType}`),
     });
   }
 
@@ -161,7 +163,7 @@ class EditBox extends React.Component {
     );
   }
 
-  editor() {
+  renderEditor() {
     if (
       !this.state.form.editorType ||
       this.state.form.editorType === "markdown"
@@ -217,6 +219,7 @@ class EditBox extends React.Component {
           id="reply_content"
         >
           <Editor
+            defaultValue={this.state.form.content}
             language={i18next.language}
             height="300px"
             id="richTextEditor"
@@ -274,7 +277,7 @@ class EditBox extends React.Component {
             <table cellPadding="5" cellSpacing="0" border="0" width="100%">
               <tbody>
                 <tr>
-                  <td>{this.editor()}</td>
+                  <td>{this.renderEditor()}</td>
                 </tr>
                 <tr>
                   <td
@@ -334,7 +337,7 @@ class EditBox extends React.Component {
                 </td>
               </tr>
               <tr>
-                <td>{this.editor()}</td>
+                <td>{this.renderEditor()}</td>
               </tr>
               <tr>
                 <td

--- a/web/src/main/richTextEditor.js
+++ b/web/src/main/richTextEditor.js
@@ -28,8 +28,12 @@ export default class Editor extends React.Component {
     // Assume here to get the editor content in html format from the server
     // const htmlContent = await this.fetchEditorContent();
     // Use BraftEditor.createEditorState to convert html strings to editorState data needed by the editor
+    const rawDefaultVal = this.props.defaultValue;
+    const defaultVal = rawDefaultVal
+      ? BraftEditor.createEditorState(rawDefaultVal)
+      : "";
     this.setState({
-      editorState: "",
+      editorState: defaultVal,
     });
   }
 


### PR DESCRIPTION
* add rich-text editorType support for new reply

![image](https://user-images.githubusercontent.com/36698124/108581936-30a8dd00-736b-11eb-92ed-89a30cbc4a57.png)

* support re-edit with the previous `editorType`

re-edit reply

https://user-images.githubusercontent.com/36698124/108582073-e6742b80-736b-11eb-9265-1b7bd5e8b44f.mp4



re-edit topic



https://user-images.githubusercontent.com/36698124/108582047-bd539b00-736b-11eb-9832-0bcac2976ed5.mp4


