### PR TITLE
feat: add support for second record commit and query methods

### DIFF
--- a/controllers/record_chain.go
+++ b/controllers/record_chain.go
@@ -39,6 +39,25 @@ func (c *ApiController) CommitRecord() {
 	c.ServeJSON()
 }
 
+// CommitRecordSecond
+// @Title CommitRecordSecond
+// @Tag Record API
+// @Description commit a record
+// @Param   body    body   object.Record  true        "The details of the record"
+// @Success 200 {object} controllers.Response The Response object
+// @router /commit-record-second [post]
+func (c *ApiController) CommitRecordSecond() {
+	var record object.Record
+	err := json.Unmarshal(c.Ctx.Input.RequestBody, &record)
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+
+	c.Data["json"] = wrapActionResponse(object.CommitRecordSecond(&record))
+	c.ServeJSON()
+}
+
 // QueryRecord
 // @Title QueryRecord
 // @Tag Record API
@@ -50,6 +69,25 @@ func (c *ApiController) QueryRecord() {
 	id := c.Input().Get("id")
 
 	res, err := object.QueryRecord(id)
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+
+	c.ResponseOk(res)
+}
+
+// QueryRecordSecond
+// @Title QueryRecordSecond
+// @Tag Record API
+// @Description query record
+// @Param   id     query    string  true        "The id ( owner/name ) of the record"
+// @Success 200 {object} object.Record The Response object
+// @router /query-record-second [get]
+func (c *ApiController) QueryRecordSecond() {
+	id := c.Input().Get("id")
+
+	res, err := object.QueryRecordSecond(id)
 	if err != nil {
 		c.ResponseError(err.Error())
 		return

--- a/object/provider_util.go
+++ b/object/provider_util.go
@@ -180,8 +180,8 @@ func GetTwoActiveBlockchainProvider(owner string) (*Provider, *Provider, error) 
 		return nil, nil, err
 	}
 
-	var providerFirst, providerSecend *Provider
-	// Try to find the first blockchain provider
+	var providerFirst, providerSecond *Provider
+	// Try to find the first default active blockchain provider
 	for _, provider := range providers {
 		if provider.Category == "Blockchain" && provider.IsDefault && provider.State == "Active" {
 			providerFirst = provider
@@ -189,14 +189,19 @@ func GetTwoActiveBlockchainProvider(owner string) (*Provider, *Provider, error) 
 		}
 	}
 
-	// Try to find the second blockchain provider
+	// If the first provider is not found, try to find the first active blockchain provider,
+	// then find the second active blockchain provider
 	for _, provider := range providers {
-		if ((provider.ClientId != "" && provider.ClientSecret != "") || (provider.ClientSecret != "" && provider.Type == "Ethereum") || provider.Type == "ChainMaker") && provider.Category == "Blockchain" && provider.State == "Active" && provider != providerFirst {
-			providerSecend = provider
-			break
+		if ((provider.ClientId != "" && provider.ClientSecret != "") || (provider.ClientSecret != "" && provider.Type == "Ethereum") || provider.Type == "ChainMaker") && provider.Category == "Blockchain" && provider.State == "Active" {
+			if providerFirst == nil {
+				providerFirst = provider
+			} else if provider.GetId() != providerFirst.GetId() {
+				providerSecond = provider
+				break
+			}
 		}
 	}
-	return providerFirst, providerSecend, nil
+	return providerFirst, providerSecond, nil
 }
 
 func generateProviderKey() string {

--- a/object/provider_util.go
+++ b/object/provider_util.go
@@ -161,7 +161,7 @@ func GetActiveBlockchainProvider(owner string) (*Provider, error) {
 	}
 
 	for _, provider := range providers {
-		if provider.Category == "Blockchain" && provider.IsDefault {
+		if provider.Category == "Blockchain" && provider.IsDefault && provider.State == "Active" {
 			return provider, nil
 		}
 	}
@@ -172,6 +172,31 @@ func GetActiveBlockchainProvider(owner string) (*Provider, error) {
 		}
 	}
 	return nil, nil
+}
+
+func GetTwoActiveBlockchainProvider(owner string) (*Provider, *Provider, error) {
+	providers, err := GetProviders(owner)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var providerFirst, providerSecend *Provider
+	// Try to find the first blockchain provider
+	for _, provider := range providers {
+		if provider.Category == "Blockchain" && provider.IsDefault && provider.State == "Active" {
+			providerFirst = provider
+			break
+		}
+	}
+
+	// Try to find the second blockchain provider
+	for _, provider := range providers {
+		if ((provider.ClientId != "" && provider.ClientSecret != "") || (provider.ClientSecret != "" && provider.Type == "Ethereum") || provider.Type == "ChainMaker") && provider.Category == "Blockchain" && provider.State == "Active" && provider != providerFirst {
+			providerSecend = provider
+			break
+		}
+	}
+	return providerFirst, providerSecend, nil
 }
 
 func generateProviderKey() string {

--- a/object/record_chain.go
+++ b/object/record_chain.go
@@ -125,6 +125,7 @@ func CommitRecord(record *Record) (bool, error) {
 
 	// Update the record fields to avoid concurrent update race conditions
 	return UpdateRecordFields(record.getId(), map[string]interface{}{
+		"provider":    record.Provider,
 		"block":       blockId,
 		"transaction": transactionId,
 		"block_hash":  blockHash,
@@ -149,6 +150,7 @@ func CommitRecordSecond(record *Record) (bool, error) {
 
 	// Update the record fields to avoid concurrent update race conditions
 	return UpdateRecordFields(record.getId(), map[string]interface{}{
+		"provider2":    record.Provider2,
 		"block2":       blockId,
 		"transaction2": transactionId,
 		"block_hash2":  blockHash,

--- a/routers/authz_filter.go
+++ b/routers/authz_filter.go
@@ -45,7 +45,7 @@ func isAllowedInDemoMode(method string, urlPath string) bool {
 		return true
 	}
 
-	if strings.HasPrefix(urlPath, "/api/signin") || urlPath == "/api/signout" || urlPath == "/api/add-chat" || urlPath == "/api/add-message" || urlPath == "/api/update-message" || urlPath == "/api/delete-welcome-message" || urlPath == "/api/generate-text-to-speech-audio" || urlPath == "/api/add-node-tunnel" || urlPath == "/api/start-session" || urlPath == "/api/stop-session" || urlPath == "/api/commit-record" || urlPath == "/api/update-chat" {
+	if strings.HasPrefix(urlPath, "/api/signin") || urlPath == "/api/signout" || urlPath == "/api/add-chat" || urlPath == "/api/add-message" || urlPath == "/api/update-message" || urlPath == "/api/delete-welcome-message" || urlPath == "/api/generate-text-to-speech-audio" || urlPath == "/api/add-node-tunnel" || urlPath == "/api/start-session" || urlPath == "/api/stop-session" || urlPath == "/api/commit-record" || urlPath == "/api/commit-record-second" || urlPath == "/api/update-chat" {
 		return true
 	}
 

--- a/routers/router.go
+++ b/routers/router.go
@@ -207,7 +207,9 @@ func initAPI() {
 	beego.Router("/api/delete-record", &controllers.ApiController{}, "POST:DeleteRecord")
 
 	beego.Router("/api/commit-record", &controllers.ApiController{}, "POST:CommitRecord")
+	beego.Router("/api/commit-record-second", &controllers.ApiController{}, "POST:CommitRecordSecond")
 	beego.Router("/api/query-record", &controllers.ApiController{}, "GET:QueryRecord")
+	beego.Router("/api/query-record-second", &controllers.ApiController{}, "GET:QueryRecordSecond")
 
 	beego.Router("/api/get-system-info", &controllers.ApiController{}, "GET:GetSystemInfo")
 	beego.Router("/api/get-version-info", &controllers.ApiController{}, "GET:GetVersionInfo")

--- a/web/src/RecordListPage.js
+++ b/web/src/RecordListPage.js
@@ -352,7 +352,7 @@ class RecordListPage extends BaseListPage {
         fixed: (Setting.isMobile()) ? "false" : "right",
         ...this.getColumnSearchProps("block"),
         render: (text, record, index) => {
-          return Setting.getBlockBrowserUrl(this.state.providerMap, record, text);
+          return Setting.getBlockBrowserUrl(this.state.providerMap, record, text, true);
         },
       },
       {
@@ -364,7 +364,7 @@ class RecordListPage extends BaseListPage {
         fixed: (Setting.isMobile()) ? "false" : "right",
         ...this.getColumnSearchProps("block2"),
         render: (text, record, index) => {
-          return Setting.getBlockBrowserUrl(this.state.providerMap, record, text);
+          return Setting.getBlockBrowserUrl(this.state.providerMap, record, text, false);
         },
       },
       {

--- a/web/src/RecordListPage.js
+++ b/web/src/RecordListPage.js
@@ -111,8 +111,9 @@ class RecordListPage extends BaseListPage {
       });
   }
 
-  commitRecord(i) {
-    RecordBackend.commitRecord(this.state.data[i])
+  commitRecord(i, isFirst = true) {
+    const commitMethod = isFirst ? RecordBackend.commitRecord : RecordBackend.commitRecordSecond;
+    commitMethod(this.state.data[i])
       .then((res) => {
         if (res.status === "ok") {
           Setting.showMessage("success", i18next.t("general:Successfully committed"));
@@ -128,8 +129,9 @@ class RecordListPage extends BaseListPage {
       });
   }
 
-  queryRecord(record) {
-    RecordBackend.queryRecord(record.owner, record.name)
+  queryRecord(record, isFirst = true) {
+    const queryMethod = isFirst ? RecordBackend.queryRecord : RecordBackend.queryRecordSecond;
+    queryMethod(record.owner, record.name)
       .then((res) => {
         if (res.status === "ok") {
           Setting.showMessage(res.data.includes("Mismatched") ? "error" : "success", `${i18next.t("record:Query")}: ${res.data}`);
@@ -220,6 +222,23 @@ class RecordListPage extends BaseListPage {
         width: "100px",
         sorter: true,
         ...this.getColumnSearchProps("provider"),
+        render: (text, record, index) => {
+          return (
+            <Link to={`/providers/${text}`}>
+              {
+                Setting.getShortText(text, 25)
+              }
+            </Link>
+          );
+        },
+      },
+      {
+        title: i18next.t("vector:Provider2"),
+        dataIndex: "provider2",
+        key: "provider2",
+        width: "100px",
+        sorter: true,
+        ...this.getColumnSearchProps("provider2"),
         render: (text, record, index) => {
           return (
             <Link to={`/providers/${text}`}>
@@ -337,6 +356,18 @@ class RecordListPage extends BaseListPage {
         },
       },
       {
+        title: i18next.t("general:Block2"),
+        dataIndex: "block2",
+        key: "block2",
+        width: "90px",
+        sorter: true,
+        fixed: (Setting.isMobile()) ? "false" : "right",
+        ...this.getColumnSearchProps("block2"),
+        render: (text, record, index) => {
+          return Setting.getBlockBrowserUrl(this.state.providerMap, record, text);
+        },
+      },
+      {
         title: i18next.t("general:Action"),
         dataIndex: "action",
         key: "action",
@@ -346,23 +377,44 @@ class RecordListPage extends BaseListPage {
           return (
             <div>
               {
-                (record.block === "") ? (
-                  <Button
-                    disabled={record.block !== ""}
-                    style={{marginTop: "10px", marginRight: "10px"}}
-                    type="primary" danger
-                    onClick={() => this.commitRecord(index)}
-                  >{i18next.t("record:Commit")}
-                  </Button>
-                ) : (
-                  <Button
-                    disabled={record.block === ""}
-                    style={{marginTop: "10px", marginRight: "10px"}}
-                    type="primary"
-                    onClick={() => this.queryRecord(record)}
-                  >{i18next.t("record:Query")}
-                  </Button>
-                )
+                <>
+                  {(record.block === "") ? (
+                    <Button
+                      disabled={record.block !== ""}
+                      style={{marginTop: "10px", marginRight: "10px"}}
+                      type="primary" danger
+                      onClick={() => this.commitRecord(index, true)}
+                    >{i18next.t("record:Commit")}
+                    </Button>
+                  ) : (
+                    <Button
+                      disabled={record.block === ""}
+                      style={{marginTop: "10px", marginRight: "10px"}}
+                      type="primary"
+                      onClick={() => this.queryRecord(record, true)}
+                    >{i18next.t("record:Query")}
+                    </Button>
+                  )}
+                  {record.provider2 && record.provider2 !== "" && (
+                    (record.block2 === "") ? (
+                      <Button
+                        disabled={record.block2 !== ""}
+                        style={{marginTop: "10px", marginRight: "10px"}}
+                        type="primary" danger
+                        onClick={() => this.commitRecord(index, false)}
+                      >{i18next.t("record:Commit2")}
+                      </Button>
+                    ) : (
+                      <Button
+                        disabled={record.block2 === ""}
+                        style={{marginTop: "10px", marginRight: "10px"}}
+                        type="primary"
+                        onClick={() => this.queryRecord(record, false)}
+                      >{i18next.t("record:Query2")}
+                      </Button>
+                    )
+                  )}
+                </>
               }
               <Button
                 // disabled={record.owner !== this.props.account.owner}

--- a/web/src/Setting.js
+++ b/web/src/Setting.js
@@ -1991,8 +1991,8 @@ export function GenerateId() {
   return uuidv4();
 }
 
-export function getBlockBrowserUrl(providerMap, record, block) {
-  const providerName = record.provider;
+export function getBlockBrowserUrl(providerMap, record, block, isFirst = true) {
+  const providerName = isFirst ? record.provider : record.provider2;
   const provider = providerMap[providerName];
   if (!provider || provider.browserUrl === "") {
     return block;

--- a/web/src/backend/RecordBackend.js
+++ b/web/src/backend/RecordBackend.js
@@ -64,8 +64,24 @@ export function commitRecord(record) {
   }).then(res => res.json());
 }
 
+export function commitRecordSecond(record) {
+  const newRecord = Setting.deepCopy(record);
+  return fetch(`${Setting.ServerUrl}/api/commit-record-second`, {
+    method: "POST",
+    credentials: "include",
+    body: JSON.stringify(newRecord),
+  }).then(res => res.json());
+}
+
 export function queryRecord(owner, name) {
   return fetch(`${Setting.ServerUrl}/api/query-record?id=${owner}/${encodeURIComponent(name)}`, {
+    method: "GET",
+    credentials: "include",
+  }).then(res => res.json());
+}
+
+export function queryRecordSecond(owner, name) {
+  return fetch(`${Setting.ServerUrl}/api/query-record-second?id=${owner}/${encodeURIComponent(name)}`, {
     method: "GET",
     credentials: "include",
   }).then(res => res.json());


### PR DESCRIPTION
Fix: https://github.com/casibase/casibase/issues/1387

### Features & Changes

#### 1. Support for Secondary Blockchain Commit and Query
- Added new API endpoint: `/api/commit-record-second` and `/api/query-record-second`
- Updated `isAllowedInDemoMode` to allow this endpoint in demo environments

#### 2. Frontend
- Added `provider2` column to the record table
- Added `commit2` and `query2` buttons to support operations on the second blockchain

#### 3. Record Model Extension
- Added new fields to the `Record` model:
  - `Provider2`
  - `Block2`
  - `BlockHash2`
  - `Transaction2`

#### 4. GetActiveBlockchainProvider
- After obtaining the default provider, you also need to check its active status.

#### 5. Concurrency Improvements
- Used field-level updates during blockchain commits
- Prevents conflicts caused by concurrent static field updates