### PR TITLE
feat: Add chromeCtx pool for ssr

### DIFF
--- a/conf/app.conf
+++ b/conf/app.conf
@@ -19,4 +19,4 @@ httpProxy = "127.0.0.1:10808"
 initScore = 2000
 enableNestedReply = true
 cacheExpireSeconds = 60
-chromeCtxNum = 1
+chromeCtxNum = 5

--- a/conf/app.conf
+++ b/conf/app.conf
@@ -19,3 +19,4 @@ httpProxy = "127.0.0.1:10808"
 initScore = 2000
 enableNestedReply = true
 cacheExpireSeconds = 60
+chromeCtxNum = 1

--- a/routers/filter_ssr.go
+++ b/routers/filter_ssr.go
@@ -1,21 +1,22 @@
 package routers
 
 import (
-	ctx "context"
 	"fmt"
+	"github.com/astaxie/beego"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
-	"github.com/astaxie/beego"
 	"github.com/astaxie/beego/context"
-	"github.com/chromedp/chromedp"
 )
 
-var chromeCtx ctx.Context
+//var chromeCtx ctx.Context
+var chromeCtxPool *SsrPool
+var chromeCtxNum int
 var isChromeInstalled bool
 var isChromeInit bool
 
@@ -66,8 +67,13 @@ func InitChromeDp() {
 	isChromeInit = true
 	isChromeInstalled = isChromeFound()
 	if isChromeInstalled {
-		chromeCtx, _ = chromedp.NewContext(ctx.Background())
+		chromeCtxNum, _ = beego.AppConfig.Int("chromeCtxNum")
+		if chromeCtxNum == 0 {
+			chromeCtxNum = 1 // default
+		}
+		chromeCtxPool = NewSsrPool(chromeCtxNum)
 	}
+	go chromeCtxPool.Run() // start ssr_pool
 }
 
 func cacheSave(urlString string, res string) {
@@ -81,32 +87,6 @@ func cacheRestore(urlString string, cacheExpireSeconds int64) (string, bool) {
 		}
 	}
 	return "", false
-}
-
-func RenderPage(urlString string) string {
-	cacheExpireSeconds, err := beego.AppConfig.Int64("cacheExpireSeconds")
-	if err != nil {
-		panic(err)
-	}
-	res, cacheHit := cacheRestore(urlString, cacheExpireSeconds)
-	if cacheHit {
-		return res //cache of urlString
-	}
-	if !isChromeInit {
-		InitChromeDp()
-	}
-	if !isChromeInstalled {
-		return "Chrome is not installed in your server"
-	}
-	err = chromedp.Run(chromeCtx,
-		chromedp.Navigate(urlString),
-		chromedp.OuterHTML("html", &res),
-	)
-	if err != nil {
-		panic(err)
-	}
-	cacheSave(urlString, res)
-	return res
 }
 
 var botRegex *regexp.Regexp
@@ -126,9 +106,23 @@ func BotFilter(ctx *context.Context) {
 	if isBot(ctx.Request.UserAgent()) {
 		ctx.ResponseWriter.WriteHeader(200)
 		urlStr := fmt.Sprintf("http://%s%s", ctx.Request.Host, ctx.Request.URL.Path)
-		_, err := ctx.ResponseWriter.Write([]byte(RenderPage(urlStr)))
-		if err != nil {
-			panic(err)
+		if !isChromeInit {
+			InitChromeDp()
 		}
+		if !isChromeInstalled {
+			_, err := ctx.ResponseWriter.Write([]byte("Chrome is not installed in your server"))
+			if err != nil {
+				panic(err)
+			}
+		}
+
+		// the context will be canceled when the task send to channel
+		// sync.WaitGroup will wait for the task to be finished, it can avoid this problem
+		var wg sync.WaitGroup
+		wg.Add(1)
+		// create ssr_task and put it into task channel
+		task := NewRenderTask(ctx, urlStr, &wg)
+		chromeCtxPool.TaskChannel <- task
+		wg.Wait()
 	}
 }

--- a/routers/filter_ssr.go
+++ b/routers/filter_ssr.go
@@ -2,7 +2,6 @@ package routers
 
 import (
 	"fmt"
-	"github.com/astaxie/beego"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -11,12 +10,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/astaxie/beego"
 	"github.com/astaxie/beego/context"
 )
 
 //var chromeCtx ctx.Context
 var chromeCtxPool *SsrPool
-var chromeCtxNum int
 var isChromeInstalled bool
 var isChromeInit bool
 
@@ -67,8 +66,8 @@ func InitChromeDp() {
 	isChromeInit = true
 	isChromeInstalled = isChromeFound()
 	if isChromeInstalled {
-		chromeCtxNum, _ = beego.AppConfig.Int("chromeCtxNum")
-		if chromeCtxNum == 0 {
+		chromeCtxNum, _ := beego.AppConfig.Int("chromeCtxNum")
+		if chromeCtxNum <= 0 {
 			chromeCtxNum = 1 // default
 		}
 		chromeCtxPool = NewSsrPool(chromeCtxNum)

--- a/routers/ssr_pool.go
+++ b/routers/ssr_pool.go
@@ -49,12 +49,6 @@ func render(chromeCtx ctx.Context, url string) string {
 	if cacheHit {
 		return res
 	}
-	if !isChromeInit {
-		InitChromeDp()
-	}
-	if !isChromeInstalled {
-		return "Chrome is not installed in your server"
-	}
 	err = chromedp.Run(chromeCtx,
 		chromedp.Navigate(url),
 		chromedp.OuterHTML("html", &res),

--- a/routers/ssr_pool.go
+++ b/routers/ssr_pool.go
@@ -2,10 +2,11 @@ package routers
 
 import (
 	ctx "context"
+	"sync"
+
 	"github.com/astaxie/beego"
 	"github.com/astaxie/beego/context"
 	"github.com/chromedp/chromedp"
-	"sync"
 )
 
 type RenderTask struct {

--- a/routers/ssr_pool.go
+++ b/routers/ssr_pool.go
@@ -1,0 +1,91 @@
+package routers
+
+import (
+	ctx "context"
+	"github.com/astaxie/beego"
+	"github.com/astaxie/beego/context"
+	"github.com/chromedp/chromedp"
+	"sync"
+)
+
+type RenderTask struct {
+	HttpCtx *context.Context
+	Url     string
+	Render  func(chromeCtx ctx.Context, url string) string
+	Wg      *sync.WaitGroup
+}
+
+type SsrPool struct {
+	TaskChannel chan *RenderTask
+	JobsChannel chan *RenderTask
+	WorkerNum   int
+}
+
+func NewRenderTask(httpCtx *context.Context, url string, wg *sync.WaitGroup) *RenderTask {
+	return &RenderTask{
+		HttpCtx: httpCtx,
+		Url:     url,
+		Render:  render,
+		Wg:      wg,
+	}
+}
+
+func NewSsrPool(cap int) *SsrPool {
+	pool := SsrPool{
+		TaskChannel: make(chan *RenderTask),
+		JobsChannel: make(chan *RenderTask),
+		WorkerNum:   cap,
+	}
+	return &pool
+}
+
+func render(chromeCtx ctx.Context, url string) string {
+	cacheExpireSeconds, err := beego.AppConfig.Int64("cacheExpireSeconds")
+	if err != nil {
+		panic(err)
+	}
+	res, cacheHit := cacheRestore(url, cacheExpireSeconds)
+	if cacheHit {
+		return res
+	}
+	if !isChromeInit {
+		InitChromeDp()
+	}
+	if !isChromeInstalled {
+		return "Chrome is not installed in your server"
+	}
+	err = chromedp.Run(chromeCtx,
+		chromedp.Navigate(url),
+		chromedp.OuterHTML("html", &res),
+	)
+	if err != nil {
+		panic(err)
+	}
+	cacheSave(url, res)
+	return res
+}
+
+func (pool *SsrPool) worker() {
+	//chromeCtx, _ := chromedp.NewExecAllocator(ctx.Background(), append(
+	//	chromedp.DefaultExecAllocatorOptions[:],
+	//	chromedp.Flag("headless", false))...)
+	//chromeCtx, _ = chromedp.NewContext(chromeCtx)
+	chromeCtx, _ := chromedp.NewContext(ctx.Background()) // set default context with headless mode
+	for task := range pool.JobsChannel {
+		urlStr := task.Render(chromeCtx, task.Url)
+		_, err := task.HttpCtx.ResponseWriter.Write([]byte(urlStr))
+		if err != nil {
+			panic(err)
+		}
+		task.Wg.Done()
+	}
+}
+
+func (pool *SsrPool) Run() {
+	for i := 0; i < pool.WorkerNum; i++ {
+		go pool.worker()
+	}
+	for task := range pool.TaskChannel {
+		pool.JobsChannel <- task
+	}
+}


### PR DESCRIPTION
Fix: https://github.com/casbin/casnode/issues/441

It will create N chrome instances according to `chromeCtxNum` in `conf/app.conf`

Proposed changes:

If set `chromeCtxNum` to `3`. (in headless mode)

![image](https://user-images.githubusercontent.com/69711608/161444971-16f071cd-d929-435b-8f9c-df8ab6e40ff8.png)

three chrome instances will handle all requests from bots.

![image](https://user-images.githubusercontent.com/69711608/161444931-3ce62fb2-d232-4a19-8988-c3d08037a521.png)