### PR TITLE
fix: #500 sometimes AT (@) people in reply box doesn't show the candidates

### DIFF
--- a/web/src/main/ReplyBox.js
+++ b/web/src/main/ReplyBox.js
@@ -198,8 +198,8 @@ class ReplyBox extends React.Component {
   }
 
   getMemberList() {
-    let list = [];
-    let temp = [];
+    let list = [this.props.topic?.author];
+    let temp = [this.props.topic?.author + " "];
     for (let i = 0; i < this.state.replies.length; ++i) {
       let flag = true;
       for (let j = 0; j < temp.length; ++j) {


### PR DESCRIPTION
Fix #500 by also pushing topic author to `memberList`
ref: https://github.com/casbin/casnode/issues/500#issuecomment-1113354120