### PR TITLE
feat: fix the bug of not being able to get vectors for non "admin" users

### DIFF
--- a/web/src/VectorEditPage.js
+++ b/web/src/VectorEditPage.js
@@ -40,7 +40,7 @@ class VectorEditPage extends React.Component {
   }
 
   getVector() {
-    VectorBackend.getVector(this.props.account.name, this.state.vectorName)
+    VectorBackend.getVector("admin", this.props.match.params.vectorName)
       .then((res) => {
         if (res.status === "ok") {
           this.setState({


### PR DESCRIPTION
The previous vector detail was queried using account.name, but "admin" is used to add so the owner is "admin".