### PR TITLE
feat: fix huggingface sdk bug

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/google/uuid v1.4.0
 	github.com/henomis/lingoose v0.1.0
+	github.com/hupe1980/go-huggingface v0.0.15
 	github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80
 	github.com/leverly/ChatGLM v1.2.0
 	github.com/lib/pq v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -352,6 +352,8 @@ github.com/henomis/lingoose v0.1.0 h1:HuR1DFYbM/qQTOozlikYqhHj3LlDuMjr3PbKLugFgE
 github.com/henomis/lingoose v0.1.0/go.mod h1:QSBUeU5LhzQNOfeGoObXd5E+EdIm7h/OJP1kqf/RpFY=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
+github.com/hupe1980/go-huggingface v0.0.15 h1:tTWmUGGunC/BYz4hrwS8SSVtMYVYjceG2uhL8HxeXvw=
+github.com/hupe1980/go-huggingface v0.0.15/go.mod h1:IRvsik3+b9BJyw9hCfw1arI6gDObcVto1UA8f3kt8mM=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imroc/req/v3 v3.35.1 h1:xrsuKq4FHWqxU2DM8lWbTwmxiObGfR7B/zgEBMmy8Wc=
 github.com/imroc/req/v3 v3.35.1/go.mod h1:c8dXW9N3SJn/DuKVjHHmryV2WO7At9bFtnu1rloiFoo=


### PR DESCRIPTION
> from https://huggingface.co/docs/api-inference/detailed_parameters#text-generation-task
```
inputs (required): | a string to be generated from
```
but, in `github.com/henomis/lingoose/llm/huggingface` requetst schema is defined:
```
type textGenerationRequest struct {
	Inputs     []string                 `json:"inputs,omitempty"`
	Parameters textGenerationParameters `json:"parameters,omitempty"`
	Options    options                  `json:"options,omitempty"`
}
```
so, we get an error：
```
 huggingface completion error: invalid character 'F' looking for beginning of value
```