### PR TITLE
fix: ci crash due to version of nodejs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 16
 
       - name: Fetch Previous version
         id: get-previous-tag

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,11 +7,14 @@ jobs:
   frontend:
     name: Front-end
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [ 16 ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '14.17.0'
+          node-version: ${{ matrix.node }}
       - uses: c-hive/gha-yarn-cache@v2
         with:
           directory: ./web

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,14 +7,11 @@ jobs:
   frontend:
     name: Front-end
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node: [ 16 ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node }}
+          node-version: 16
       - uses: c-hive/gha-yarn-cache@v2
         with:
           directory: ./web


### PR DESCRIPTION
fix: ci crash due to version of nodejs

Fix: https://github.com/casbin/casnode/issues/545