### PR TITLE
fix: fix CI warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,14 +86,12 @@ jobs:
 
           if [ ${old_array[0]} != ${new_array[0]} ]
           then 
-              echo ::set-output name=push::'true'
+              echo "push='true'" >> GITHUB_OUTPUT
           elif [ ${old_array[1]} != ${new_array[1]} ]
           then 
-              echo ::set-output name=push::'true'
-
+              echo "push='true'" >> GITHUB_OUTPUT
           else
-              echo ::set-output name=push::'false'
-
+              echo "push='false'" >> GITHUB_OUTPUT
           fi
 
       - name: Log in to Docker Hub


### PR DESCRIPTION
We got a warning here: https://github.com/casbin/casnode/actions/runs/3548531776/jobs/5959881858

The warning is as follows: `Warning: The set-output command is deprecated and will be disabled soon. Please upgrade to using Environment Files. `

This PR will fix this warning.