### PR TITLE
fix: update count field not atomic

### DIFF
--- a/object/balance.go
+++ b/object/balance.go
@@ -73,7 +73,6 @@ func UpdateMemberBalance(user *auth.User, amount int) (bool, error) {
 	return auth.UpdateUserForColumns(user, []string{"score"})
 }
 
-
 func UpdateMemberConsumptionSum(user *auth.User, amount int) (bool, error) {
 	user.Karma += amount
 	return auth.UpdateUserForColumns(user, []string{"karma"})

--- a/object/favorites.go
+++ b/object/favorites.go
@@ -195,6 +195,26 @@ func GetNodeFavoritesNum(id string) int {
 	return int(total)
 }
 
+func GetTopicFavoritesNum(id string) int {
+	topic := new(Favorites)
+	total, err := adapter.Engine.Where("favorites_type = ?", FavorTopic).And("object_id = ?", id).Count(topic)
+	if err != nil {
+		panic(err)
+	}
+
+	return int(total)
+}
+
+func GetTopicSubscribeNum(id string) int {
+	topic := new(Favorites)
+	total, err := adapter.Engine.Where("favorites_type = ?", SubscribeTopic).And("object_id = ?", id).Count(topic)
+	if err != nil {
+		panic(err)
+	}
+
+	return int(total)
+}
+
 func GetFollowingNum(id string) int {
 	member := new(Favorites)
 	total, err := adapter.Engine.Where("favorites_type = ?", FollowUser).And("member_id = ?", id).Count(member)

--- a/object/reply.go
+++ b/object/reply.go
@@ -445,11 +445,6 @@ func GetReplyAuthor(id int) *auth.User {
 
 // AddReplyThanksNum updates reply's thanks num.
 func AddReplyThanksNum(id int) bool {
-	reply := GetReply(id)
-	if reply == nil {
-		return false
-	}
-
 	affected, err := adapter.Engine.ID(id).Incr("thanks_num", 1).Update(Reply{})
 	if err != nil {
 		panic(err)

--- a/object/reply.go
+++ b/object/reply.go
@@ -450,8 +450,7 @@ func AddReplyThanksNum(id int) bool {
 		return false
 	}
 
-	reply.ThanksNum++
-	affected, err := adapter.Engine.Id(id).Cols("thanks_num").Update(reply)
+	affected, err := adapter.Engine.ID(id).Incr("thanks_num", 1).Update(Reply{})
 	if err != nil {
 		panic(err)
 	}

--- a/object/topic.go
+++ b/object/topic.go
@@ -540,8 +540,7 @@ func AddTopicHitCount(topicId int) bool {
 		return false
 	}
 
-	topic.HitCount++
-	affected, err := adapter.Engine.Id(topicId).Cols("hit_count").Update(topic)
+	affected, err := adapter.Engine.ID(topicId).Incr("hit_count", 1).Update(Topic{})
 	if err != nil {
 		panic(err)
 	}
@@ -555,8 +554,7 @@ func ChangeTopicFavoriteCount(topicId int, num int) bool {
 		return false
 	}
 
-	topic.FavoriteCount += num
-	affected, err := adapter.Engine.Id(topicId).Cols("favorite_count").Update(topic)
+	affected, err := adapter.Engine.ID(topicId).Incr("favorite_count", num).Update(Topic{})
 	if err != nil {
 		panic(err)
 	}
@@ -570,8 +568,7 @@ func ChangeTopicSubscribeCount(topicId int, num int) bool {
 		return false
 	}
 
-	topic.SubscribeCount += num
-	affected, err := adapter.Engine.Id(topicId).Cols("subscribe_count").Update(topic)
+	affected, err := adapter.Engine.ID(topicId).Incr("subscribe_count", num).Update(Topic{})
 	if err != nil {
 		panic(err)
 	}
@@ -585,8 +582,7 @@ func ChangeTopicReplyCount(topicId int, num int) bool {
 		return false
 	}
 
-	topic.ReplyCount += num
-	affected, err := adapter.Engine.Id(topicId).Cols("reply_count").Update(topic)
+	affected, err := adapter.Engine.ID(topicId).Incr("reply_count", num).Update(Topic{})
 	if err != nil {
 		panic(err)
 	}

--- a/object/topic.go
+++ b/object/topic.go
@@ -535,11 +535,6 @@ func GetAllCreatedTopics(author string, tab string, limit int, offset int) []*To
 }
 
 func AddTopicHitCount(topicId int) bool {
-	topic := GetTopic(topicId)
-	if topic == nil {
-		return false
-	}
-
 	affected, err := adapter.Engine.ID(topicId).Incr("hit_count", 1).Update(Topic{})
 	if err != nil {
 		panic(err)
@@ -549,11 +544,6 @@ func AddTopicHitCount(topicId int) bool {
 }
 
 func ChangeTopicFavoriteCount(topicId int, num int) bool {
-	topic := GetTopic(topicId)
-	if topic == nil {
-		return false
-	}
-
 	affected, err := adapter.Engine.ID(topicId).Incr("favorite_count", num).Update(Topic{})
 	if err != nil {
 		panic(err)
@@ -563,11 +553,6 @@ func ChangeTopicFavoriteCount(topicId int, num int) bool {
 }
 
 func ChangeTopicSubscribeCount(topicId int, num int) bool {
-	topic := GetTopic(topicId)
-	if topic == nil {
-		return false
-	}
-
 	affected, err := adapter.Engine.ID(topicId).Incr("subscribe_count", num).Update(Topic{})
 	if err != nil {
 		panic(err)
@@ -577,11 +562,6 @@ func ChangeTopicSubscribeCount(topicId int, num int) bool {
 }
 
 func ChangeTopicReplyCount(topicId int, num int) bool {
-	topic := GetTopic(topicId)
-	if topic == nil {
-		return false
-	}
-
 	affected, err := adapter.Engine.ID(topicId).Incr("reply_count", num).Update(Topic{})
 	if err != nil {
 		panic(err)

--- a/object/topic_test.go
+++ b/object/topic_test.go
@@ -1,0 +1,9 @@
+package object
+
+import (
+	"testing"
+)
+
+func TestSyncTopicReplyCount(t *testing.T) {
+
+}

--- a/object/topic_test.go
+++ b/object/topic_test.go
@@ -1,3 +1,17 @@
+// Copyright 2022 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package object
 
 import (

--- a/object/topic_test.go
+++ b/object/topic_test.go
@@ -1,9 +1,58 @@
 package object
 
 import (
+	"fmt"
+	"strconv"
 	"testing"
 )
 
 func TestSyncTopicReplyCount(t *testing.T) {
+	InitConfig()
+	InitAdapter()
 
+	topics := GetAllTopics()
+	for _, topic := range topics {
+		num := GetTopicReplyNum(topic.Id)
+		if num != topic.ReplyCount {
+			tmp := topic.ReplyCount
+			topic.ReplyCount = num
+			UpdateTopic(topic.Id, topic)
+			fmt.Printf("[update topic:%d]: ReplyCount: %d -> %d\n", topic.Id, tmp, topic.ReplyCount)
+		}
+	}
+	fmt.Println("Synced ReplyCount of all topics!")
+}
+
+func TestSyncTopicFavoriteCount(t *testing.T) {
+	InitConfig()
+	InitAdapter()
+
+	topics := GetAllTopics()
+	for _, topic := range topics {
+		num := GetTopicFavoritesNum(strconv.Itoa(topic.Id))
+		if num != topic.FavoriteCount {
+			tmp := topic.FavoriteCount
+			topic.FavoriteCount = num
+			UpdateTopic(topic.Id, topic)
+			fmt.Printf("[update topic:%d]: FavoriteCount: %d -> %d\n", topic.Id, tmp, topic.FavoriteCount)
+		}
+	}
+	fmt.Println("Synced FavoriteCount of all topics!")
+}
+
+func TestSyncTopicSubscribeCount(t *testing.T) {
+	InitConfig()
+	InitAdapter()
+
+	Topics := GetAllTopics()
+	for _, topic := range Topics {
+		num := GetTopicSubscribeNum(strconv.Itoa(topic.Id))
+		if num != topic.SubscribeCount {
+			tmp := topic.SubscribeCount
+			topic.SubscribeCount = num
+			UpdateTopic(topic.Id, topic)
+			fmt.Printf("[update topic:%d]: SubscribeCount: %d -> %d\n", topic.Id, tmp, topic.SubscribeCount)
+		}
+	}
+	fmt.Println("Synced SubscribeCount of all topics!")
 }


### PR DESCRIPTION
Fix: https://github.com/casbin/casnode/issues/495

- fix
The database (update/insert/delete) operations will add exclusive locks by default, while the query (select) will not add any locks
just change sql as following example: 
sql: `update topic set reply_count = reply_count + 1 where id = ?`

- test
add unit test to update `XXX_count` field to correct value