### PR TITLE
feat: use default icon if the icon image cannot load

### DIFF
--- a/web/src/OsDesktop.js
+++ b/web/src/OsDesktop.js
@@ -50,7 +50,7 @@ const DesktopIcon = ({name, iconPath, onClick, gradient}) => {
     >
       <div className="icon">
         <img
-          src={`${StaticBaseUrl}/apps/${iconPath}`}
+          src={`${StaticBaseUrl}/apps/${iconPath || routeManager.defaultIcons[0]}`}
           alt={name}
         />
       </div>

--- a/web/src/component/AppRouteManager.js
+++ b/web/src/component/AppRouteManager.js
@@ -18,6 +18,9 @@ import {Spin} from "antd";
 class AppRouteManager {
   constructor() {
     this.routes = new Map();
+    this.defaultIcons = [
+      "default-1.svg",
+    ];
   }
 
   registerApp(appType, config) {


### PR DESCRIPTION
Demo screenshot:
<img width="2940" height="1662" alt="image" src="https://github.com/user-attachments/assets/6b143a05-2f85-4e1b-9cb5-e9c169856a88" />
