### PR TITLE
fix: ssl is not recover from a panic

### DIFF
--- a/routers/ssr_pool.go
+++ b/routers/ssr_pool.go
@@ -2,26 +2,28 @@ package routers
 
 import (
 	ctx "context"
-	"errors"
+	"fmt"
+	"runtime"
 	"sync"
-	"syscall"
 
 	"github.com/astaxie/beego"
 	"github.com/astaxie/beego/context"
+	"github.com/astaxie/beego/logs"
 	"github.com/chromedp/chromedp"
 )
 
 type RenderTask struct {
 	HttpCtx *context.Context
 	Url     string
-	Render  func(chromeCtx ctx.Context, url string) string
+	Render  func(chromeCtx ctx.Context, url string) (string, error)
 	Wg      *sync.WaitGroup
 }
 
 type SsrPool struct {
-	TaskChannel chan *RenderTask
-	JobsChannel chan *RenderTask
-	WorkerNum   int
+	TaskChannel      chan *RenderTask
+	JobsChannel      chan *RenderTask
+	AddWorkerChannel chan bool
+	WorkerNum        int
 }
 
 func NewRenderTask(httpCtx *context.Context, url string, wg *sync.WaitGroup) *RenderTask {
@@ -42,24 +44,24 @@ func NewSsrPool(cap int) *SsrPool {
 	return &pool
 }
 
-func render(chromeCtx ctx.Context, url string) string {
+func render(chromeCtx ctx.Context, url string) (string, error) {
 	cacheExpireSeconds, err := beego.AppConfig.Int64("cacheExpireSeconds")
 	if err != nil {
-		panic(err)
+		return "", err
 	}
 	res, cacheHit := cacheRestore(url, cacheExpireSeconds)
 	if cacheHit {
-		return res
+		return res, nil
 	}
 	err = chromedp.Run(chromeCtx,
 		chromedp.Navigate(url),
 		chromedp.OuterHTML("html", &res),
 	)
 	if err != nil {
-		panic(err)
+		return "", err
 	}
 	cacheSave(url, res)
-	return res
+	return res, nil
 }
 
 func (pool *SsrPool) worker() {
@@ -69,22 +71,75 @@ func (pool *SsrPool) worker() {
 	//chromeCtx, _ = chromedp.NewContext(chromeCtx)
 	chromeCtx, _ := chromedp.NewContext(ctx.Background()) // set default context with headless mode
 	for task := range pool.JobsChannel {
-		urlStr := task.Render(chromeCtx, task.Url)
-		_, err := task.HttpCtx.ResponseWriter.Write([]byte(urlStr))
-		if err != nil {
-			if !errors.Is(err, syscall.EPIPE) {
+		cancel := func() bool {
+			defer func() {
+				if err := recover(); err != nil {
+					handleErr(task.HttpCtx, err.(error))
+					task.Wg.Done()
+				}
+			}()
+			urlStr, err := task.Render(chromeCtx, task.Url)
+			if err != nil {
+				if err.Error() == "context canceled" { // when browser process has terminated
+					handleErr(task.HttpCtx, err)
+					task.Wg.Done()
+					return true
+				} else {
+					panic(err)
+				}
+			}
+			_, err = task.HttpCtx.ResponseWriter.Write([]byte(urlStr))
+			if err != nil {
 				panic(err)
 			}
+			task.Wg.Done()
+			return false
+		}()
+		// if canceled, break the loop
+		if cancel {
+			break
 		}
-		task.Wg.Done()
 	}
+	// if break, add a new worker
+	pool.AddWorkerChannel <- true
 }
 
 func (pool *SsrPool) Run() {
+	pool.AddWorkerChannel = make(chan bool, pool.WorkerNum)
 	for i := 0; i < pool.WorkerNum; i++ {
-		go pool.worker()
+		pool.AddWorkerChannel <- true
 	}
+	go func() {
+		for j := range pool.AddWorkerChannel {
+			if j == true {
+				go pool.worker()
+			}
+		}
+	}()
 	for task := range pool.TaskChannel {
 		pool.JobsChannel <- task
+	}
+}
+
+func handleErr(ctx *context.Context, err error) {
+	var stack string
+	logs.Critical("the request url is ", ctx.Input.URL())
+	logs.Critical("Handler crashed with error:", err)
+	for i := 1; ; i++ {
+		_, file, line, ok := runtime.Caller(i)
+		if !ok {
+			break
+		}
+		logs.Critical(fmt.Sprintf("%s:%d", file, line))
+		stack = stack + fmt.Sprintln(fmt.Sprintf("%s:%d", file, line))
+	}
+	if ctx.Output.Status != 0 {
+		ctx.ResponseWriter.WriteHeader(ctx.Output.Status)
+	} else {
+		ctx.ResponseWriter.WriteHeader(500)
+	}
+	_, _err := ctx.ResponseWriter.Write([]byte(err.(error).Error()))
+	if _err != nil {
+		logs.Critical("write response error:", err)
 	}
 }


### PR DESCRIPTION
Fix: https://github.com/casbin/casnode/issues/466

Fix: https://github.com/casbin/casnode/issues/471

**How it happens?**

Panic generated from `ssl_pool.go` will not be captured by Beego's recoverPanic.

**Proposed changes**

A call to recover will capture the value given to panic from `ssl_pool.go` and handle it as the same as beego.

When browser process has terminated externally, a new browser instances will start up.

Demo:

https://user-images.githubusercontent.com/69711608/162209925-b9f1f083-ce35-4f4d-a946-e25eca907b5b.mp4

Panic logs:

![image](https://user-images.githubusercontent.com/69711608/162209637-b07d4698-8110-43be-9c85-4405165847a2.png)
