### PR TITLE
fix: chrome render page gets stuck

### DIFF
--- a/routers/ssr_pool.go
+++ b/routers/ssr_pool.go
@@ -85,7 +85,7 @@ func render(chromeCtx ctx.Context, url string) (string, error) {
 		if err != nil {
 			return "", errors.New("context cancel failed")
 		}
-		return "", errors.New("context canceled")
+		return "", ctx.Canceled
 	}
 }
 
@@ -105,7 +105,7 @@ func (pool *SsrPool) worker() {
 			}()
 			urlStr, err := task.Render(chromeCtx, task.Url)
 			if err != nil {
-				if err.Error() == "context canceled" { // when browser process has terminated
+				if err == ctx.Canceled { // when browser process has terminated
 					handleErr(task.HttpCtx, err)
 					task.Wg.Done()
 					return true

--- a/routers/ssr_pool.go
+++ b/routers/ssr_pool.go
@@ -14,7 +14,7 @@ import (
 	"github.com/chromedp/chromedp"
 )
 
-var renderTimeOut = 60 * time.Second
+var renderTimeout = 20 * time.Second
 
 type RenderTask struct {
 	HttpCtx *context.Context
@@ -80,7 +80,7 @@ func render(chromeCtx ctx.Context, url string) (string, error) {
 		} else {
 			return "", err
 		}
-	case <-time.After(renderTimeOut):
+	case <-time.After(renderTimeout):
 		err := chromedp.Cancel(chromeCtx)
 		if err != nil {
 			return "", errors.New("context cancel failed")


### PR DESCRIPTION
**Proposed changes**
The current chrome instance will be terminated safely if it takes more than a minute to rendering page, and a new chrome instance will be created