### PR TITLE
fix: Fixed bug that crashed when user and session were empty

### DIFF
--- a/web/src/ChatPage.js
+++ b/web/src/ChatPage.js
@@ -495,7 +495,7 @@ class ChatPage extends BaseListPage {
       const chat = chats[i];
       this.setState({
         chat: chat,
-        // messages: null,
+      // messages: null,
       });
       this.getMessages(chat);
       this.goToLinkSoft(`/chat/${chat.name}`);
@@ -535,6 +535,7 @@ class ChatPage extends BaseListPage {
         <div style={{width: (Setting.isMobile() || Setting.isAnonymousUser(this.props.account) || Setting.getUrlParam("isRaw") !== null) ? "0px" : "250px", height: "100%", backgroundColor: "white", marginRight: "2px"}}>
           <ChatMenu ref={this.menu} chats={chats} chatName={this.getChat()} onSelectChat={onSelectChat} onAddChat={onAddChat} onDeleteChat={onDeleteChat} onUpdateChatName={onUpdateChatName} stores={!this.state.canSelectStore ? [] : this.state.stores} />
         </div>
+
         <div style={{flex: 1, height: "100%", backgroundColor: "white", position: "relative"}}>
           {
             (this.state.messages === undefined || this.state.messages === null) ? null : (
@@ -556,7 +557,7 @@ class ChatPage extends BaseListPage {
               </div>
             )
           }
-          <ChatBox disableInput={this.state.disableInput} messages={this.state.messages} sendMessage={(text, fileName, regenerate = false) => {this.sendMessage(text, fileName, false, regenerate);}} account={this.props.account} dots={this.state.dots} name={this.state.chat?.name} displayName={this.state.chat?.displayName} store={this.state.stores?.find(store => store.name === this.state.chat.store)} />
+          <ChatBox disableInput={this.state.disableInput} messages={this.state.messages} sendMessage={(text, fileName, regenerate = false) => {this.sendMessage(text, fileName, false, regenerate);}} account={this.props.account} dots={this.state.dots} name={this.state.chat?.name} displayName={this.state.chat?.displayName} store={this.state.stores?.find(store => store.name === this.state.chat?.store)} />
         </div>
       </div>
     );

--- a/web/src/UsagePage.js
+++ b/web/src/UsagePage.js
@@ -416,18 +416,18 @@ class UsagePage extends BaseListPage {
       <option key="all" value="All" disabled={!(this.props.account.name === "admin" || this.props.account.type === "chat-admin")}>
         All
       </option>,
-      ...this.state.users.map((user, index) => (
+      ...(this.state.users ? this.state.users.map((user, index) => (
         <option key={index} value={index}>
           {user}
         </option>
-      )),
+      )) : []),
     ];
     const handleChange = (value) => {
       let user;
       if (value === "All") {
         user = "All";
       } else {
-        user = this.state.users[value];
+        user = this.state.users ? this.state.users[value] : null;
       }
       this.setState({
         selectedUser: user,


### PR DESCRIPTION

```
<ChatBox disableInput={this.state.disableInput} messages={this.state.messages} sendMessage={(text, fileName, regenerate = false) => {this.sendMessage(text, fileName, false, regenerate);}} account={this.props.account} dots={this.state.dots} name={this.state.chat?.name} displayName={this.state.chat?.displayName} store={this.state.stores?.find(store => store.name === this.state.chat?.store)} />
```
Changing `this.state.chat.store` to `this.state.chat?.store` fixed the bug where the page would crash after deleting all chats.


```
user = this.state.users ? this.state.users[value] : null;
```
To prevent a crash when `this.state.users` is `undefined` or `null`.




```
...this.state.users.map((user, index) => (
```

If this.state.users is `undefined` or `null`, the program will crash
Here, a check is performed first: `this.state.users ? this.state.users.map(...) : [].`