### PR TITLE
feat: support texts and images in the response at the same time

### DIFF
--- a/model/open_revised_util.go
+++ b/model/open_revised_util.go
@@ -1,0 +1,65 @@
+// Copyright 2023 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type Prompt struct {
+	Text     string `json:"text prompt"`
+	Image    string `json:"image prompt"`
+	Relation string `json:"relation"`
+}
+
+func PromptProcessing(question string) string {
+	var builder strings.Builder
+	var promptPrefix string = `Give you a message, you should give me a JSON contains "text prompt", "image prompt" and "relation", no other information. The language should be the same as the message's language type. Text prompt is information about text generating, image prompt is information about image generating, both of them should be described as detailed as possible but not add additional information randomly. And relation has three values "image first", "text first", "none". If request in "text prompt" depends on an image in "image first" firstly, then relation is "image first", if request in "image prompt" depends on text in "text prompt" firstly, then relation is "text first", if image is independent of text, then relation is "none". Message is "`
+	builder.WriteString(promptPrefix)
+	builder.WriteString(question)
+	builder.WriteString(`"`)
+	str := builder.String()
+	return str
+}
+
+func ConvertJSONToPrompt(prompt string) (Prompt, error) {
+	if strings.HasPrefix(prompt, "```json\n") && strings.HasSuffix(prompt, "\n```") {
+		prompt = strings.TrimPrefix(prompt, "```json\n")
+		prompt = strings.TrimSuffix(prompt, "\n```")
+	} else if !strings.HasPrefix(prompt, "{\n") && !strings.HasSuffix(prompt, "\n}") {
+		return Prompt{}, fmt.Errorf("incorrect prompt")
+	}
+
+	var promptJSON Prompt
+
+	err := json.Unmarshal([]byte(prompt), &promptJSON)
+	if err != nil {
+		return Prompt{}, err
+	}
+
+	fmt.Printf("Parsed Prompt struct: %+v\n", promptJSON)
+
+	return promptJSON, nil
+}
+
+func promptConcatenate(prompt string, preAnswer string) string {
+	var builder strings.Builder
+	builder.WriteString(prompt)
+	builder.WriteString(preAnswer)
+	str := builder.String()
+	return str
+}

--- a/model/openai_revised.go
+++ b/model/openai_revised.go
@@ -112,7 +112,6 @@ func getAnswer(question string, p *openaiRefinedModelProvider, modelProvider str
 	}
 	defer respStream.Close()
 
-	// 接收流转成字符串
 	var answer string
 	isLeadingReturn := true
 	for {

--- a/model/openai_revised.go
+++ b/model/openai_revised.go
@@ -1,0 +1,231 @@
+// Copyright 2023 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/sashabaranov/go-openai"
+)
+
+type openaiRefinedModelProvider struct {
+	typ              string
+	subType          string
+	secretKey        string
+	temperature      float32
+	topP             float32
+	frequencyPenalty float32
+	presencePenalty  float32
+}
+
+func NewOpenAiRevisedModelProvider(typ string, subType string, secretKey string, temperature float32, topP float32, frequencyPenalty float32, presencePenalty float32) (*openaiRefinedModelProvider, error) {
+	p := &openaiRefinedModelProvider{
+		typ:              typ,
+		subType:          subType,
+		secretKey:        secretKey,
+		temperature:      temperature,
+		topP:             topP,
+		frequencyPenalty: frequencyPenalty,
+		presencePenalty:  presencePenalty,
+	}
+	return p, nil
+}
+
+func getAnswer(question string, p *openaiRefinedModelProvider, modelProvider string, writer io.Writer, writerUsed bool) (string, error) {
+	client := getOpenAiClientFromToken(p.secretKey)
+	ctx := context.Background()
+
+	flusher, ok := writer.(http.Flusher)
+	if !ok {
+		return "", fmt.Errorf("writer does not implement http.Flusher")
+	}
+
+	model := modelProvider
+	temperature := p.temperature
+	topP := p.topP
+	frequencyPenalty := p.frequencyPenalty
+	presencePenalty := p.presencePenalty
+	maxTokens := getOpenAiMaxTokens(model)
+
+	flushData := func(data string) error {
+		if _, err := fmt.Fprintf(writer, "event: message\ndata: %s\n\n", data); err != nil {
+			return err
+		}
+		flusher.Flush()
+		return nil
+	}
+
+	if modelProvider == "dall-e-3" && writerUsed {
+		reqUrl := openai.ImageRequest{
+			Prompt:         question,
+			Model:          openai.CreateImageModelDallE3,
+			Size:           openai.CreateImageSize1024x1024,
+			ResponseFormat: openai.CreateImageResponseFormatURL,
+			N:              1,
+		}
+		respUrl, err := client.CreateImage(ctx, reqUrl)
+		if err != nil {
+			fmt.Printf("Image creation error: %v\n", err)
+			return "", err
+		}
+		url := fmt.Sprintf("<img src=\"%s\" width=\"100%%\" height=\"auto\">", respUrl.Data[0].URL)
+		fmt.Fprint(writer, url)
+		flusher.Flush()
+		return url, nil
+	}
+
+	emptyHistory := []*RawMessage{}
+	emptyKnowledge := []*RawMessage{}
+
+	rawMessages, err := generateMessages("", question, emptyHistory, emptyKnowledge, model, maxTokens)
+	if err != nil {
+		return "", err
+	}
+	var messages []openai.ChatCompletionMessage
+	messages, err = rawMessagesToGPT4VisionMessages(rawMessages)
+	if err != nil {
+		return "", err
+	}
+	respStream, err := client.CreateChatCompletionStream(
+		ctx,
+		ChatCompletionRequest(model, messages, temperature, topP, frequencyPenalty, presencePenalty),
+	)
+	if err != nil {
+		return "", err
+	}
+	defer respStream.Close()
+
+	// 接收流转成字符串
+	var answer string
+	isLeadingReturn := true
+	for {
+		completion, streamErr := respStream.Recv()
+		if streamErr != nil {
+			if streamErr == io.EOF {
+				break
+			}
+			return "", streamErr
+		}
+
+		if len(completion.Choices) == 0 {
+			continue
+		}
+		data := completion.Choices[0].Delta.Content
+		if isLeadingReturn && len(data) != 0 {
+			if strings.Count(data, "\n") == len(data) {
+				continue
+			} else {
+				isLeadingReturn = false
+			}
+		}
+		answer += data
+
+		if writerUsed {
+			err = flushData(data)
+			if err != nil {
+				return "", err
+			}
+		}
+	}
+	return answer, nil
+}
+
+func textFirst(textPrompt string, imagePrompt string, writer io.Writer, p *openaiRefinedModelProvider) error {
+	textAnswer, err := getAnswer(textPrompt, p, "gpt-4-vision-preview", writer, true)
+	if err != nil {
+		return err
+	}
+
+	imagePrompt = promptConcatenate(imagePrompt, textAnswer)
+	_, err = getAnswer(imagePrompt, p, "dall-e-3", writer, true)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func imageFirst(textPrompt string, imagePrompt string, writer io.Writer, p *openaiRefinedModelProvider) error {
+	imageAnswer, err := getAnswer(imagePrompt, p, "dall-e-3", writer, true)
+	if err != nil {
+		return err
+	}
+
+	textPrompt = promptConcatenate(textPrompt, imageAnswer)
+	_, err = getAnswer(textPrompt, p, "gpt-4-vision-preview", writer, true)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func noneRelation(textPrompt string, imagePrompt string, writer io.Writer, p *openaiRefinedModelProvider) error {
+	_, err := getAnswer(textPrompt, p, "gpt-4-vision-preview", writer, true)
+	if err != nil {
+		return err
+	}
+
+	_, err = getAnswer(imagePrompt, p, "dall-e-3", writer, true)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *openaiRefinedModelProvider) QueryText(question string, writer io.Writer, history []*RawMessage, prompt string, knowledgeMessages []*RawMessage) error {
+	question = PromptProcessing(question)
+	var promptStruct Prompt
+	for {
+		answer, err := getAnswer(question, p, "gpt-4-vision-preview", writer, false)
+		if err != nil {
+			return err
+		}
+
+		promptStruct, err = ConvertJSONToPrompt(answer)
+		if err == nil {
+			break
+		}
+
+		time.Sleep(2 * time.Second)
+	}
+	fmt.Println(promptStruct)
+
+	switch promptStruct.Relation {
+	case "image first":
+		err := imageFirst(promptStruct.Text, promptStruct.Image, writer, p)
+		if err != nil {
+			return err
+		}
+	case "text first":
+		err := textFirst(promptStruct.Text, promptStruct.Image, writer, p)
+		if err != nil {
+			return err
+		}
+	case "none":
+		err := noneRelation(promptStruct.Text, promptStruct.Image, writer, p)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/model/provider.go
+++ b/model/provider.go
@@ -27,6 +27,8 @@ func GetModelProvider(typ string, subType string, clientId string, clientSecret 
 		p, err = NewLocalModelProvider(typ, subType, clientSecret, temperature, topP, frequencyPenalty, presencePenalty, providerUrl)
 	} else if typ == "OpenAI" {
 		p, err = NewOpenAiModelProvider(typ, subType, clientSecret, temperature, topP, frequencyPenalty, presencePenalty)
+	} else if typ == "OpenAI Revised" {
+		p, err = NewOpenAiRevisedModelProvider(typ, subType, clientSecret, temperature, topP, frequencyPenalty, presencePenalty)
 	} else if typ == "Gemini" {
 		p, err = NewGeminiModelProvider(subType, clientSecret, temperature, topP, topK)
 	} else if typ == "Azure" {

--- a/web/src/ProviderEditPage.js
+++ b/web/src/ProviderEditPage.js
@@ -171,6 +171,8 @@ class ProviderEditPage extends React.Component {
               if (this.state.provider.category === "Model") {
                 if (value === "OpenAI") {
                   this.updateProviderField("subType", "gpt-4");
+                } else if (value === "OpenAI Revised") {
+                  this.updateProviderField("subType", "dall-e-3 and gpt-4-vision-preview");
                 } else if (value === "Gemini") {
                   this.updateProviderField("subType", "gemini-pro");
                 } else if (value === "OpenRouter") {
@@ -270,6 +272,74 @@ class ProviderEditPage extends React.Component {
         }
         {
           (this.state.provider.category === "Model" && this.state.provider.type === "OpenAI") ? (
+            <>
+              <Row style={{marginTop: "20px"}}>
+                <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+                  {i18next.t("provider:Temperature")}:
+                </Col>
+                <this.InputSlider
+                  min={0}
+                  max={2}
+                  step={0.01}
+                  value={this.state.provider.temperature}
+                  onChange={(value) => {
+                    this.updateProviderField("temperature", value);
+                  }}
+                  isMobile={Setting.isMobile()}
+                />
+              </Row>
+              <Row style={{marginTop: "20px"}}>
+                <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+                  {i18next.t("provider:Top P")}:
+                </Col>
+                <this.InputSlider
+                  min={0}
+                  max={1}
+                  step={0.01}
+                  value={this.state.provider.topP}
+                  onChange={(value) => {
+                    this.updateProviderField("topP", value);
+                  }}
+                  isMobile={Setting.isMobile()}
+                />
+              </Row>
+              <Row style={{marginTop: "20px"}}>
+                <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+                  {i18next.t("provider:Frequency penalty")}:
+                </Col>
+                <this.InputSlider
+                  label={i18next.t("provider:Frequency penalty")}
+                  min={-2}
+                  max={2}
+                  step={0.01}
+                  value={this.state.provider.frequencyPenalty}
+                  onChange={(value) => {
+                    this.updateProviderField("frequencyPenalty", value);
+                  }}
+                  isMobile={Setting.isMobile()}
+                />
+              </Row>
+              <Row style={{marginTop: "20px"}}>
+                <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+                  {i18next.t("provider:Presence penalty")}:
+                </Col>
+                <this.InputSlider
+                  label={i18next.t("provider:Presence penalty")}
+                  min={-2}
+                  max={2}
+                  step={0.01}
+                  value={this.state.provider.presencePenalty}
+                  onChange={(value) => {
+                    this.updateProviderField("presencePenalty", value);
+                  }}
+                  isMobile={Setting.isMobile()}
+                />
+              </Row>
+            </>
+          ) : null
+        }
+        {
+          (this.state.provider.category === "Model" && this.state.provider.type === "OpenAI Revised") ? (
             <>
               <Row style={{marginTop: "20px"}}>
                 <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>

--- a/web/src/Setting.js
+++ b/web/src/Setting.js
@@ -638,6 +638,7 @@ export function getProviderTypeOptions(category) {
     return (
       [
         {id: "OpenAI", name: "OpenAI"},
+        {id: "OpenAI Revised", name: "OpenAI Revised"},
         {id: "Gemini", name: "Gemini"},
         {id: "Hugging Face", name: "Hugging Face"},
         {id: "Claude", name: "Claude"},
@@ -729,6 +730,12 @@ export function getProviderSubTypeOptions(category, type) {
     } else {
       return [];
     }
+  } else if (type === "OpenAI Revised") {
+    return (
+      [
+        {id: "dall-e-3 and gpt-4-vision-preview", name: "dall-e-3 and gpt-4-vision-preview"},
+      ]
+    );
   } else if (type === "Gemini") {
     if (category === "Model") {
       return (


### PR DESCRIPTION
1. Add a model type called "OpenAI Revised", for supporting output texts and images at the same time
2. Add a getAnswer() function in the model. It can get answer in stream, convert it to string, and also allow the writer to transfer the answer to the client. It is up to the phase of analyzing. For example, in the prompt extraction phase, writer should be prohibitted, only get answer.
3. Modify web page. In web/src/ProviderEditPage.js, temperature, topP kind of parameters are all for gpt-4-vision-preview, because dall-e-3 does not need these parameters.