### PR TITLE
fix: broken pipe error

### DIFF
--- a/routers/ssr_pool.go
+++ b/routers/ssr_pool.go
@@ -2,7 +2,9 @@ package routers
 
 import (
 	ctx "context"
+	"errors"
 	"sync"
+	"syscall"
 
 	"github.com/astaxie/beego"
 	"github.com/astaxie/beego/context"
@@ -70,7 +72,9 @@ func (pool *SsrPool) worker() {
 		urlStr := task.Render(chromeCtx, task.Url)
 		_, err := task.HttpCtx.ResponseWriter.Write([]byte(urlStr))
 		if err != nil {
-			panic(err)
+			if !errors.Is(err, syscall.EPIPE) {
+				panic(err)
+			}
 		}
 		task.Wg.Done()
 	}


### PR DESCRIPTION
From PR: **feat: Add chromeCtx pool for ssr** [#458](https://github.com/casbin/casnode/pull/458)

When HTTP server responses, "broken pipe" error will be occured sometimes.

The response used `"net/http".ResponseWriter.Write()` function.

You can reproduce this error by repeatedly sending requests to different urls and forcibly cancel the request using postman.

Got the error like the following:

```
panic: write tcp [::1]:3000->[::1]:61376: write: broken pipe
```

[What causes it?] 

The connection was forcibly closed in the client side. At that time, when HTTP server responses even though the connection is closed, the "broken pipe" error (pipe error) will come out.

Just ignore it when it happens.