### PR TITLE
feat: fix bug that click "Regenerate" for first error, but second error refreshes

### DIFF
--- a/web/src/ChatBox.js
+++ b/web/src/ChatBox.js
@@ -137,19 +137,12 @@ class ChatBox extends React.Component {
     this.setState({value: "", files: []});
   };
 
-  handleRegenerate = () => {
+  handleRegenerate = (index) => {
+    // can only regenerate after sending the message
     const messages = this.state.messages || [];
-    const isSingleWelcomeMessage = (
-      messages.length === 1 &&
-        messages[0].replyTo === "Welcome" &&
-        messages[0].author === "AI"
-    );
+    const message = [...messages.slice(0, index)].reverse().find(message => message.author !== "AI");
 
-    const text = isSingleWelcomeMessage
-      ? ""
-      : [...messages].reverse().find(message => message.author !== "AI")?.text || "";
-
-    this.props.sendMessage(text, "", true);
+    this.handleEditMessage({...message, text: message.text, updatedTime: new Date().toISOString()});
   };
 
   handleInputChange = async(file) => {

--- a/web/src/chat/MessageActions.js
+++ b/web/src/chat/MessageActions.js
@@ -62,8 +62,8 @@ const MessageActions = ({
           icon={<ReloadOutlined />}
           style={{border: "none", color: ThemeDefault.colorPrimary}}
           onClick={() => {
-            onRegenerate();
             setIsRegenerating(true);
+            onRegenerate(index);
           }}
           disabled={isRegenerating}
         />

--- a/web/src/chat/MessageItem.js
+++ b/web/src/chat/MessageItem.js
@@ -82,7 +82,7 @@ const MessageItem = ({
           action={
             <Button danger type="primary" onClick={() => {
               setIsRegenerating(true);
-              onRegenerate();
+              onRegenerate(index);
             }} disabled={isRegenerating}>
               {
                 isRegenerating ? i18next.t("general:Regenerating...") :


### PR DESCRIPTION
fix: https://github.com/casibase/casibase/issues/1102
now that the regenerating handler will call editing handler to regenerate message, which means that all messages after will be removed.