### PR TITLE
docs: fix the translate format

### DIFF
--- a/web/src/locales/zh/data.json
+++ b/web/src/locales/zh/data.json
@@ -338,7 +338,7 @@
     "Set image": "设置图标",
     "Sorter": "排序",
     "Tab": "类别",
-    "Topic": "第",
+    "Topic": "主题",
     "Topics in the ignored nodes will not appear on the homepage.": "被忽略的节点中的主题将不会在首页出现",
     "Total favorites": "总收藏人数",
     "Total nodes": "总节点数",


### PR DESCRIPTION
Fix the colons matching problem:
https://casnode.org/zh/docs/migration/