### PR TITLE
fix: made casnode adapt the layout according to the page size

### DIFF
--- a/object/basic.go
+++ b/object/basic.go
@@ -113,7 +113,7 @@ func GetCaptcha() (string, []byte) {
 
 	var buffer bytes.Buffer
 
-	err := captcha.WriteImage(&buffer, id, 320, 80)
+	err := captcha.WriteImage(&buffer, id, 200, 80)
 	if err != nil {
 		panic(err)
 	}

--- a/web/src/TopicPage.js
+++ b/web/src/TopicPage.js
@@ -252,7 +252,7 @@ class TopicPage extends React.Component {
           <tbody>
             <tr>
               <td width="auto">
-                {this.state.unreadNotificationNum !== 0 ? (
+                {this.state.unreadNotificationNum === 0 ? (
                   <Link to="/notifications" className="gray">
                     0 {i18next.t("bar:unread")}
                   </Link>

--- a/web/src/admin/AdminMember.js
+++ b/web/src/admin/AdminMember.js
@@ -518,7 +518,10 @@ class AdminMember extends React.Component {
                 <table cellPadding="5" cellSpacing="0" border="0" width="100%">
                   <tbody>
                     <tr>
-                      <td width="120" align="right">
+                      <td
+                        width={Setting.PcBrowser ? "120" : "90"}
+                        align="right"
+                      >
                         {i18next.t("member:Username")}
                       </td>
                       <td width="auto" align="left">
@@ -526,7 +529,10 @@ class AdminMember extends React.Component {
                       </td>
                     </tr>
                     <tr>
-                      <td width="120" align="right">
+                      <td
+                        width={Setting.PcBrowser ? "120" : "90"}
+                        align="right"
+                      >
                         {i18next.t("member:Topic num")}
                       </td>
                       <td width="auto" align="left">
@@ -534,7 +540,10 @@ class AdminMember extends React.Component {
                       </td>
                     </tr>
                     <tr>
-                      <td width="120" align="right">
+                      <td
+                        width={Setting.PcBrowser ? "120" : "90"}
+                        align="right"
+                      >
                         {i18next.t("member:Reply num")}
                       </td>
                       <td width="auto" align="left">
@@ -542,7 +551,10 @@ class AdminMember extends React.Component {
                       </td>
                     </tr>
                     <tr>
-                      <td width="120" align="right">
+                      <td
+                        width={Setting.PcBrowser ? "120" : "90"}
+                        align="right"
+                      >
                         {i18next.t("member:Balance")}
                       </td>
                       <td width="auto" align="left">
@@ -550,7 +562,10 @@ class AdminMember extends React.Component {
                       </td>
                     </tr>
                     <tr>
-                      <td width="120" align="right">
+                      <td
+                        width={Setting.PcBrowser ? "120" : "90"}
+                        align="right"
+                      >
                         {i18next.t("member:Latest login")}
                       </td>
                       <td width="auto" align="left">
@@ -558,7 +573,10 @@ class AdminMember extends React.Component {
                       </td>
                     </tr>
                     <tr>
-                      <td width="120" align="right">
+                      <td
+                        width={Setting.PcBrowser ? "120" : "90"}
+                        align="right"
+                      >
                         {i18next.t("member:Files num")}
                       </td>
                       <td width="auto" align="left">
@@ -568,7 +586,10 @@ class AdminMember extends React.Component {
                       </td>
                     </tr>
                     <tr>
-                      <td width="120" align="right">
+                      <td
+                        width={Setting.PcBrowser ? "120" : "90"}
+                        align="right"
+                      >
                         {i18next.t("member:File quota")}
                       </td>
                       <td width="auto" align="left">
@@ -608,7 +629,10 @@ class AdminMember extends React.Component {
                       </td>
                     </tr>
                     <tr>
-                      <td width="120" align="right">
+                      <td
+                        width={Setting.PcBrowser ? "120" : "90"}
+                        align="right"
+                      >
                         {i18next.t("member:Status")}
                       </td>
                       <td width="auto" align="left">
@@ -616,7 +640,10 @@ class AdminMember extends React.Component {
                           value={this.getIndexFromStatus(
                             this.state.form?.status
                           )}
-                          style={{ width: "300px", fontSize: "14px" }}
+                          style={{
+                            width: Setting.PcBrowser ? "300px" : "200px",
+                            fontSize: "14px",
+                          }}
                           data={this.state.Status_LIST.map((status, i) => {
                             return {
                               text: `${i18next.t(`member:${status.label}`)}`,
@@ -641,7 +668,10 @@ class AdminMember extends React.Component {
                       </td>
                     </tr>
                     <tr>
-                      <td width="120" align="right"></td>
+                      <td
+                        width={Setting.PcBrowser ? "120" : "90"}
+                        align="right"
+                      ></td>
                       <td width="auto" align="left">
                         <input
                           type="submit"
@@ -667,7 +697,7 @@ class AdminMember extends React.Component {
               <table cellPadding="5" cellSpacing="0" border="0" width="100%">
                 <tbody>
                   <tr>
-                    <td width="120" align="right">
+                    <td width={Setting.PcBrowser ? "120" : "90"} align="right">
                       <Avatar
                         username={member?.id}
                         size="small"
@@ -680,7 +710,7 @@ class AdminMember extends React.Component {
                     </td>
                   </tr>
                   <tr>
-                    <td width="120" align="right">
+                    <td width={Setting.PcBrowser ? "120" : "90"} align="right">
                       {i18next.t("setting:Username")}
                     </td>
                     <td width="auto" align="left">
@@ -688,7 +718,7 @@ class AdminMember extends React.Component {
                     </td>
                   </tr>
                   <tr>
-                    <td width="120" align="right">
+                    <td width={Setting.PcBrowser ? "120" : "90"} align="right">
                       {i18next.t("setting:Phone")}
                     </td>
                     <td width="200" align="left">
@@ -702,7 +732,7 @@ class AdminMember extends React.Component {
                         </code>
                       )}
                     </td>
-                    <td width="auto" align="left">
+                    <td width="100" align="left">
                       {member?.phoneVerifiedTime.length === 0 ? (
                         <span className="negative">
                           {i18next.t("member:Unverified")}
@@ -715,7 +745,7 @@ class AdminMember extends React.Component {
                     </td>
                   </tr>
                   <tr>
-                    <td width="120" align="right">
+                    <td width={Setting.PcBrowser ? "120" : "90"} align="right">
                       {i18next.t("setting:Email")}
                     </td>
                     <td width="200" align="left">
@@ -727,7 +757,7 @@ class AdminMember extends React.Component {
                         <code>{member?.email}</code>
                       )}
                     </td>
-                    <td width="auto" align="left">
+                    <td width="100" align="left">
                       {member?.emailVerifiedTime.length === 0 ? (
                         <span className="negative">
                           {i18next.t("member:Unverified")}
@@ -740,7 +770,7 @@ class AdminMember extends React.Component {
                     </td>
                   </tr>
                   <tr>
-                    <td width="120" align="right">
+                    <td width={Setting.PcBrowser ? "120" : "90"} align="right">
                       Google
                     </td>
                     <td width="200" align="left">
@@ -754,7 +784,7 @@ class AdminMember extends React.Component {
                     </td>
                   </tr>
                   <tr>
-                    <td width="120" align="right">
+                    <td width={Setting.PcBrowser ? "120" : "90"} align="right">
                       Github
                     </td>
                     <td width="200" align="left">
@@ -768,7 +798,7 @@ class AdminMember extends React.Component {
                     </td>
                   </tr>
                   <tr>
-                    <td width="120" align="right">
+                    <td width={Setting.PcBrowser ? "120" : "90"} align="right">
                       {i18next.t("setting:WeChat")}
                     </td>
                     <td width="200" align="left">
@@ -782,7 +812,7 @@ class AdminMember extends React.Component {
                     </td>
                   </tr>
                   <tr>
-                    <td width="120" align="right">
+                    <td width={Setting.PcBrowser ? "120" : "90"} align="right">
                       QQ
                     </td>
                     <td width="200" align="left">
@@ -794,7 +824,7 @@ class AdminMember extends React.Component {
                         <code>{member?.qqAccount}</code>
                       )}
                     </td>
-                    <td width="auto" align="left">
+                    <td width="100" align="left">
                       {member?.qqVerifiedTime.length === 0 ? (
                         <span className="negative">
                           {i18next.t("member:Unverified")}
@@ -807,7 +837,7 @@ class AdminMember extends React.Component {
                     </td>
                   </tr>
                   <tr>
-                    <td width="120" align="right">
+                    <td width={Setting.PcBrowser ? "120" : "90"} align="right">
                       {i18next.t("setting:Website")}
                     </td>
                     <td width="200" align="left">
@@ -815,7 +845,7 @@ class AdminMember extends React.Component {
                     </td>
                   </tr>
                   <tr>
-                    <td width="120" align="right">
+                    <td width={Setting.PcBrowser ? "120" : "90"} align="right">
                       {i18next.t("setting:Company")}
                     </td>
                     <td width="200" align="left">
@@ -823,7 +853,7 @@ class AdminMember extends React.Component {
                     </td>
                   </tr>
                   <tr>
-                    <td width="120" align="right">
+                    <td width={Setting.PcBrowser ? "120" : "90"} align="right">
                       {i18next.t("setting:Company title")}
                     </td>
                     <td width="200" align="left">
@@ -831,7 +861,7 @@ class AdminMember extends React.Component {
                     </td>
                   </tr>
                   <tr>
-                    <td width="120" align="right">
+                    <td width={Setting.PcBrowser ? "120" : "90"} align="right">
                       {i18next.t("setting:Location")}
                     </td>
                     <td width="200" align="left">
@@ -839,7 +869,7 @@ class AdminMember extends React.Component {
                     </td>
                   </tr>
                   <tr>
-                    <td width="120" align="right">
+                    <td width={Setting.PcBrowser ? "120" : "90"} align="right">
                       {i18next.t("setting:Tagline")}
                     </td>
                     <td width="200" align="left">
@@ -847,7 +877,7 @@ class AdminMember extends React.Component {
                     </td>
                   </tr>
                   <tr>
-                    <td width="120" align="right">
+                    <td width={Setting.PcBrowser ? "120" : "90"} align="right">
                       {i18next.t("setting:Bio")}
                     </td>
                     <td width="200" align="left">
@@ -855,7 +885,10 @@ class AdminMember extends React.Component {
                     </td>
                   </tr>
                   <tr>
-                    <td width="120" align="right"></td>
+                    <td
+                      width={Setting.PcBrowser ? "120" : "90"}
+                      align="right"
+                    ></td>
                     <td width="auto" align="left">
                       <Link to={`/member/${member?.id}`} target="_blank">
                         {i18next.t("member:Homepage")}&nbsp; ›&nbsp;

--- a/web/src/admin/AdminNode.js
+++ b/web/src/admin/AdminNode.js
@@ -482,7 +482,10 @@ class AdminNode extends React.Component {
     return (
       <Select2
         value={value}
-        style={{ width: "300px", fontSize: "14px" }}
+        style={{
+          width: Setting.PcBrowser ? "300px" : "200px",
+          fontSize: "14px",
+        }}
         data={data}
         onSelect={(event) => {
           const s = event.target.value;
@@ -1001,6 +1004,7 @@ class AdminNode extends React.Component {
                         accept=".jpg,.gif,.png,.JPG,.GIF,.PNG"
                         onChange={(event) => this.handleUploadImage(event)}
                         name="backgroundImage"
+                        style={{ width: "200px" }}
                       />
                     </td>
                   </tr>

--- a/web/src/admin/AdminTab.js
+++ b/web/src/admin/AdminTab.js
@@ -567,7 +567,10 @@ class AdminTab extends React.Component {
                             value={this.getIndexFromNodeId(
                               this.state.form?.defaultNode
                             )}
-                            style={{ width: "300px", fontSize: "14px" }}
+                            style={{
+                              width: Setting.PcBrowser ? "300px" : "200px",
+                              fontSize: "14px",
+                            }}
                             data={this.state.nodes.map((node, i) => {
                               return {
                                 text: `${node.name} / ${node.id}`,

--- a/web/src/main/EditBox.js
+++ b/web/src/main/EditBox.js
@@ -181,9 +181,9 @@ class EditBox extends React.Component {
         >
           <Resizable
             enable={false}
-            defaultSize={{
-              width: 730,
-              height: 310,
+            style={{
+              width: "100%",
+              height: "310",
             }}
           >
             <CodeMirror

--- a/web/src/main/ForgotBox.js
+++ b/web/src/main/ForgotBox.js
@@ -634,12 +634,12 @@ class ForgotBox extends React.Component {
                 <td width="120" align="right">
                   {i18next.t("login:Are you a bot?")}{" "}
                 </td>
-                <td width="auto" align="left">
+                <td width="200" align="left">
                   <div
                     style={{
                       backgroundImage: `url('data:image/png;base64,${this.state.captcha}')`,
                       backgroundRepeat: "no-repeat",
-                      width: "320px",
+                      width: "auto",
                       height: "80px",
                       borderRadius: "3px",
                       border: "1px solid #ccc",

--- a/web/src/main/MoveTopicNodeBox.js
+++ b/web/src/main/MoveTopicNodeBox.js
@@ -184,7 +184,10 @@ class MoveTopicNodeBox extends React.Component {
                 <td width="auto" align="left">
                   <Select2
                     value={this.getIndexFromNodeId(this.state.form.nodeId)}
-                    style={{ width: "300px", fontSize: "14px" }}
+                    style={{
+                      width: Setting.PcBrowser ? "300px" : "200px",
+                      fontSize: "14px",
+                    }}
                     data={this.state.nodes.map((node, i) => {
                       return { text: `${node.name} / ${node.id}`, id: i };
                     })}

--- a/web/src/main/NewBox.js
+++ b/web/src/main/NewBox.js
@@ -332,7 +332,10 @@ class NewBox extends React.Component {
           >
             <Select2
               value={this.getIndexFromNodeId(this.state.form.nodeId)}
-              style={{ width: "300px", fontSize: "14px" }}
+              style={{
+                width: Setting.PcBrowser ? "300px" : "200px",
+                fontSize: "14px",
+              }}
               data={this.state.nodes.map((node, i) => {
                 return { text: `${node.name} / ${node.id}`, id: i };
               })}

--- a/web/src/main/RankingRichBox.js
+++ b/web/src/main/RankingRichBox.js
@@ -95,7 +95,7 @@ class RankingRichBox extends React.Component {
               ? this.state.richList.map((member, key) => (
                   <tr>
                     <td
-                      width={Setting.PcBrowser ? "73" : "56"}
+                      width={Setting.PcBrowser ? "73" : "36"}
                       valign="top"
                       align="center"
                       key={key}
@@ -120,7 +120,7 @@ class RankingRichBox extends React.Component {
                       <div className="sep5"></div>
                       {/* <span className="fade">第 n 名会员</span> */}
                     </td>
-                    <td width="200" align="center">
+                    <td width="140" align="center">
                       <div>{this.renderRichBox(member.scoreCount)}</div>
                     </td>
                   </tr>

--- a/web/src/main/SettingsBox.js
+++ b/web/src/main/SettingsBox.js
@@ -365,6 +365,7 @@ class SettingsBox extends React.Component {
                         accept=".jpg,.gif,.png,.JPG,.GIF,.PNG"
                         onChange={(event) => this.handleChangeAvatar(event)}
                         name="avatar"
+                        style={{ width: "200px" }}
                       />
                     </td>
                   </tr>

--- a/web/src/main/SigninBox.js
+++ b/web/src/main/SigninBox.js
@@ -188,7 +188,7 @@ class SigninBox extends React.Component {
                       placeholder={i18next.t(
                         "general:Username, email address or phone number"
                       )}
-                      style={{ width: "280px" }}
+                      style={{ width: Setting.PcBrowser ? "280px" : "100%" }}
                     />
                   </td>
                 </tr>
@@ -208,7 +208,7 @@ class SigninBox extends React.Component {
                       autoCorrect="off"
                       spellCheck="false"
                       autoCapitalize="off"
-                      style={{ width: "280px" }}
+                      style={{ width: Setting.PcBrowser ? "280px" : "100%" }}
                     />
                   </td>
                 </tr>
@@ -221,7 +221,7 @@ class SigninBox extends React.Component {
                       style={{
                         backgroundImage: `url('data:image/png;base64,${this.state.captcha}')`,
                         backgroundRepeat: "no-repeat",
-                        width: Setting.PcBrowser ? "320px" : "280px",
+                        width: Setting.PcBrowser ? "320px" : "100%",
                         height: "80px",
                         borderRadius: "3px",
                         border: "1px solid #ccc",

--- a/web/src/main/SignupBox.js
+++ b/web/src/main/SignupBox.js
@@ -473,7 +473,10 @@ class SignupBox extends React.Component {
                         value={this.getIndexFromAreaCode(
                           this.state.form.areaCode
                         )}
-                        style={{ width: "300px", fontSize: "14px" }}
+                        style={{
+                          width: Setting.PcBrowser ? "300px" : "200px",
+                          fontSize: "14px",
+                        }}
                         data={Area_Code.map((code, i) => {
                           return { text: `${code.label}`, id: i };
                         })}


### PR DESCRIPTION
fix: https://github.com/casbin/casnode/issues/191

Now, when you drag the browser window to 4:3, it automatically displays the phone's layout, no matter what device you are using. 

And now there is a minimum width limit.

Deployed at: https://forum-hk.chromium.link/