### PR TITLE
feat: fix getMessageAnswer miss cookies information

### DIFF
--- a/web/src/backend/MessageBackend.js
+++ b/web/src/backend/MessageBackend.js
@@ -50,7 +50,9 @@ export function getMessageAnswer(owner, name, onMessage, onError, onEnd) {
   if (eventSourceMap.has(`${owner}/${name}`)) {
     return;
   }
-  const eventSource = new EventSource(`${Setting.ServerUrl}/api/get-message-answer?id=${owner}/${encodeURIComponent(name)}`);
+  const eventSource = new EventSource(`${Setting.ServerUrl}/api/get-message-answer?id=${owner}/${encodeURIComponent(name)}`, {
+    withCredentials: true,
+  });
   eventSourceMap.set(`${owner}/${name}`, eventSource);
 
   eventSource.addEventListener("message", (e) => {


### PR DESCRIPTION
This problem causes `GetMessageAnswer` interface.

```
_, ok := c.CheckSignedIn()
```
`ok` always be false