### PR TITLE
fix(editor): fix user default editor init issue

### DIFF
--- a/web/src/main/NewBox.js
+++ b/web/src/main/NewBox.js
@@ -61,7 +61,8 @@ class NewBox extends React.Component {
   componentWillMount() {
     this.getNodes();
     MemberBackend.getMemberEditorType().then((res) => {
-      this.updateFormField("editorType", res.data);
+      const editorType = res.data ? res.data : "markdown";
+      this.updateFormField("editorType", editorType);
       this.setState({
         placeholder: i18next.t(`new:${this.state.form.editorType}`),
       });

--- a/web/src/main/NewNodeTopicBox.js
+++ b/web/src/main/NewNodeTopicBox.js
@@ -65,7 +65,8 @@ class NewNodeTopicBox extends React.Component {
 
   componentWillMount() {
     MemberBackend.getMemberEditorType().then((res) => {
-      this.updateFormField("editorType", res.data);
+      const editorType = res.data ? res.data : "markdown";
+      this.updateFormField("editorType", editorType);
       this.setState({
         placeholder: i18next.t(`new:${this.state.form.editorType}`),
       });

--- a/web/src/main/NewReplyBox.js
+++ b/web/src/main/NewReplyBox.js
@@ -61,7 +61,8 @@ class NewReplyBox extends React.Component {
 
   componentWillMount() {
     MemberBackend.getMemberEditorType().then((res) => {
-      this.updateFormField("editorType", res.data);
+      const editorType = res.data ? res.data : "markdown";
+      this.updateFormField("editorType", editorType);
       this.setState({
         placeholder: i18next.t(`new:${this.state.form.editorType}`),
       });


### PR DESCRIPTION
the user which never chooses the `editorType`  will get `null` editorType.

![image](https://user-images.githubusercontent.com/36698124/108646330-64f9d600-74f0-11eb-82dd-0cedb45268d6.png)

And it cause the empty `editorType`  init in FE.


before:(the user never chooses the `editorType` )

![image](https://user-images.githubusercontent.com/36698124/108646509-18fb6100-74f1-11eb-95df-8da5976a5027.png)


now:
![image](https://user-images.githubusercontent.com/36698124/108646469-f5381b00-74f0-11eb-9cc8-aeb07930de1d.png)
