### PR TITLE
feat: support Cohere "command" model

### DIFF
--- a/model/cohere.go
+++ b/model/cohere.go
@@ -1,0 +1,55 @@
+// Copyright 2023 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	cohere "github.com/henomis/lingoose/llm/cohere"
+)
+
+type CohereModelProvider struct {
+	secretKey   string
+	subType     string
+	temperature float64
+	maxTokens   int
+	verbose     bool
+	stop        []string
+}
+
+func NewCohereModelProvider(subType string, secretKey string) (*CohereModelProvider, error) {
+	return &CohereModelProvider{
+		secretKey: secretKey, 
+		subType: subType,
+	}, nil
+}
+
+func (c *CohereModelProvider) QueryText(message string, writer io.Writer, chat_history []*RawMessage, prompt string, knowledgeMessages []*RawMessage) error {
+	client := cohere.NewCompletion().WithAPIKey(c.secretKey).WithModel(cohere.Model(c.subType))
+	
+	ctx := context.Background()
+
+	resp, err := client.Completion(ctx, message)
+	if err != nil {
+		return err
+	}
+
+	resp = strings.Split(resp, "\n")[0]
+	fmt.Println(resp)
+	return nil
+}

--- a/model/provider.go
+++ b/model/provider.go
@@ -45,6 +45,8 @@ func GetModelProvider(typ string, subType string, clientId string, clientSecret 
 		p, err = NewChatGLMModelProvider(subType, clientSecret)
 	} else if typ == "MiniMax" {
 		p, err = NewMiniMaxModelProvider(subType, clientId, clientSecret, temperature)
+	} else if typ == "Cohere" {
+		p, err = NewCohereModelProvider(subType, clientSecret)
 	}
 	if err != nil {
 		return nil, err

--- a/model/util.go
+++ b/model/util.go
@@ -24,6 +24,7 @@ import (
 type RawMessage struct {
 	Text   string
 	Author string
+	User   *string // chat_history in cohere may need a user
 }
 
 func reverseMessages(arr []*RawMessage) []*RawMessage {

--- a/web/src/ProviderEditPage.js
+++ b/web/src/ProviderEditPage.js
@@ -191,6 +191,8 @@ class ProviderEditPage extends React.Component {
                   this.updateProviderField("subType", "custom-model");
                 } else if (value === "Azure") {
                   this.updateProviderField("subType", "gpt-4");
+                } else if (value === "Cohere") {
+                  this.updateProviderField("subType", "command");
                 }
               } else if (this.state.provider.category === "Embedding") {
                 if (value === "OpenAI") {

--- a/web/src/Setting.js
+++ b/web/src/Setting.js
@@ -648,6 +648,7 @@ export function getProviderTypeOptions(category) {
         {id: "MiniMax", name: "MiniMax"},
         {id: "Local", name: "Local"},
         {id: "Azure", name: "Azure"},
+        {id: "Cohere", name: "Cohere"},
       ]
     );
   } else if (category === "Embedding") {
@@ -827,13 +828,22 @@ export function getProviderSubTypeOptions(category, type) {
       return [];
     }
   } else if (type === "Cohere") {
-    return (
-      [
-        {id: "embed-english-v2.0", name: "embed-english-v2.0"},
-        {id: "embed-english-light-v2.0", name: "embed-english-light-v2.0"},
-        {id: "embed-multilingual-v2.0", name: "embed-multilingual-v2.0"},
-      ]
-    );
+    if (category === "Model") {
+      return (
+        [
+          {id: "command-light", name: "command-light"},
+          {id: "command", name: "command"},
+        ]
+      );
+    } else if (category === "Embedding") {
+      return (
+        [
+          {id: "embed-english-v2.0", name: "embed-english-v2.0"},
+          {id: "embed-english-light-v2.0", name: "embed-english-light-v2.0"},
+          {id: "embed-multilingual-v2.0", name: "embed-multilingual-v2.0"},
+        ]
+      );
+    }
   } else if (type === "iFlytek") {
     return (
       [


### PR DESCRIPTION
**For Supporting Cohere "Command" model, I modified 5 files as follows**

1. Add casibase/model/cohere.go, initialize “command" model.

2. Modified casibase/model/provider.go, add a condition to check cohere.

3. Modified casibase/model/util.go. add a User in RawMessage to be compitable with chat_history in "command".

4. Modified casibase/web/src/setting.js, add options for cohere in Model.

5. Modified casibase/web/src/ProviderEditPages.js, add a default model for cohere "command".