### PR TITLE
feat(eidtor): support user default editor

### DIFF
--- a/controllers/member.go
+++ b/controllers/member.go
@@ -144,6 +144,43 @@ func (c *APIController) UpdateMemberInfo() {
 	c.ServeJSON()
 }
 
+func (c *APIController) GetMemberEditorType() {
+	memberId := c.GetSessionUser()
+
+	var resp Response
+	var editorType string
+
+	if len(memberId) == 0 {
+		editorType = ""
+	} else {
+		editorType = object.GetMemberEditorType(memberId)
+	}
+
+	resp = Response{Status: "ok", Msg: "success", Data: editorType}
+
+	c.Data["json"] = resp
+	c.ServeJSON()
+}
+
+func (c *APIController) UpdateMemberEditorType() {
+	editorType := c.Input().Get("editorType")
+	memberId := c.GetSessionUser()
+
+	var resp Response
+
+	if editorType != "markdown" && editorType != "richtext" {
+		resp = Response{Status: "fail", Msg: "Bad request."}
+		c.Data["json"] = resp
+		c.ServeJSON()
+	}
+
+	res := object.UpdateMemberEditorType(memberId, editorType)
+	resp = Response{Status: "ok", Msg: "success", Data: res}
+
+	c.Data["json"] = resp
+	c.ServeJSON()
+}
+
 func (c *APIController) UpdateMemberLanguage() {
 	language := c.Input().Get("language")
 	memberId := c.GetSessionUser()

--- a/object/member.go
+++ b/object/member.go
@@ -40,6 +40,7 @@ type Member struct {
 	Website            string `xorm:"varchar(100)" json:"website"`
 	Location           string `xorm:"varchar(100)" json:"location"`
 	Language           string `xorm:"varchar(10)"  json:"language"`
+	EditorType         string `xorm:"varchar(10)"  json:"editorType"`
 	FileQuota          int    `xorm:"int" json:"fileQuota"`
 	GoogleAccount      string `xorm:"varchar(100)" json:"googleAccount"`
 	GithubAccount      string `xorm:"varchar(100)" json:"githubAccount"`
@@ -241,6 +242,36 @@ func UpdateMemberAvatar(id string, avatar string) bool {
 	}
 
 	return true
+}
+
+func UpdateMemberEditorType(id string, editorType string) bool {
+	if GetMember(id) == nil {
+		return false
+	}
+
+	member := new(Member)
+	member.EditorType = editorType
+
+	_, err := adapter.engine.Id(id).MustCols("editor_type").Update(member)
+	if err != nil {
+		panic(err)
+	}
+
+	return true
+}
+
+func GetMemberEditorType(id string) string {
+	member := Member{}
+	existed, err := adapter.engine.Id(id).Cols("editor_type").Get(&member)
+	if err != nil {
+		panic(err)
+	}
+
+	if existed {
+		return member.EditorType
+	} else {
+		return ""
+	}
 }
 
 func UpdateMemberLanguage(id string, language string) bool {

--- a/routers/router.go
+++ b/routers/router.go
@@ -77,6 +77,8 @@ func initAPI() {
 	beego.Router("/api/get-member-sts-token", &controllers.APIController{}, "GET:GetMemberStsToken")
 	beego.Router("/api/update-member-language", &controllers.APIController{}, "POST:UpdateMemberLanguage")
 	beego.Router("/api/get-member-language", &controllers.APIController{}, "GET:GetMemberLanguage")
+	beego.Router("/api/update-member-editorType", &controllers.APIController{}, "POST:UpdateMemberEditorType")
+	beego.Router("/api/get-member-editorType", &controllers.APIController{}, "GET:GetMemberEditorType")
 	beego.Router("/api/update-member-email-reminder", &controllers.APIController{}, "POST:UpdateMemberEmailReminder")
 
 	beego.Router("/api/get-nodes", &controllers.APIController{}, "GET:GetNodes")

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -36,6 +36,7 @@ import NodesBox from "./main/NodeBox";
 import FavoritesBox from "./main/FavoritesBox";
 import RecentTopicsBox from "./main/RecentTopicsBox";
 import SelectLanguageBox from "./main/SelectLanguageBox";
+import SelectEditorTypeBox from "./main/SelectEditorTypeBox";
 import RightCommunityHealthBox from "./rightbar/RightCommunityHealthBox";
 import RightFavouriteBox from "./rightbar/RightFavouriteBox";
 import RightNodeBox from "./rightbar/RightNodeBox";
@@ -305,6 +306,12 @@ class App extends Component {
           <div id={pcBrowser ? "Main" : ""}>
             {pcBrowser ? <div className="sep20" /> : null}
             <SelectLanguageBox />
+          </div>
+        </Route>
+        <Route exact path="/select/editorType">
+          <div id={pcBrowser ? "Main" : ""}>
+            {pcBrowser ? <div className="sep20" /> : null}
+            <SelectEditorTypeBox />
           </div>
         </Route>
         <Route exact path="/notifications">

--- a/web/src/Footer.js
+++ b/web/src/Footer.js
@@ -159,6 +159,16 @@ class Footer extends React.Component {
               />{" "}
               &nbsp; {i18next.t("footer:Select Language")}
             </Link>
+            &nbsp; <span className="snow">·</span> &nbsp;{" "}
+            <Link to="/select/editorType" className="f11">
+              <img
+                src={Setting.getStatic("/static/img/editType.png")}
+                width="16"
+                align="absmiddle"
+                id="ico-select-editorType"
+              />{" "}
+              &nbsp; {i18next.t("footer:Select Editor")}
+            </Link>
             <div className="sep20" />
             {i18next.t("footer:Community of Creators")}
             <div className="sep5" />

--- a/web/src/Setting.js
+++ b/web/src/Setting.js
@@ -202,6 +202,15 @@ export function getOSSClient(initNewOSSClient) {
   });
 }
 
+export function SetEditorType(editorType) {
+  localStorage.setItem("casbin-forum-editorType", editorType);
+}
+
+export function ChangeEditorType(editorType) {
+  localStorage.setItem("casbin-forum-editorType", editorType);
+  MemberBackend.updateMemberEditorType(editorType).then(() => goToLink("/"));
+}
+
 export function SetLanguage(language) {
   localStorage.setItem("casbin-forum-language", language);
   changeMomentLanguage(language);

--- a/web/src/backend/MemberBackend.js
+++ b/web/src/backend/MemberBackend.js
@@ -155,3 +155,13 @@ export function updateMemberLanguage(language) {
     }
   ).then((res) => res.json());
 }
+
+export function updateMemberEditorType(editorType) {
+  return fetch(
+    `${Setting.ServerUrl}/api/update-member-editorType?editorType=${editorType}`,
+    {
+      method: "POST",
+      credentials: "include",
+    }
+  ).then((res) => res.json());
+}

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -616,7 +616,8 @@
     "Online": "Online",
     "Highest": "Highest",
     "Community of Creators": "Community of Creators",
-    "Select Language": "Select Language"
+    "Select Language": "Select Language",
+    "Select Editor": "Select Editor"
   },
   "admin": {
     "Backstage management": "Backstage management",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -616,7 +616,8 @@
     "Online": "人在线",
     "Highest": "最高记录",
     "Community of Creators": "创意工作者们的社区",
-    "Select Language": "选择语言"
+    "Select Language": "选择语言",
+    "Select Editor": "选择编辑器"
   },
   "admin": {
     "Backstage management": "后台管理",

--- a/web/src/main/SelectEditorTypeBox.js
+++ b/web/src/main/SelectEditorTypeBox.js
@@ -1,0 +1,72 @@
+// Copyright 2020 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from "react";
+import * as Setting from "../Setting";
+import { Link } from "react-router-dom";
+import i18next from "i18next";
+
+class SelectLanguageBox extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      classes: props,
+    };
+  }
+
+  render() {
+    return (
+      <div align="center">
+        <div
+          class="box"
+          style={{ width: Setting.PcBrowser ? "600px" : "auto" }}
+        >
+          <div class="header">
+            <Link to="/">{Setting.getForumName()}</Link>{" "}
+            <span class="chevron">&nbsp;›&nbsp;</span> Select Default Editor /
+            选择默认编辑器
+          </div>
+          <div class="cell">
+            {Setting.PcBrowser ? (
+              <span>
+                Please select the Default Editor you would like to use on{" "}
+                {Setting.getForumName()}
+              </span>
+            ) : (
+              <span>
+                Please select the Default Editor you would like to use:
+              </span>
+            )}
+          </div>
+          <a
+            href="javascript:void(0);"
+            onClick={() => Setting.ChangeEditorType("markdown")}
+            class="lang-selector"
+          >
+            {i18next.t("new:MarkDown")}
+          </a>
+          <a
+            href="javascript:void(0);"
+            onClick={() => Setting.ChangeEditorType("richtext")}
+            class="lang-selector"
+          >
+            {i18next.t("new:RichText")}
+          </a>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default SelectLanguageBox;


### PR DESCRIPTION
**Support user default editor**

Add API:

* `/api/update-member-editorType`
* `/api/get-member-editorType`

and add UI/UX for default editor for user:

![image](https://user-images.githubusercontent.com/36698124/108596333-58299500-73bf-11eb-81b9-4337812a0123.png)


![image](https://user-images.githubusercontent.com/36698124/108596349-755e6380-73bf-11eb-9b38-aa70fab859be.png)

back-end API test:

call `get` API `http://localhost:7000/api/get-member-editorType`

![image](https://user-images.githubusercontent.com/36698124/108596216-88246880-73be-11eb-9a81-d0c17000bd7b.png)

Table `member`:

![image](https://user-images.githubusercontent.com/36698124/108596242-ac804500-73be-11eb-8e6d-788de0906d37.png)


call `update` API `http://localhost:7000/api/update-member-editorType?editorType=richtext`

![image](https://user-images.githubusercontent.com/36698124/108596256-c7eb5000-73be-11eb-87c5-00748690e27e.png)

Table `member/editorType` changed:

![image](https://user-images.githubusercontent.com/36698124/108596268-e3565b00-73be-11eb-9b7f-2942d0ff1761.png)




