### PR TITLE
Removed keywords in html Tags when searching

### DIFF
--- a/object/topic.go
+++ b/object/topic.go
@@ -666,7 +666,7 @@ func SearchTopics(keyword string) []TopicWithAvatar {
 	var topics []Topic
 	keyword = fmt.Sprintf("%%%s%%", keyword)
 
-	err := adapter.Engine.Where("deleted = 0").Where("title like ? or content like ?", keyword, keyword).Find(&topics)
+	err := adapter.Engine.Where("deleted = 0").Where("regexp_replace(title, '<[^>]+>', '') like ? or regexp_replace(content, '<[^>]+>', '') like ?", keyword, keyword).Find(&topics)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Fixed: https://github.com/casbin/casnode/issues/282

Deployed at: https://forum-hk.chromium.link

Search `div_contains` to test.
![image](https://user-images.githubusercontent.com/42638489/122427823-020edc00-cfc4-11eb-9240-5a721f15c798.png)
