### PR TITLE
fix: optimize chat menu rendering and prevent null ref errors

### DIFF
--- a/web/src/ChatPage.js
+++ b/web/src/ChatPage.js
@@ -179,7 +179,9 @@ class ChatPage extends BaseListPage {
                 });
 
                 const chats = res.data;
-                this.menu.current.setSelectedKeyToNewChat(chats);
+                if (this.menu && this.menu.current) {
+                  this.menu.current.setSelectedKeyToNewChat(chats);
+                }
               }
             });
 
@@ -555,9 +557,13 @@ class ChatPage extends BaseListPage {
         {
           this.renderUnsafePasswordModal()
         }
-        <div style={{width: (Setting.isMobile() || Setting.isAnonymousUser(this.props.account) || Setting.getUrlParam("isRaw") !== null) ? "0px" : "250px", height: "100%", backgroundColor: "white", marginRight: "2px"}}>
-          <ChatMenu ref={this.menu} chats={chats} chatName={this.getChat()} onSelectChat={onSelectChat} onAddChat={onAddChat} onDeleteChat={onDeleteChat} onUpdateChatName={onUpdateChatName} stores={!this.state.canSelectStore ? [] : this.state.stores} />
-        </div>
+        {
+          !(Setting.isMobile() || Setting.isAnonymousUser(this.props.account) || Setting.getUrlParam("isRaw") !== null) && (
+            <div style={{width: "250px", height: "100%", backgroundColor: "white", marginRight: "2px"}}>
+              <ChatMenu ref={this.menu} chats={chats} chatName={this.getChat()} onSelectChat={onSelectChat} onAddChat={onAddChat} onDeleteChat={onDeleteChat} onUpdateChatName={onUpdateChatName} stores={!this.state.canSelectStore ? [] : this.state.stores} />
+            </div>
+          )
+        }
         <div style={{flex: 1, height: "100%", backgroundColor: "white", position: "relative"}}>
           {
             (this.state.messages === undefined || this.state.messages === null) ? null : (
@@ -633,7 +639,9 @@ class ChatPage extends BaseListPage {
           this.getGlobalStores();
 
           if (!setLoading) {
-            this.menu.current.setSelectedKeyToNewChat(chats);
+            if (this.menu && this.menu.current) {
+              this.menu.current.setSelectedKeyToNewChat(chats);
+            }
           }
         }
       });


### PR DESCRIPTION
fix: https://github.com/casibase/casibase/issues/1052

## Description
Improved chat menu rendering logic by using conditional rendering instead of width=0 to hide the menu. Also added null checks for menu ref to prevent runtime errors.
<img width="1383" alt="5b32048b2e786f487a37acf9ba0aed31" src="https://github.com/user-attachments/assets/ebad4f89-87e9-4269-9cd7-0976d8f7e4b4" />
