### PR TITLE
fix: code mirror editor display bugs

### DIFF
--- a/web/src/App.js
+++ b/web/src/App.js
@@ -14,6 +14,7 @@
 
 import React, { Component } from "react";
 import "./App.css";
+import "codemirror/lib/codemirror.css";
 import { BackTop } from "antd";
 import * as Setting from "./Setting";
 import { Switch, Route } from "react-router-dom";

--- a/web/src/Embed.js
+++ b/web/src/Embed.js
@@ -15,7 +15,6 @@
 import React from "react";
 import ReplyBox from "./main/ReplyBox";
 import * as TopicBackend from "./backend/TopicBackend";
-import "codemirror/lib/codemirror.css";
 
 export default class Embed extends React.Component {
   constructor(props) {

--- a/web/src/main/EditBox.js
+++ b/web/src/main/EditBox.js
@@ -19,7 +19,6 @@ import * as TopicBackend from "../backend/TopicBackend";
 import * as ReplyBackend from "../backend/ReplyBackend";
 import { Controlled as CodeMirror } from "react-codemirror2";
 import TagsInput from "react-tagsinput";
-import "codemirror/lib/codemirror.css";
 import "../tagsInput.css";
 import * as Tools from "./Tools";
 import i18next from "i18next";

--- a/web/src/main/NewBox.js
+++ b/web/src/main/NewBox.js
@@ -25,7 +25,6 @@ import { withRouter } from "react-router-dom";
 import i18next from "i18next";
 import Select2 from "react-select2-wrapper";
 import { Controlled as CodeMirror } from "react-codemirror2";
-import "codemirror/lib/codemirror.css";
 import Editor from "./richTextEditor";
 import * as Conf from "../Conf";
 import TagsInput from "react-tagsinput";

--- a/web/src/main/NewNodeTopicBox.js
+++ b/web/src/main/NewNodeTopicBox.js
@@ -24,7 +24,6 @@ import "../codemirrorSize.css";
 import i18next from "i18next";
 import Select2 from "react-select2-wrapper";
 import Editor from "./richTextEditor";
-import "codemirror/lib/codemirror.css";
 import { Controlled as CodeMirror } from "react-codemirror2";
 import TagsInput from "react-tagsinput";
 import "../tagsInput.css";

--- a/web/src/main/TopicBox.js
+++ b/web/src/main/TopicBox.js
@@ -25,7 +25,6 @@ import * as TranslatorBackend from "../backend/TranslatorBackend";
 import "../node.css";
 import Zmage from "react-zmage";
 import { Link } from "react-router-dom";
-import "codemirror/lib/codemirror.css";
 import i18next from "i18next";
 
 require("codemirror/mode/markdown/markdown");


### PR DESCRIPTION
Since `codemirror.css` is small (only 9 KB), and is widely used, we can move it to `App.js` to avoid lots of display bugs.