### PR TITLE
feat: auto create user during synchronization from Google Groups

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/astaxie/beego v1.12.2
 	github.com/aws/aws-sdk-go v1.38.7
 	github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f // indirect
-	github.com/casbin/google-groups-crawler v0.0.3
+	github.com/casbin/google-groups-crawler v0.0.5
 	github.com/chromedp/chromedp v0.6.10
 	github.com/dchest/captcha v0.0.0-20200903113550-03f5f0333e1f
 	github.com/go-gomail/gomail v0.0.0-20160411212932-81ebce5c23df

--- a/go.sum
+++ b/go.sum
@@ -76,6 +76,8 @@ github.com/casbin/google-groups-crawler v0.0.2 h1:/yGWj7yg3QbMiGZxDrS62W2AnAPSJ2
 github.com/casbin/google-groups-crawler v0.0.2/go.mod h1:N80gK73I2liha+W4FLT0GnZtCYDhqv9LfJOuHBPGONY=
 github.com/casbin/google-groups-crawler v0.0.3 h1:II6tzUNZLdXhoxSkcCXLPxVmyWcYMtKpZYGScTOxutg=
 github.com/casbin/google-groups-crawler v0.0.3/go.mod h1:N80gK73I2liha+W4FLT0GnZtCYDhqv9LfJOuHBPGONY=
+github.com/casbin/google-groups-crawler v0.0.5 h1:+4fOZoYCace3HpKxPZuDClLO3KjHLN/qe8xG2fznqFE=
+github.com/casbin/google-groups-crawler v0.0.5/go.mod h1:N80gK73I2liha+W4FLT0GnZtCYDhqv9LfJOuHBPGONY=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=

--- a/object/node.go
+++ b/object/node.go
@@ -33,6 +33,7 @@ type Node struct {
 	Hot              int      `xorm:"int" json:"hot"`
 	Moderators       []string `xorm:"varchar(200)" json:"moderators"`
 	MailingList      string   `xorm:"varchar(100)" json:"mailingList"`
+	GoogleGroupCookie      string   `xorm:"varchar(1500)" json:"googleGroupCookie"`
 }
 
 func GetNodes() []*Node {

--- a/web/src/admin/AdminNode.js
+++ b/web/src/admin/AdminNode.js
@@ -189,6 +189,7 @@ class AdminNode extends React.Component {
       form["backgroundRepeat"] = this.state.nodeInfo?.backgroundRepeat;
       form["headerImage"] = this.state.nodeInfo?.headerImage;
       form["mailingList"] = this.state.nodeInfo?.mailingList;
+      form["googleGroupCookie"] = this.state.nodeInfo?.googleGroupCookie;
     }
 
     this.setState({
@@ -850,6 +851,26 @@ class AdminNode extends React.Component {
                           onChange={(event) =>
                             this.updateFormField(
                               "mailingList",
+                              event.target.value
+                            )
+                          }
+                          autoComplete="off"
+                        />
+                      </td>
+                    </tr>
+                    <tr>
+                      <td width="120" align="right">
+                        {i18next.t("node:Google Group Cookie")}
+                      </td>
+                      <td width="auto" align="left">
+                        <input
+                          type="text"
+                          className="sl"
+                          name="googleGroupCookie"
+                          defaultValue={this.state.form?.googleGroupCookie}
+                          onChange={(event) =>
+                            this.updateFormField(
+                              "googleGroupCookie",
                               event.target.value
                             )
                           }


### PR DESCRIPTION
Let's assume that `Kininaru` replied in Google Group with email `rachelgardner2001@gmail.com`: 

If there is a member called `Kininaru` in Casnode, then this reply will be attributed to `Kininaru`.

If there isn't a member called `Kininaru`, then Casnode will attribute this reply to the member whose name is `rachelgardner2001` (the prefix of the email address).

If there isn't a member called `rachelgardner2001`, then Casnode will attribute this reply to the member whose email is `rachelgardner2001@gmail.com`. 

If there isn't a member whose email is `rachelgardner2001@gmail.com`, then Casnode will create a member called `rachelgardner2001` (the prefix of the email address), then attribute this reply to the new member.