### PR TITLE
fix: [Web] fixed hidding of SignIn behind github -with signoff

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -29,3 +29,16 @@
   background-size: 163.92px 28px;
   background-repeat: no-repeat;
 }
+
+@media (max-width: 1200px) {
+  .header-content-nav {
+    padding-right: 2.5rem;
+  }
+}
+
+@media (max-width: 800px) {
+  .header-content-nav {
+    padding-top: 0 !important;
+    padding-right: 4rem;
+  }
+}

--- a/web/src/Header.js
+++ b/web/src/Header.js
@@ -20,8 +20,8 @@ import * as Conf from "./Conf";
 import { withRouter, Link } from "react-router-dom";
 import i18next from "i18next";
 import * as Auth from "./auth/Auth";
-import {ServerUrl} from "./Setting";
-import {authConfig} from "./auth/Auth";
+import { ServerUrl } from "./Setting";
+import { authConfig } from "./auth/Auth";
 
 class Header extends React.Component {
   constructor(props) {
@@ -103,7 +103,12 @@ class Header extends React.Component {
 
     if (!isSignedIn) {
       return (
-        <td width="570" align="right" style={{ paddingTop: "2px" }}>
+        <td
+          width="570"
+          align="right"
+          className="header-content-nav"
+          style={{ paddingTop: "2px" }}
+        >
           <Link to="/" className="top">
             {i18next.t("general:Home")}
           </Link>
@@ -123,7 +128,12 @@ class Header extends React.Component {
       );
     } else {
       return (
-        <td width="570" align="right" style={{ paddingTop: "2px" }}>
+        <td
+          width="570"
+          align="right"
+          className="header-content-nav"
+          style={{ paddingTop: "2px" }}
+        >
           <Link to="/" className="top">
             {i18next.t("general:Home")}
           </Link>


### PR DESCRIPTION
This PR fixes #306 
Signed-off-by: Nikhil <nikhilsharmamusic2000@gmail.com>

** Description **
There was an issue with the navbar links as on the smaller devices the "SignIn" link gets hide behind the GitHub logo.

## Before Changes
![Screenshot from 2021-06-22 17-40-06](https://user-images.githubusercontent.com/58226527/122923110-f2a3e000-d381-11eb-8d9f-269f34f853c2.png)

![Screenshot from 2021-06-22 17-40-01](https://user-images.githubusercontent.com/58226527/122923111-f2a3e000-d381-11eb-9890-18ec98e93326.png)

## After Changes
![Screenshot from 2021-06-22 17-39-43](https://user-images.githubusercontent.com/58226527/122923135-fc2d4800-d381-11eb-9356-886a6a61eccc.png)

![Screenshot from 2021-06-22 17-39-50](https://user-images.githubusercontent.com/58226527/122923165-04858300-d382-11eb-8ae8-373fac79130a.png)


