### PR TITLE
feat: rename "API key" to "Provider key" to avoid confusion

### DIFF
--- a/controllers/openai_api.go
+++ b/controllers/openai_api.go
@@ -43,7 +43,7 @@ func (c *ApiController) ChatCompletions() {
 	apiKey = strings.TrimPrefix(apiKey, "Bearer ")
 
 	// Get the model provider based on API key
-	modelProvider, err := object.GetModelProviderByApiKey(apiKey)
+	modelProvider, err := object.GetModelProviderByProviderKey(apiKey)
 	if err != nil {
 		c.ResponseError(fmt.Sprintf("Authentication failed: %s", err.Error()))
 		return

--- a/object/provider.go
+++ b/object/provider.go
@@ -42,7 +42,7 @@ type Provider struct {
 	ClientId           string            `xorm:"varchar(100)" json:"clientId"`
 	ClientSecret       string            `xorm:"varchar(2000)" json:"clientSecret"`
 	Region             string            `xorm:"varchar(100)" json:"region"`
-	ApiKey             string            `xorm:"varchar(100)" json:"apiKey"`
+	ProviderKey        string            `xorm:"varchar(100)" json:"providerKey"`
 	ProviderUrl        string            `xorm:"varchar(200)" json:"providerUrl"`
 	ApiVersion         string            `xorm:"varchar(100)" json:"apiVersion"`
 	CompitableProvider string            `xorm:"varchar(100)" json:"compitableProvider"`
@@ -88,8 +88,8 @@ func GetMaskedProvider(provider *Provider, isMaskEnabled bool, user *casdoorsdk.
 	}
 
 	if !isAdmin(user) {
-		if provider.ApiKey != "" {
-			provider.ApiKey = "***"
+		if provider.ProviderKey != "" {
+			provider.ProviderKey = "***"
 		}
 		if provider.UserKey != "" {
 			provider.UserKey = "***"
@@ -206,8 +206,8 @@ func UpdateProvider(id string, provider *Provider) (bool, error) {
 		provider.SignKey = p.SignKey
 	}
 
-	if provider.ApiKey == "" && provider.Category == "Model" {
-		provider.ApiKey = generateApiKey()
+	if provider.ProviderKey == "" && provider.Category == "Model" {
+		provider.ProviderKey = generateApiKey()
 	}
 
 	if provider.Type == "Ollama" && provider.ProviderUrl != "" && !strings.HasPrefix(provider.ProviderUrl, "http") {
@@ -234,8 +234,8 @@ func UpdateProvider(id string, provider *Provider) (bool, error) {
 }
 
 func AddProvider(provider *Provider) (bool, error) {
-	if provider.ApiKey == "" && provider.Category == "Model" {
-		provider.ApiKey = generateApiKey()
+	if provider.ProviderKey == "" && provider.Category == "Model" {
+		provider.ProviderKey = generateApiKey()
 	}
 
 	if providerAdapter != nil && provider.Category != "Storage" {

--- a/object/provider.go
+++ b/object/provider.go
@@ -207,7 +207,7 @@ func UpdateProvider(id string, provider *Provider) (bool, error) {
 	}
 
 	if provider.ProviderKey == "" && provider.Category == "Model" {
-		provider.ProviderKey = generateApiKey()
+		provider.ProviderKey = generateProviderKey()
 	}
 
 	if provider.Type == "Ollama" && provider.ProviderUrl != "" && !strings.HasPrefix(provider.ProviderUrl, "http") {
@@ -235,7 +235,7 @@ func UpdateProvider(id string, provider *Provider) (bool, error) {
 
 func AddProvider(provider *Provider) (bool, error) {
 	if provider.ProviderKey == "" && provider.Category == "Model" {
-		provider.ProviderKey = generateApiKey()
+		provider.ProviderKey = generateProviderKey()
 	}
 
 	if providerAdapter != nil && provider.Category != "Storage" {

--- a/object/provider_default.go
+++ b/object/provider_default.go
@@ -20,7 +20,7 @@ import (
 	"github.com/casibase/casibase/model"
 )
 
-// GetProviderByProviderKey retrieves a provider using the API key
+// GetProviderByProviderKey retrieves a provider using the Provider key
 func GetProviderByProviderKey(providerKey string) (*Provider, error) {
 	if providerKey == "" {
 		return nil, fmt.Errorf("empty provider key")

--- a/object/provider_default.go
+++ b/object/provider_default.go
@@ -20,23 +20,23 @@ import (
 	"github.com/casibase/casibase/model"
 )
 
-// GetProviderByApiKey retrieves a provider using the API key
-func GetProviderByApiKey(apiKey string) (*Provider, error) {
-	if apiKey == "" {
-		return nil, fmt.Errorf("empty API key")
+// GetProviderByProviderKey retrieves a provider using the API key
+func GetProviderByProviderKey(providerKey string) (*Provider, error) {
+	if providerKey == "" {
+		return nil, fmt.Errorf("empty provider key")
 	}
 
 	provider := &Provider{}
 
 	// Try to find in main database first
-	existed, err := adapter.engine.Where("api_key = ?", apiKey).Get(provider)
+	existed, err := adapter.engine.Where("provider_key = ?", providerKey).Get(provider)
 	if err != nil {
 		return nil, err
 	}
 
 	// If not found in main database, try provider adapter
 	if providerAdapter != nil && !existed {
-		existed, err = providerAdapter.engine.Where("api_key = ?", apiKey).Get(provider)
+		existed, err = providerAdapter.engine.Where("provider_key = ?", providerKey).Get(provider)
 		if err != nil {
 			return nil, err
 		}
@@ -49,9 +49,9 @@ func GetProviderByApiKey(apiKey string) (*Provider, error) {
 	return nil, nil
 }
 
-// GetModelProviderByApiKey retrieves both the provider and its model provider by API key
-func GetModelProviderByApiKey(apiKey string) (model.ModelProvider, error) {
-	provider, err := GetProviderByApiKey(apiKey)
+// GetModelProviderByProviderKey retrieves both the provider and its model provider by API key
+func GetModelProviderByProviderKey(providerKey string) (model.ModelProvider, error) {
+	provider, err := GetProviderByProviderKey(providerKey)
 	if err != nil {
 		return nil, err
 	}

--- a/object/provider_util.go
+++ b/object/provider_util.go
@@ -168,6 +168,6 @@ func getActiveBlockchainProvider(owner string) (*Provider, error) {
 	return nil, nil
 }
 
-func generateApiKey() string {
+func generateProviderKey() string {
 	return fmt.Sprintf("sk-%s", util.GetRandomString(24))
 }

--- a/web/src/ProviderEditPage.js
+++ b/web/src/ProviderEditPage.js
@@ -948,14 +948,14 @@ class ProviderEditPage extends React.Component {
           this.state.provider.category === "Model" ? (
             <Row style={{marginTop: "20px"}} >
               <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                {Setting.getLabel(i18next.t("provider:API key"), i18next.t("provider:API key - Tooltip"))} :
+                {Setting.getLabel(i18next.t("provider:Provider key"), i18next.t("provider:Provider key - Tooltip"))} :
               </Col>
               <Col span={22} >
                 <Input.Password
-                  value={this.state.provider.apiKey}
+                  value={this.state.provider.providerKey}
                   disabled={!this.state.isAdmin}
                   onChange={e => {
-                    this.updateProviderField("apiKey", e.target.value);
+                    this.updateProviderField("providerKey", e.target.value);
                   }}
                 />
               </Col>

--- a/web/src/locales/de/data.json
+++ b/web/src/locales/de/data.json
@@ -438,6 +438,8 @@
     "Presence penalty": "Presence penalty",
     "Presence penalty - Tooltip": "Presence penalty - Tooltip",
     "Provider URL": "Provider URL",
+    "Provider key": "Provider key",
+    "Provider key - Tooltip": "Provider key - Tooltip",
     "Provider test": "Provider test",
     "Provider test - Tooltip": "Provider test - Tooltip",
     "Refresh MCP tools": "Refresh MCP tools",

--- a/web/src/locales/en/data.json
+++ b/web/src/locales/en/data.json
@@ -438,6 +438,8 @@
     "Presence penalty": "Presence penalty",
     "Presence penalty - Tooltip": "Penalize repeated phrases",
     "Provider URL": "Provider URL",
+    "Provider key": "Provider key",
+    "Provider key - Tooltip": "Provider key - Tooltip",
     "Provider test": "Provider test",
     "Provider test - Tooltip": "Test text for TTS preview",
     "Refresh MCP tools": "Refresh MCP tools",

--- a/web/src/locales/es/data.json
+++ b/web/src/locales/es/data.json
@@ -438,6 +438,8 @@
     "Presence penalty": "Presence penalty",
     "Presence penalty - Tooltip": "Presence penalty - Tooltip",
     "Provider URL": "Provider URL",
+    "Provider key": "Provider key",
+    "Provider key - Tooltip": "Provider key - Tooltip",
     "Provider test": "Provider test",
     "Provider test - Tooltip": "Provider test - Tooltip",
     "Refresh MCP tools": "Refresh MCP tools",

--- a/web/src/locales/fr/data.json
+++ b/web/src/locales/fr/data.json
@@ -438,6 +438,8 @@
     "Presence penalty": "Presence penalty",
     "Presence penalty - Tooltip": "Presence penalty - Tooltip",
     "Provider URL": "Provider URL",
+    "Provider key": "Provider key",
+    "Provider key - Tooltip": "Provider key - Tooltip",
     "Provider test": "Provider test",
     "Provider test - Tooltip": "Provider test - Tooltip",
     "Refresh MCP tools": "Refresh MCP tools",

--- a/web/src/locales/id/data.json
+++ b/web/src/locales/id/data.json
@@ -438,6 +438,8 @@
     "Presence penalty": "Presence penalty",
     "Presence penalty - Tooltip": "Presence penalty - Tooltip",
     "Provider URL": "Provider URL",
+    "Provider key": "Provider key",
+    "Provider key - Tooltip": "Provider key - Tooltip",
     "Provider test": "Provider test",
     "Provider test - Tooltip": "Provider test - Tooltip",
     "Refresh MCP tools": "Refresh MCP tools",

--- a/web/src/locales/ja/data.json
+++ b/web/src/locales/ja/data.json
@@ -438,6 +438,8 @@
     "Presence penalty": "Presence penalty",
     "Presence penalty - Tooltip": "Presence penalty - Tooltip",
     "Provider URL": "Provider URL",
+    "Provider key": "Provider key",
+    "Provider key - Tooltip": "Provider key - Tooltip",
     "Provider test": "Provider test",
     "Provider test - Tooltip": "Provider test - Tooltip",
     "Refresh MCP tools": "Refresh MCP tools",

--- a/web/src/locales/ko/data.json
+++ b/web/src/locales/ko/data.json
@@ -438,6 +438,8 @@
     "Presence penalty": "Presence penalty",
     "Presence penalty - Tooltip": "Presence penalty - Tooltip",
     "Provider URL": "Provider URL",
+    "Provider key": "Provider key",
+    "Provider key - Tooltip": "Provider key - Tooltip",
     "Provider test": "Provider test",
     "Provider test - Tooltip": "Provider test - Tooltip",
     "Refresh MCP tools": "Refresh MCP tools",

--- a/web/src/locales/ru/data.json
+++ b/web/src/locales/ru/data.json
@@ -438,6 +438,8 @@
     "Presence penalty": "Presence penalty",
     "Presence penalty - Tooltip": "Presence penalty - Tooltip",
     "Provider URL": "URL Провайдера",
+    "Provider key": "Provider key",
+    "Provider key - Tooltip": "Provider key - Tooltip",
     "Provider test": "Provider test",
     "Provider test - Tooltip": "Provider test - Tooltip",
     "Refresh MCP tools": "Refresh MCP tools",

--- a/web/src/locales/zh/data.json
+++ b/web/src/locales/zh/data.json
@@ -1,7 +1,7 @@
 {
   "account": {
-    "1. Go to your setting page by clicking on the below \"My Account\" button.": "1. 点击下方的\"我的账户\"按钮进入设置页面。",
-    "2. Click \"Modify password...\" button to change your password. Then close the setting page.": "2. 点击\"修改密码...\"按钮更改您的密码。然后关闭设置页面。",
+    "1. Go to your setting page by clicking on the below \"My Account\" button.": "1. Go to your setting page by clicking on the below \"My Account\" button.",
+    "2. Click \"Modify password...\" button to change your password. Then close the setting page.": "2. Click \"Modify password...\" button to change your password. Then close the setting page.",
     "3. Go back to this page and refresh it by pressing F5 key. This alert message should be gone.": "3. 返回此页面，并按F5键刷新。这个警告信息会自行消失。",
     "4. If you encounter any issues, please contact your administrator.": "4. 如果还有任何问题，请联系管理员。",
     "My Account": "我的账户",
@@ -438,6 +438,8 @@
     "Presence penalty": "重复惩罚",
     "Presence penalty - Tooltip": "重复惩罚（-2~2，正值减少重复）",
     "Provider URL": "提供商URL",
+    "Provider key": "提供商密钥",
+    "Provider key - Tooltip": "提供商 OpenAI 兼容密钥",
     "Provider test": "语音合成测试",
     "Provider test - Tooltip": "语音合成测试文本（点击按钮试听）",
     "Refresh MCP tools": "刷新MCP工具",

--- a/web/src/locales/zh/data.json
+++ b/web/src/locales/zh/data.json
@@ -1,7 +1,7 @@
 {
   "account": {
-    "1. Go to your setting page by clicking on the below \"My Account\" button.": "1. Go to your setting page by clicking on the below \"My Account\" button.",
-    "2. Click \"Modify password...\" button to change your password. Then close the setting page.": "2. Click \"Modify password...\" button to change your password. Then close the setting page.",
+    "1. Go to your setting page by clicking on the below \"My Account\" button.": "1. 点击下方的\"我的账户\"按钮进入设置页面。",
+    "2. Click \"Modify password...\" button to change your password. Then close the setting page.": "2. 点击\"修改密码...\"按钮更改您的密码。然后关闭设置页面。",
     "3. Go back to this page and refresh it by pressing F5 key. This alert message should be gone.": "3. 返回此页面，并按F5键刷新。这个警告信息会自行消失。",
     "4. If you encounter any issues, please contact your administrator.": "4. 如果还有任何问题，请联系管理员。",
     "My Account": "我的账户",


### PR DESCRIPTION
To avoid confusion, we've renamed "API key" to "Provider key" in the model provider settings, as it's not the third-party service's key, but rather an internal key our platform uses to generate its own API access tokens.