### PR TITLE
Add nil judgements to balance and notification backend to avoid crashing and fixed avatar error in search results

### DIFF
--- a/object/topic.go
+++ b/object/topic.go
@@ -662,13 +662,22 @@ func (t Topic) GetAllRepliesOfTopic() []string {
 	return ret
 }
 
-func SearchTopics(keyword string) []Topic {
-	var ret []Topic
+func SearchTopics(keyword string) []TopicWithAvatar {
+	var topics []Topic
 	keyword = fmt.Sprintf("%%%s%%", keyword)
 
-	err := adapter.Engine.Where("deleted = 0").Where("title like ? or content like ?", keyword, keyword).Find(&ret)
+	err := adapter.Engine.Where("deleted = 0").Where("title like ? or content like ?", keyword, keyword).Find(&topics)
 	if err != nil {
 		panic(err)
+	}
+
+	memberAvatar := GetMemberAvatarMapping()
+	var ret []TopicWithAvatar
+	for _, topic := range topics {
+		ret = append(ret, TopicWithAvatar{
+			Topic: topic,
+			Avatar: memberAvatar[topic.Author],
+		})
 	}
 
 	return ret


### PR DESCRIPTION
`replyInfo` may be `nil` in these places. The hole program will crash if `replyInfo` is `nil`. 

And
Fixed: https://github.com/casbin/casnode/issues/280
in the 3rd commit.