### PR TITLE
feat: upload avatar to oss when sync from google group

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/mozillazg/go-unidecode v0.1.1 // indirect
 	github.com/qor/oss v0.0.0-20191031055114-aef9ba66bf76
 	github.com/satori/go.uuid v1.2.0 // indirect
-	golang.org/x/net v0.0.0-20210220033124-5f55cee0dc0d // indirect
+	golang.org/x/net v0.0.0-20210220033124-5f55cee0dc0d
 	golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43
 	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
 	gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df // indirect


### PR DESCRIPTION
Deployed at: https://forum-hk.chromium.link/

Now all the avatars are synchronized from Gravatar, and stored in OSS. Frontend users can access these avatars even they can't access gravatar.