### PR TITLE
feat: add WeChat iLink chat provider

### DIFF
--- a/chat/provider.go
+++ b/chat/provider.go
@@ -34,12 +34,18 @@ type ChatProvider interface {
 	SetWebhook(webhookUrl string) error
 }
 
-func GetChatProvider(typ string, clientSecret string, lang string) (ChatProvider, error) {
+const (
+	WeChatTypeIlinkBot = "WeChat iLink Bot"
+)
+
+func GetChatProvider(typ string, clientSecret string, providerUrl string, lang string) (ChatProvider, error) {
 	var p ChatProvider
 	var err error
 
 	if typ == "Telegram" {
 		p, err = NewTelegramChatProvider(clientSecret, proxy.ProxyHttpClient)
+	} else if typ == WeChatTypeIlinkBot {
+		p, err = NewWeChatIlinkChatProvider(providerUrl, clientSecret, proxy.ProxyHttpClient)
 	} else {
 		return nil, fmt.Errorf(i18n.Translate(lang, "chat:the chat provider type: %s is not supported"), typ)
 	}

--- a/chat/wechat_ilink.go
+++ b/chat/wechat_ilink.go
@@ -1,0 +1,334 @@
+// Copyright 2026 The Casibase Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chat
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	WeChatIlinkDefaultBaseUrl = "https://ilinkai.weixin.qq.com"
+	WeChatIlinkDefaultBotType = "3"
+
+	weChatIlinkAppId         = "bot"
+	weChatIlinkClientVersion = "131335"
+	weChatIlinkChannel       = "casibase"
+	weChatIlinkMessageText   = 1
+	weChatIlinkMessageBot    = 2
+	weChatIlinkMessageFinish = 2
+)
+
+type WeChatIlinkClient struct {
+	baseUrl    string
+	token      string
+	httpClient *http.Client
+}
+
+type WeChatIlinkQRCodeResponse struct {
+	Qrcode             string `json:"qrcode"`
+	QrcodeImageContent string `json:"qrcode_img_content"`
+}
+
+type WeChatIlinkQRCodeStatus struct {
+	Status       string `json:"status"`
+	BotToken     string `json:"bot_token"`
+	IlinkBotId   string `json:"ilink_bot_id"`
+	BaseUrl      string `json:"baseurl"`
+	IlinkUserId  string `json:"ilink_user_id"`
+	RedirectHost string `json:"redirect_host"`
+}
+
+type WeChatIlinkBaseInfo struct {
+	ChannelVersion string `json:"channel_version"`
+}
+
+type WeChatIlinkGetUpdatesResponse struct {
+	Ret                  int                   `json:"ret"`
+	ErrCode              int                   `json:"errcode"`
+	ErrMsg               string                `json:"errmsg"`
+	Messages             []*WeChatIlinkMessage `json:"msgs"`
+	GetUpdatesBuf        string                `json:"get_updates_buf"`
+	LongPollingTimeoutMs int                   `json:"longpolling_timeout_ms"`
+}
+
+type WeChatIlinkMessage struct {
+	Seq          int64                     `json:"seq"`
+	MessageId    int64                     `json:"message_id"`
+	FromUserId   string                    `json:"from_user_id"`
+	ToUserId     string                    `json:"to_user_id"`
+	ClientId     string                    `json:"client_id"`
+	CreateTimeMs int64                     `json:"create_time_ms"`
+	SessionId    string                    `json:"session_id"`
+	MessageType  int                       `json:"message_type"`
+	MessageState int                       `json:"message_state"`
+	ItemList     []*WeChatIlinkMessageItem `json:"item_list"`
+	ContextToken string                    `json:"context_token"`
+}
+
+type WeChatIlinkMessageItem struct {
+	Type     int                  `json:"type"`
+	TextItem *WeChatIlinkTextItem `json:"text_item,omitempty"`
+}
+
+type WeChatIlinkTextItem struct {
+	Text string `json:"text"`
+}
+
+type weChatIlinkGetUpdatesRequest struct {
+	GetUpdatesBuf string              `json:"get_updates_buf"`
+	BaseInfo      WeChatIlinkBaseInfo `json:"base_info"`
+}
+
+type weChatIlinkSendMessageRequest struct {
+	Message  WeChatIlinkMessage  `json:"msg"`
+	BaseInfo WeChatIlinkBaseInfo `json:"base_info"`
+}
+
+type weChatIlinkApiResponse struct {
+	Ret     int    `json:"ret"`
+	ErrCode int    `json:"errcode"`
+	ErrMsg  string `json:"errmsg"`
+}
+
+type WeChatIlinkChatProvider struct {
+	client *WeChatIlinkClient
+}
+
+func NewWeChatIlinkClient(baseUrl string, token string, httpClient *http.Client) *WeChatIlinkClient {
+	if strings.TrimSpace(baseUrl) == "" {
+		baseUrl = WeChatIlinkDefaultBaseUrl
+	}
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	return &WeChatIlinkClient{
+		baseUrl:    strings.TrimRight(strings.TrimSpace(baseUrl), "/"),
+		token:      strings.TrimSpace(token),
+		httpClient: httpClient,
+	}
+}
+
+func NewWeChatIlinkChatProvider(baseUrl string, token string, httpClient *http.Client) (*WeChatIlinkChatProvider, error) {
+	if strings.TrimSpace(token) == "" {
+		return nil, fmt.Errorf("WeChat iLink bot token should not be empty")
+	}
+
+	return &WeChatIlinkChatProvider{
+		client: NewWeChatIlinkClient(baseUrl, token, httpClient),
+	}, nil
+}
+
+func (p *WeChatIlinkChatProvider) SendMessage(chatId string, text string) error {
+	return p.client.SendTextMessage(chatId, "", text)
+}
+
+func (p *WeChatIlinkChatProvider) ParseWebhookRequest(body []byte) (*IncomingMessage, error) {
+	return nil, fmt.Errorf("WeChat iLink Bot uses long polling and does not support webhook parsing")
+}
+
+func (p *WeChatIlinkChatProvider) SetWebhook(webhookUrl string) error {
+	return fmt.Errorf("WeChat iLink Bot uses long polling and does not support webhook setup")
+}
+
+func (c *WeChatIlinkClient) StartQRCodeLogin() (*WeChatIlinkQRCodeResponse, error) {
+	var response WeChatIlinkQRCodeResponse
+	err := c.doGet(fmt.Sprintf("ilink/bot/get_bot_qrcode?bot_type=%s", url.QueryEscape(WeChatIlinkDefaultBotType)), &response)
+	if err != nil {
+		return nil, err
+	}
+	if response.Qrcode == "" || response.QrcodeImageContent == "" {
+		return nil, fmt.Errorf("WeChat iLink get_bot_qrcode response is missing qrcode")
+	}
+	return &response, nil
+}
+
+func (c *WeChatIlinkClient) PollQRCodeStatus(qrcode string) (*WeChatIlinkQRCodeStatus, error) {
+	if strings.TrimSpace(qrcode) == "" {
+		return nil, fmt.Errorf("WeChat iLink qrcode should not be empty")
+	}
+
+	var response WeChatIlinkQRCodeStatus
+	err := c.doGet(fmt.Sprintf("ilink/bot/get_qrcode_status?qrcode=%s", url.QueryEscape(qrcode)), &response)
+	if err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+func (c *WeChatIlinkClient) GetUpdatesWithContext(ctx context.Context, getUpdatesBuf string, timeoutMs int) (*WeChatIlinkGetUpdatesResponse, error) {
+	request := weChatIlinkGetUpdatesRequest{
+		GetUpdatesBuf: getUpdatesBuf,
+		BaseInfo:      buildWeChatIlinkBaseInfo(),
+	}
+
+	var response WeChatIlinkGetUpdatesResponse
+	err := c.doPost(ctx, "ilink/bot/getupdates", request, timeoutMs, &response)
+	if err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+func (c *WeChatIlinkClient) SendTextMessage(toUserId string, contextToken string, text string) error {
+	if strings.TrimSpace(toUserId) == "" {
+		return fmt.Errorf("WeChat iLink to_user_id should not be empty")
+	}
+
+	request := weChatIlinkSendMessageRequest{
+		Message: WeChatIlinkMessage{
+			ToUserId:     toUserId,
+			ClientId:     generateWeChatIlinkClientId(),
+			MessageType:  weChatIlinkMessageBot,
+			MessageState: weChatIlinkMessageFinish,
+			ContextToken: contextToken,
+			ItemList: []*WeChatIlinkMessageItem{
+				{
+					Type:     weChatIlinkMessageText,
+					TextItem: &WeChatIlinkTextItem{Text: text},
+				},
+			},
+		},
+		BaseInfo: buildWeChatIlinkBaseInfo(),
+	}
+
+	var response weChatIlinkApiResponse
+	if err := c.doPost(context.Background(), "ilink/bot/sendmessage", request, 0, &response); err != nil {
+		return err
+	}
+	if response.Ret != 0 || response.ErrCode != 0 {
+		return fmt.Errorf("WeChat iLink sendmessage error: ret=%d errcode=%d errmsg=%s", response.Ret, response.ErrCode, response.ErrMsg)
+	}
+	return nil
+}
+
+func (m *WeChatIlinkMessage) Text() (string, bool) {
+	if m == nil {
+		return "", false
+	}
+	for _, item := range m.ItemList {
+		if item != nil && item.Type == weChatIlinkMessageText && item.TextItem != nil && item.TextItem.Text != "" {
+			return item.TextItem.Text, true
+		}
+	}
+	return "", false
+}
+
+func (c *WeChatIlinkClient) doGet(endpoint string, target interface{}) error {
+	req, err := http.NewRequest(http.MethodGet, c.buildUrl(endpoint), nil)
+	if err != nil {
+		return err
+	}
+	setWeChatIlinkCommonHeaders(req.Header)
+	return c.do(req, target)
+}
+
+func (c *WeChatIlinkClient) doPost(ctx context.Context, endpoint string, payload interface{}, timeoutMs int, target interface{}) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	var cancel context.CancelFunc
+	if timeoutMs > 0 {
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(timeoutMs+5000)*time.Millisecond)
+		defer cancel()
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.buildUrl(endpoint), bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	setWeChatIlinkCommonHeaders(req.Header)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("AuthorizationType", "ilink_bot_token")
+	req.Header.Set("Content-Length", strconv.Itoa(len(body)))
+	req.Header.Set("X-WECHAT-UIN", randomWeChatIlinkUin())
+	if c.token != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.token))
+	}
+
+	return c.do(req, target)
+}
+
+func (c *WeChatIlinkClient) do(req *http.Request, target interface{}) error {
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("WeChat iLink API error (status %d): %s", resp.StatusCode, string(respBody))
+	}
+	if target == nil || len(respBody) == 0 {
+		return nil
+	}
+	if err = json.Unmarshal(respBody, target); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *WeChatIlinkClient) buildUrl(endpoint string) string {
+	endpoint = strings.TrimLeft(endpoint, "/")
+	return fmt.Sprintf("%s/%s", c.baseUrl, endpoint)
+}
+
+func setWeChatIlinkCommonHeaders(header http.Header) {
+	header.Set("iLink-App-Id", weChatIlinkAppId)
+	header.Set("iLink-App-ClientVersion", weChatIlinkClientVersion)
+}
+
+func buildWeChatIlinkBaseInfo() WeChatIlinkBaseInfo {
+	return WeChatIlinkBaseInfo{ChannelVersion: weChatIlinkChannel}
+}
+
+func randomWeChatIlinkUin() string {
+	buf := make([]byte, 4)
+	if _, err := rand.Read(buf); err != nil {
+		return base64.StdEncoding.EncodeToString([]byte("0"))
+	}
+
+	value := binary.BigEndian.Uint32(buf)
+	return base64.StdEncoding.EncodeToString([]byte(strconv.FormatUint(uint64(value), 10)))
+}
+
+func generateWeChatIlinkClientId() string {
+	buf := make([]byte, 8)
+	if _, err := rand.Read(buf); err != nil {
+		return fmt.Sprintf("casibase-%d", time.Now().UnixNano())
+	}
+	return fmt.Sprintf("casibase-%x", buf)
+}

--- a/controllers/provider.go
+++ b/controllers/provider.go
@@ -215,6 +215,54 @@ func (c *ApiController) RefreshMcpTools() {
 	c.ResponseOk(&provider)
 }
 
+// StartWeChatIlinkLogin starts a WeChat iLink Bot QR login session.
+// @Title StartWeChatIlinkLogin
+// @Tag Provider API
+// @Description start WeChat iLink Bot QR login
+// @Param   id     query    string  true  "The id of the provider (owner/name)"
+// @Success 200 {object} controllers.Response The Response object
+// @router /start-wechat-ilink-login [post]
+func (c *ApiController) StartWeChatIlinkLogin() {
+	if !c.RequireAdmin() {
+		return
+	}
+
+	id := c.Input().Get("id")
+
+	result, err := object.StartWeChatIlinkLogin(id)
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+
+	c.ResponseOk(result)
+}
+
+// WaitWeChatIlinkLogin waits once for a WeChat iLink Bot QR login result.
+// @Title WaitWeChatIlinkLogin
+// @Tag Provider API
+// @Description wait once for WeChat iLink Bot QR login result
+// @Param   id          query    string  true  "The id of the provider (owner/name)"
+// @Param   sessionKey  query    string  true  "The QR login session key"
+// @Success 200 {object} controllers.Response The Response object
+// @router /wait-wechat-ilink-login [post]
+func (c *ApiController) WaitWeChatIlinkLogin() {
+	if !c.RequireAdmin() {
+		return
+	}
+
+	id := c.Input().Get("id")
+	sessionKey := c.Input().Get("sessionKey")
+
+	result, err := object.WaitWeChatIlinkLogin(id, sessionKey)
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+
+	c.ResponseOk(result)
+}
+
 // TestToolProvider
 // @Title TestToolProvider
 // @Tag Provider API

--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ func main() {
 	object.InitCommitRecordsTask()
 	object.InitScanJobProcessor()
 	object.InitMessageTransactionRetry()
+	object.InitWeChatIlinkPollers()
 
 	beego.SetStaticPath("/swagger", "swagger")
 	beego.InsertFilter("*", beego.BeforeRouter, routers.CorsFilter)

--- a/object/provider.go
+++ b/object/provider.go
@@ -252,6 +252,7 @@ func UpdateProvider(id string, provider *Provider) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	oldId := util.GetIdFromOwnerAndName(owner, name)
 	providerDb, err := getProvider(owner, name)
 	if err != nil {
 		return false, err
@@ -268,6 +269,11 @@ func UpdateProvider(id string, provider *Provider) (bool, error) {
 			return false, err
 		}
 
+		SyncWeChatIlinkProviderById(oldId)
+		if provider.GetId() != oldId {
+			SyncWeChatIlinkProviderById(provider.GetId())
+		}
+
 		// return affected != 0
 		return true, nil
 	}
@@ -275,6 +281,11 @@ func UpdateProvider(id string, provider *Provider) (bool, error) {
 	_, err = adapter.engine.ID(core.PK{owner, name}).AllCols().Update(provider)
 	if err != nil {
 		return false, err
+	}
+
+	SyncWeChatIlinkProviderById(oldId)
+	if provider.GetId() != oldId {
+		SyncWeChatIlinkProviderById(provider.GetId())
 	}
 
 	// return affected != 0
@@ -292,6 +303,7 @@ func AddProvider(provider *Provider) (bool, error) {
 			return false, err
 		}
 
+		SyncWeChatIlinkProviderById(provider.GetId())
 		return affected != 0, nil
 	}
 
@@ -300,10 +312,13 @@ func AddProvider(provider *Provider) (bool, error) {
 		return false, err
 	}
 
+	SyncWeChatIlinkProviderById(provider.GetId())
 	return affected != 0, nil
 }
 
 func DeleteProvider(provider *Provider) (bool, error) {
+	StopWeChatIlinkProviderById(provider.GetId())
+
 	if providerAdapter != nil && provider.IsRemote {
 		affected, err := providerAdapter.engine.ID(core.PK{provider.Owner, provider.Name}).Delete(&Provider{})
 		if err != nil {
@@ -418,7 +433,7 @@ func (p *Provider) GetSpeechToTextProvider(lang string) (stt.SpeechToTextProvide
 }
 
 func (p *Provider) GetChatProvider(lang string) (chat.ChatProvider, error) {
-	pProvider, err := chat.GetChatProvider(p.Type, p.ClientSecret, lang)
+	pProvider, err := chat.GetChatProvider(p.Type, p.ClientSecret, p.ProviderUrl, lang)
 	if err != nil {
 		return nil, err
 	}
@@ -788,7 +803,8 @@ func (p *Provider) restoreMaskedToolProviderSecrets(loadProvider func(owner stri
 	maskedClientSecret := p.ClientSecret == "***"
 	maskedUserKey := p.UserKey == "***"
 	maskedSignKey := p.SignKey == "***"
-	if !maskedClientSecret && !maskedUserKey && !maskedSignKey {
+	maskedConfigText := p.ConfigText == "***"
+	if !maskedClientSecret && !maskedUserKey && !maskedSignKey && !maskedConfigText {
 		return nil
 	}
 	if strings.TrimSpace(p.Owner) == "" || strings.TrimSpace(p.Name) == "" {
@@ -814,6 +830,9 @@ func (p *Provider) restoreMaskedToolProviderSecrets(loadProvider func(owner stri
 	if maskedSignKey && (p.SignKey == "" || p.SignKey == "***") {
 		return fmt.Errorf("masked signKey could not be restored")
 	}
+	if maskedConfigText && (p.ConfigText == "" || p.ConfigText == "***") {
+		return fmt.Errorf("masked configText could not be restored")
+	}
 
 	return nil
 }
@@ -827,6 +846,9 @@ func (p *Provider) processProviderParams(providerDb *Provider) {
 	}
 	if p.SignKey == "***" {
 		p.SignKey = providerDb.SignKey
+	}
+	if p.ConfigText == "***" {
+		p.ConfigText = providerDb.ConfigText
 	}
 	if p.ProviderKey == "" && p.Category == "Model" {
 		p.ProviderKey = generateProviderKey()

--- a/object/wechat_ilink.go
+++ b/object/wechat_ilink.go
@@ -1,0 +1,473 @@
+// Copyright 2026 The Casibase Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package object
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/beego/beego/logs"
+	"github.com/the-open-agent/openagent/chat"
+	"github.com/the-open-agent/openagent/util"
+	"xorm.io/core"
+)
+
+const (
+	weChatIlinkLoginSessionTtl = 5 * time.Minute
+	weChatIlinkRetryDelay      = 2 * time.Second
+	weChatIlinkErrorDelay      = 30 * time.Second
+	weChatIlinkDefaultTimeout  = 35_000
+)
+
+type WeChatIlinkRuntime struct {
+	GetUpdatesBuf        string `json:"get_updates_buf"`
+	LongPollingTimeoutMs int    `json:"longpolling_timeout_ms"`
+}
+
+type WeChatIlinkLoginStartResult struct {
+	SessionKey string `json:"sessionKey"`
+	QrcodeUrl  string `json:"qrcodeUrl"`
+}
+
+type WeChatIlinkLoginWaitResult struct {
+	Connected bool   `json:"connected"`
+	Message   string `json:"message"`
+}
+
+type weChatIlinkLoginSession struct {
+	ProviderId     string
+	Qrcode         string
+	CurrentBaseUrl string
+	StartedAt      time.Time
+}
+
+type weChatIlinkPoller struct {
+	providerId string
+	stopCh     chan struct{}
+	doneCh     chan struct{}
+	mutex      sync.Mutex
+	cancel     context.CancelFunc
+}
+
+type WeChatIlinkPollerManager struct {
+	mutex   sync.Mutex
+	pollers map[string]*weChatIlinkPoller
+	lang    string
+}
+
+var (
+	weChatIlinkLoginMutex    sync.Mutex
+	weChatIlinkLoginSessions = map[string]*weChatIlinkLoginSession{}
+
+	defaultWeChatIlinkPollerManager = &WeChatIlinkPollerManager{
+		pollers: map[string]*weChatIlinkPoller{},
+		lang:    "en",
+	}
+
+	weChatIlinkAnswerFunc = func(modelProvider string, question string, lang string) (string, error) {
+		answer, _, err := GetAnswer(modelProvider, question, lang)
+		return answer, err
+	}
+)
+
+func IsWeChatIlinkProvider(provider *Provider) bool {
+	return provider != nil &&
+		provider.Category == "Chat" &&
+		provider.Type == chat.WeChatTypeIlinkBot
+}
+
+func InitWeChatIlinkPollers() {
+	if err := defaultWeChatIlinkPollerManager.StartActiveProviders(); err != nil {
+		logs.Error("InitWeChatIlinkPollers() error: %s", err.Error())
+	}
+}
+
+func SyncWeChatIlinkProviderById(id string) {
+	if err := defaultWeChatIlinkPollerManager.SyncProviderById(id); err != nil {
+		logs.Error("SyncWeChatIlinkProviderById(%s) error: %s", id, err.Error())
+	}
+}
+
+func StopWeChatIlinkProviderById(id string) {
+	defaultWeChatIlinkPollerManager.Stop(id)
+}
+
+func StartWeChatIlinkLogin(id string) (*WeChatIlinkLoginStartResult, error) {
+	provider, err := GetProvider(id)
+	if err != nil {
+		return nil, err
+	}
+	if !IsWeChatIlinkProvider(provider) {
+		return nil, fmt.Errorf("provider is not a WeChat iLink Bot Chat provider")
+	}
+
+	client := chat.NewWeChatIlinkClient(chat.WeChatIlinkDefaultBaseUrl, "", nil)
+	qrcode, err := client.StartQRCodeLogin()
+	if err != nil {
+		return nil, err
+	}
+
+	sessionKey := util.GenerateId()
+	now := time.Now()
+	weChatIlinkLoginMutex.Lock()
+	defer weChatIlinkLoginMutex.Unlock()
+	cleanupExpiredWeChatIlinkLoginSessionsLocked(now)
+	deleteWeChatIlinkLoginSessionsByProviderLocked(id)
+	weChatIlinkLoginSessions[sessionKey] = &weChatIlinkLoginSession{
+		ProviderId:     id,
+		Qrcode:         qrcode.Qrcode,
+		CurrentBaseUrl: chat.WeChatIlinkDefaultBaseUrl,
+		StartedAt:      now,
+	}
+
+	return &WeChatIlinkLoginStartResult{
+		SessionKey: sessionKey,
+		QrcodeUrl:  qrcode.QrcodeImageContent,
+	}, nil
+}
+
+func WaitWeChatIlinkLogin(id string, sessionKey string) (*WeChatIlinkLoginWaitResult, error) {
+	provider, err := GetProvider(id)
+	if err != nil {
+		return nil, err
+	}
+	if !IsWeChatIlinkProvider(provider) {
+		return nil, fmt.Errorf("provider is not a WeChat iLink Bot Chat provider")
+	}
+
+	session, err := getWeChatIlinkLoginSession(id, sessionKey)
+	if err != nil {
+		return nil, err
+	}
+
+	client := chat.NewWeChatIlinkClient(session.CurrentBaseUrl, "", nil)
+	status, err := client.PollQRCodeStatus(session.Qrcode)
+	if err != nil {
+		return nil, err
+	}
+
+	if status.Status == "scaned_but_redirect" {
+		if status.RedirectHost != "" {
+			setWeChatIlinkLoginSessionBaseUrl(sessionKey, fmt.Sprintf("https://%s", status.RedirectHost))
+		}
+		return &WeChatIlinkLoginWaitResult{Connected: false, Message: "scaned_but_redirect"}, nil
+	}
+	if status.Status != "confirmed" {
+		return &WeChatIlinkLoginWaitResult{Connected: false, Message: status.Status}, nil
+	}
+	if status.BotToken == "" || status.IlinkBotId == "" {
+		return nil, fmt.Errorf("WeChat iLink login confirmed but token or bot id is missing")
+	}
+
+	baseUrl := strings.TrimSpace(status.BaseUrl)
+	if baseUrl == "" {
+		baseUrl = session.CurrentBaseUrl
+	}
+
+	provider.ClientId = status.IlinkBotId
+	provider.ClientSecret = status.BotToken
+	provider.ProviderUrl = baseUrl
+	provider.UserKey = status.IlinkUserId
+	provider.ConfigText = ""
+	provider.ErrorText = ""
+
+	if _, err = UpdateProvider(id, provider); err != nil {
+		return nil, err
+	}
+
+	deleteWeChatIlinkLoginSession(sessionKey)
+	return &WeChatIlinkLoginWaitResult{
+		Connected: true,
+		Message:   "connected",
+	}, nil
+}
+
+func getWeChatIlinkLoginSession(id string, sessionKey string) (*weChatIlinkLoginSession, error) {
+	weChatIlinkLoginMutex.Lock()
+	defer weChatIlinkLoginMutex.Unlock()
+
+	session := weChatIlinkLoginSessions[sessionKey]
+	if session == nil || session.ProviderId != id {
+		return nil, fmt.Errorf("WeChat iLink login session not found")
+	}
+	if time.Since(session.StartedAt) > weChatIlinkLoginSessionTtl {
+		delete(weChatIlinkLoginSessions, sessionKey)
+		return nil, fmt.Errorf("WeChat iLink login session expired")
+	}
+	return session, nil
+}
+
+func setWeChatIlinkLoginSessionBaseUrl(sessionKey string, baseUrl string) {
+	weChatIlinkLoginMutex.Lock()
+	defer weChatIlinkLoginMutex.Unlock()
+
+	session := weChatIlinkLoginSessions[sessionKey]
+	if session != nil && strings.TrimSpace(baseUrl) != "" {
+		session.CurrentBaseUrl = strings.TrimRight(strings.TrimSpace(baseUrl), "/")
+	}
+}
+
+func deleteWeChatIlinkLoginSession(sessionKey string) {
+	weChatIlinkLoginMutex.Lock()
+	defer weChatIlinkLoginMutex.Unlock()
+	delete(weChatIlinkLoginSessions, sessionKey)
+}
+
+func cleanupExpiredWeChatIlinkLoginSessionsLocked(now time.Time) {
+	for sessionKey, session := range weChatIlinkLoginSessions {
+		if session == nil || now.Sub(session.StartedAt) > weChatIlinkLoginSessionTtl {
+			delete(weChatIlinkLoginSessions, sessionKey)
+		}
+	}
+}
+
+func deleteWeChatIlinkLoginSessionsByProviderLocked(providerId string) {
+	for sessionKey, session := range weChatIlinkLoginSessions {
+		if session != nil && session.ProviderId == providerId {
+			delete(weChatIlinkLoginSessions, sessionKey)
+		}
+	}
+}
+
+func (m *WeChatIlinkPollerManager) StartActiveProviders() error {
+	providers, err := GetProviders("admin")
+	if err != nil {
+		return err
+	}
+
+	for _, provider := range providers {
+		if IsWeChatIlinkProvider(provider) && provider.State == "Active" {
+			m.Start(provider.GetId())
+		}
+	}
+	return nil
+}
+
+func (m *WeChatIlinkPollerManager) SyncProviderById(id string) error {
+	provider, err := GetProvider(id)
+	if err != nil {
+		return err
+	}
+	if !IsWeChatIlinkProvider(provider) || provider.State != "Active" {
+		m.Stop(id)
+		return nil
+	}
+
+	m.Start(id)
+	return nil
+}
+
+func (m *WeChatIlinkPollerManager) Start(id string) {
+	m.Stop(id)
+
+	poller := &weChatIlinkPoller{
+		providerId: id,
+		stopCh:     make(chan struct{}),
+		doneCh:     make(chan struct{}),
+	}
+
+	m.mutex.Lock()
+	m.pollers[id] = poller
+	m.mutex.Unlock()
+
+	go poller.run(m.lang)
+}
+
+func (m *WeChatIlinkPollerManager) Stop(id string) {
+	m.mutex.Lock()
+	poller := m.pollers[id]
+	if poller != nil {
+		delete(m.pollers, id)
+		close(poller.stopCh)
+		poller.cancelRequest()
+	}
+	m.mutex.Unlock()
+
+	if poller != nil {
+		<-poller.doneCh
+	}
+}
+
+func (m *WeChatIlinkPollerManager) IsRunning(id string) bool {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	return m.pollers[id] != nil
+}
+
+func (p *weChatIlinkPoller) run(lang string) {
+	defer close(p.doneCh)
+
+	for {
+		select {
+		case <-p.stopCh:
+			return
+		default:
+		}
+
+		if !p.runOnce(lang) {
+			return
+		}
+	}
+}
+
+func (p *weChatIlinkPoller) runOnce(lang string) bool {
+	provider, err := GetProvider(p.providerId)
+	if err != nil {
+		p.sleepOrStop(weChatIlinkErrorDelay)
+		return true
+	}
+	if !IsWeChatIlinkProvider(provider) || provider.State != "Active" {
+		return false
+	}
+	if strings.TrimSpace(provider.ClientSecret) == "" || strings.TrimSpace(provider.ProviderUrl) == "" {
+		_ = updateWeChatIlinkProviderRuntime(provider, nil, "WeChat iLink Bot is not logged in")
+		p.sleepOrStop(weChatIlinkErrorDelay)
+		return true
+	}
+
+	runtimeConfig, err := parseWeChatIlinkRuntime(provider.ConfigText)
+	if err != nil {
+		_ = updateWeChatIlinkProviderRuntime(provider, nil, err.Error())
+		p.sleepOrStop(weChatIlinkErrorDelay)
+		return true
+	}
+	timeoutMs := runtimeConfig.LongPollingTimeoutMs
+	if timeoutMs <= 0 {
+		timeoutMs = weChatIlinkDefaultTimeout
+	}
+
+	client := chat.NewWeChatIlinkClient(provider.ProviderUrl, provider.ClientSecret, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	p.setCancel(cancel)
+	select {
+	case <-p.stopCh:
+		p.clearCancel()
+		cancel()
+		return false
+	default:
+	}
+	updates, err := client.GetUpdatesWithContext(ctx, runtimeConfig.GetUpdatesBuf, timeoutMs)
+	p.clearCancel()
+	cancel()
+	if err != nil {
+		select {
+		case <-p.stopCh:
+			return false
+		default:
+		}
+		_ = updateWeChatIlinkProviderRuntime(provider, nil, err.Error())
+		p.sleepOrStop(weChatIlinkRetryDelay)
+		return true
+	}
+	if updates.Ret != 0 || updates.ErrCode != 0 {
+		_ = updateWeChatIlinkProviderRuntime(provider, nil, fmt.Sprintf("WeChat iLink getupdates error: ret=%d errcode=%d errmsg=%s", updates.Ret, updates.ErrCode, updates.ErrMsg))
+		p.sleepOrStop(weChatIlinkErrorDelay)
+		return true
+	}
+
+	if updates.GetUpdatesBuf != "" {
+		runtimeConfig.GetUpdatesBuf = updates.GetUpdatesBuf
+	}
+	if updates.LongPollingTimeoutMs > 0 {
+		runtimeConfig.LongPollingTimeoutMs = updates.LongPollingTimeoutMs
+	}
+	_ = updateWeChatIlinkProviderRuntime(provider, runtimeConfig, "")
+
+	for _, message := range updates.Messages {
+		text, ok := message.Text()
+		if !ok {
+			continue
+		}
+		answer, err := weChatIlinkAnswerFunc(provider.ModelProvider, text, lang)
+		if err != nil {
+			answer = fmt.Sprintf("Error: %v", err)
+		}
+		if err = client.SendTextMessage(message.FromUserId, message.ContextToken, answer); err != nil {
+			_ = updateWeChatIlinkProviderRuntime(provider, nil, err.Error())
+		}
+	}
+
+	return true
+}
+
+func (p *weChatIlinkPoller) sleepOrStop(duration time.Duration) bool {
+	select {
+	case <-time.After(duration):
+		return true
+	case <-p.stopCh:
+		return false
+	}
+}
+
+func (p *weChatIlinkPoller) setCancel(cancel context.CancelFunc) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	p.cancel = cancel
+}
+
+func (p *weChatIlinkPoller) clearCancel() {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	p.cancel = nil
+}
+
+func (p *weChatIlinkPoller) cancelRequest() {
+	p.mutex.Lock()
+	cancel := p.cancel
+	p.cancel = nil
+	p.mutex.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+}
+
+func parseWeChatIlinkRuntime(configText string) (*WeChatIlinkRuntime, error) {
+	if strings.TrimSpace(configText) == "" {
+		return &WeChatIlinkRuntime{}, nil
+	}
+
+	var runtimeConfig WeChatIlinkRuntime
+	if err := json.Unmarshal([]byte(configText), &runtimeConfig); err != nil {
+		return nil, fmt.Errorf("invalid WeChat iLink runtime config: %w", err)
+	}
+	return &runtimeConfig, nil
+}
+
+func updateWeChatIlinkProviderRuntime(provider *Provider, runtimeConfig *WeChatIlinkRuntime, errorText string) error {
+	update := &Provider{
+		ErrorText: errorText,
+	}
+	cols := []string{"error_text"}
+	if runtimeConfig != nil {
+		data, err := json.Marshal(runtimeConfig)
+		if err != nil {
+			return err
+		}
+		update.ConfigText = string(data)
+		cols = append(cols, "config_text")
+	}
+
+	engine := adapter.engine
+	if providerAdapter != nil && provider.IsRemote {
+		engine = providerAdapter.engine
+	}
+	_, err := engine.ID(core.PK{provider.Owner, provider.Name}).Cols(cols...).Update(update)
+	return err
+}

--- a/routers/authz_filter.go
+++ b/routers/authz_filter.go
@@ -63,7 +63,8 @@ func permissionFilter(ctx *context.Context) {
 
 	disablePreviewMode, _ := beego.AppConfig.Bool("disablePreviewMode")
 
-	isUpdateRequest := strings.HasPrefix(controllerName, "update-") || strings.HasPrefix(controllerName, "add-") || strings.HasPrefix(controllerName, "delete-") || strings.HasPrefix(controllerName, "refresh-") || strings.HasPrefix(controllerName, "deploy-")
+	isUpdateRequest := strings.HasPrefix(controllerName, "update-") || strings.HasPrefix(controllerName, "add-") || strings.HasPrefix(controllerName, "delete-") || strings.HasPrefix(controllerName, "refresh-") || strings.HasPrefix(controllerName, "deploy-") ||
+		controllerName == "start-wechat-ilink-login" || controllerName == "wait-wechat-ilink-login"
 	isGetRequest := strings.HasPrefix(controllerName, "get-")
 
 	if !disablePreviewMode && isGetRequest {

--- a/routers/router.go
+++ b/routers/router.go
@@ -72,6 +72,8 @@ func initAPI() {
 	beego.Router("/api/add-provider", &controllers.ApiController{}, "POST:AddProvider")
 	beego.Router("/api/delete-provider", &controllers.ApiController{}, "POST:DeleteProvider")
 	beego.Router("/api/refresh-mcp-tools", &controllers.ApiController{}, "POST:RefreshMcpTools")
+	beego.Router("/api/start-wechat-ilink-login", &controllers.ApiController{}, "POST:StartWeChatIlinkLogin")
+	beego.Router("/api/wait-wechat-ilink-login", &controllers.ApiController{}, "POST:WaitWeChatIlinkLogin")
 	beego.Router("/api/test-tool-provider", &controllers.ApiController{}, "POST:TestToolProvider")
 	beego.Router("/api/test-mcp-provider", &controllers.ApiController{}, "POST:TestMcpProvider")
 	beego.Router("/api/set-telegram-webhook", &controllers.ApiController{}, "POST:SetTelegramWebhook")

--- a/web/src/ProviderEditPage.js
+++ b/web/src/ProviderEditPage.js
@@ -14,7 +14,7 @@
 
 import React from "react";
 import Loading from "./common/Loading";
-import {AutoComplete, Button, Card, Col, Input, InputNumber, Row, Select, Slider, Switch} from "antd";
+import {AutoComplete, Button, Card, Col, Input, InputNumber, QRCode, Row, Select, Slider, Switch} from "antd";
 import {LinkOutlined} from "@ant-design/icons";
 import * as ProviderBackend from "./backend/ProviderBackend";
 import * as Setting from "./Setting";
@@ -43,12 +43,22 @@ class ProviderEditPage extends React.Component {
       originalProvider: null,
       modelProviders: [],
       refreshButtonLoading: false,
+      weChatIlinkLoginLoading: false,
+      weChatIlinkSessionKey: "",
+      weChatIlinkQrcodeUrl: "",
       isNewProvider: props.location?.state?.isNewProvider || false,
     };
+    this.weChatIlinkLoginTimer = null;
+    this.unmounted = false;
   }
 
   UNSAFE_componentWillMount() {
     this.getProvider();
+  }
+
+  componentWillUnmount() {
+    this.unmounted = true;
+    this.clearWeChatIlinkLoginTimer();
   }
 
   getModelProviders() {
@@ -201,6 +211,9 @@ class ProviderEditPage extends React.Component {
     if (provider.category === "Tool") {
       return false;
     }
+    if (provider.category === "Chat" && provider.type === "WeChat iLink Bot") {
+      return false;
+    }
     return (
       ((provider.category === "Embedding" && provider.type === "Baidu Cloud") ||
         (provider.category === "Embedding" && provider.type === "Tencent Cloud") ||
@@ -221,6 +234,7 @@ class ProviderEditPage extends React.Component {
       (provider.category === "Blockchain" && provider.type === "ChainMaker") ||
       provider.category === "Scan" ||
       provider.category === "Tool" ||
+      (provider.category === "Chat" && provider.type === "WeChat iLink Bot") ||
       provider.type === "Dummy" ||
       provider.type === "Ollama"
     );
@@ -566,6 +580,8 @@ class ProviderEditPage extends React.Component {
                 if (value === "Tencent") {
                   this.updateProviderField("subType", "WeCom Bot");
                 }
+              } else if (this.state.provider.category === "Chat") {
+                this.updateProviderField("subType", "");
               }
             })}
             showSearch
@@ -659,7 +675,7 @@ class ProviderEditPage extends React.Component {
           ) : null
         }
         {
-          this.state.provider.category === "Chat" ? (
+          (this.state.provider.category === "Chat" && this.state.provider.type === "Telegram") ? (
             <Row style={{marginTop: "20px"}} >
               <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
                 {this.getClientIdLabel(this.state.provider)} :
@@ -667,6 +683,27 @@ class ProviderEditPage extends React.Component {
               <Col span={22} >
                 <Select virtual={false} disabled={isRemote} style={{width: "100%"}} value={this.state.provider.clientId}
                   onChange={(value) => this.updateProviderField("clientId", value)}
+                  onDropdownVisibleChange={(open) => {if (open) {this.getModelProviders();}}}
+                  showSearch
+                  filterOption={(input, option) =>
+                    option.children[1].toLowerCase().includes(input.toLowerCase())
+                  }
+                >
+                  {this.state.modelProviders.map((provider, index) => this.renderModelProviderOption(provider, index))}
+                </Select>
+              </Col>
+            </Row>
+          ) : null
+        }
+        {
+          (this.state.provider.category === "Chat" && this.state.provider.type === "WeChat iLink Bot") ? (
+            <Row style={{marginTop: "20px"}} >
+              <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+                {Setting.getLabel(i18next.t("provider:Model provider"), i18next.t("provider:Model provider - Tooltip"))} :
+              </Col>
+              <Col span={22} >
+                <Select virtual={false} disabled={isRemote} style={{width: "100%"}} value={this.state.provider.modelProvider}
+                  onChange={(value) => this.updateProviderField("modelProvider", value)}
                   onDropdownVisibleChange={(open) => {if (open) {this.getModelProviders();}}}
                   showSearch
                   filterOption={(input, option) =>
@@ -1247,7 +1284,7 @@ class ProviderEditPage extends React.Component {
           onUpdateProvider={this.updateProviderField.bind(this)}
         />
         {
-          this.state.provider.category === "Chat" ? (
+          (this.state.provider.category === "Chat" && this.state.provider.type === "Telegram") ? (
             <Row style={{marginTop: "20px"}} >
               <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
                 {Setting.getLabel(i18next.t("provider:Domain"), i18next.t("provider:Domain - Tooltip"))} :
@@ -1258,6 +1295,70 @@ class ProviderEditPage extends React.Component {
                 }} />
               </Col>
             </Row>
+          ) : null
+        }
+        {
+          (this.state.provider.category === "Chat" && this.state.provider.type === "WeChat iLink Bot") ? (
+            <>
+              <Row style={{marginTop: "20px"}} >
+                <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+                  {Setting.getLabel(i18next.t("provider:Account ID"), i18next.t("provider:Account ID - Tooltip"))} :
+                </Col>
+                <Col span={22} >
+                  <Input disabled value={this.state.provider.clientId} />
+                </Col>
+              </Row>
+              <Row style={{marginTop: "20px"}} >
+                <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+                  {Setting.getLabel(i18next.t("general:Provider URL"), i18next.t("general:Provider URL - Tooltip"))} :
+                </Col>
+                <Col span={22} >
+                  <Input disabled value={this.state.provider.providerUrl} />
+                </Col>
+              </Row>
+              <Row style={{marginTop: "20px"}} >
+                <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+                  {Setting.getLabel(i18next.t("provider:WeChat user ID"), i18next.t("provider:WeChat user ID - Tooltip"))} :
+                </Col>
+                <Col span={22} >
+                  <Input disabled value={this.state.provider.userKey} />
+                </Col>
+              </Row>
+              <Row style={{marginTop: "20px"}} >
+                <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+                  {Setting.getLabel(i18next.t("general:Error"), i18next.t("scan:Error - Tooltip"))} :
+                </Col>
+                <Col span={22} >
+                  <Input.TextArea value={this.state.provider.errorText} disabled rows={2} />
+                </Col>
+              </Row>
+              <Row style={{marginTop: "20px"}} >
+                <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+                  {Setting.getLabel(i18next.t("provider:QR login"), i18next.t("provider:QR login - Tooltip"))} :
+                </Col>
+                <Col span={22} >
+                  <Button disabled={isRemote} type="primary" loading={this.state.weChatIlinkLoginLoading} onClick={() => this.startWeChatIlinkLogin()}>
+                    {i18next.t("provider:Login with QR code")}
+                  </Button>
+                  {
+                    this.state.weChatIlinkQrcodeUrl !== "" ? (
+                      <div style={{marginTop: "20px"}}>
+                        <QRCode value={this.state.weChatIlinkQrcodeUrl} size={240} />
+                        <Input.Group compact style={{marginTop: "20px"}}>
+                          <Input readOnly style={{width: "calc(100% - 90px)"}} value={this.state.weChatIlinkQrcodeUrl} />
+                          <Button onClick={() => {
+                            copy(this.state.weChatIlinkQrcodeUrl);
+                            Setting.showMessage("success", i18next.t("general:Copied to clipboard successfully"));
+                          }}>
+                            {i18next.t("general:Copy")}
+                          </Button>
+                        </Input.Group>
+                      </div>
+                    ) : null
+                  }
+                </Col>
+              </Row>
+            </>
           ) : null
         }
         {
@@ -1344,7 +1445,7 @@ class ProviderEditPage extends React.Component {
           ) : null
         }
         {
-          (this.state.provider.category !== "Model" || this.modelCategoryShowsProviderUrlInput(this.state.provider.type)) ? (
+          (this.state.provider.category !== "Chat" && (this.state.provider.category !== "Model" || this.modelCategoryShowsProviderUrlInput(this.state.provider.type))) ? (
             <Row style={{marginTop: "20px"}} >
               <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
                 {this.getProviderUrlLabel(this.state.provider)} :
@@ -1420,6 +1521,91 @@ class ProviderEditPage extends React.Component {
       .catch((error) => {
         Setting.showMessage("error", `${i18next.t("general:Failed to save")}: ${error}`);
       });
+  }
+
+  startWeChatIlinkLogin() {
+    const id = `${this.state.provider.owner}/${this.state.provider.name}`;
+    this.clearWeChatIlinkLoginTimer();
+    this.setState({
+      weChatIlinkLoginLoading: true,
+      weChatIlinkQrcodeUrl: "",
+      weChatIlinkSessionKey: "",
+    });
+    ProviderBackend.startWeChatIlinkLogin(id)
+      .then((res) => {
+        if (this.unmounted) {
+          return;
+        }
+        if (res.status === "ok") {
+          this.setState({
+            weChatIlinkSessionKey: res.data.sessionKey,
+            weChatIlinkQrcodeUrl: res.data.qrcodeUrl,
+          }, () => this.waitWeChatIlinkLogin());
+        } else {
+          this.clearWeChatIlinkLoginTimer();
+          this.setState({weChatIlinkLoginLoading: false});
+          Setting.showMessage("error", `${i18next.t("general:Failed to save")}: ${res.msg}`);
+        }
+      })
+      .catch((error) => {
+        if (this.unmounted) {
+          return;
+        }
+        this.clearWeChatIlinkLoginTimer();
+        this.setState({weChatIlinkLoginLoading: false});
+        Setting.showMessage("error", `${i18next.t("general:Failed to save")}: ${error}`);
+      });
+  }
+
+  waitWeChatIlinkLogin() {
+    const id = `${this.state.provider.owner}/${this.state.provider.name}`;
+    const sessionKey = this.state.weChatIlinkSessionKey;
+    if (sessionKey === "") {
+      return;
+    }
+
+    ProviderBackend.waitWeChatIlinkLogin(id, sessionKey)
+      .then((res) => {
+        if (this.unmounted) {
+          return;
+        }
+        if (res.status !== "ok") {
+          this.clearWeChatIlinkLoginTimer();
+          this.setState({weChatIlinkLoginLoading: false});
+          Setting.showMessage("error", `${i18next.t("general:Failed to save")}: ${res.msg}`);
+          return;
+        }
+        if (res.data.connected) {
+          this.clearWeChatIlinkLoginTimer();
+          this.setState({
+            weChatIlinkLoginLoading: false,
+            weChatIlinkSessionKey: "",
+            weChatIlinkQrcodeUrl: "",
+          });
+          Setting.showMessage("success", i18next.t("provider:WeChat connected successfully"));
+          this.getProvider();
+          return;
+        }
+        this.weChatIlinkLoginTimer = setTimeout(() => {
+          this.weChatIlinkLoginTimer = null;
+          this.waitWeChatIlinkLogin();
+        }, 1000);
+      })
+      .catch((error) => {
+        if (this.unmounted) {
+          return;
+        }
+        this.clearWeChatIlinkLoginTimer();
+        this.setState({weChatIlinkLoginLoading: false});
+        Setting.showMessage("error", `${i18next.t("general:Failed to save")}: ${error}`);
+      });
+  }
+
+  clearWeChatIlinkLoginTimer() {
+    if (this.weChatIlinkLoginTimer !== null) {
+      clearTimeout(this.weChatIlinkLoginTimer);
+      this.weChatIlinkLoginTimer = null;
+    }
   }
 
   refreshMcpTools() {

--- a/web/src/Setting.js
+++ b/web/src/Setting.js
@@ -1152,6 +1152,10 @@ export function getOtherProviderInfo() {
         logo: `${StaticBaseUrl}/img/social_telegram.png`,
         url: "https://telegram.org/",
       },
+      "WeChat iLink Bot": {
+        logo: `${StaticBaseUrl}/img/social_wechat.png`,
+        url: "https://mp.weixin.qq.com/",
+      },
     },
     "Scan": {
       "Nmap": {
@@ -1451,6 +1455,7 @@ export function getProviderTypeOptions(category) {
   } else if (category === "Chat") {
     return [
       {id: "Telegram", name: "Telegram"},
+      {id: "WeChat iLink Bot", name: "WeChat iLink Bot"},
     ];
   } else if (category === "Scan") {
     return [

--- a/web/src/backend/ProviderBackend.js
+++ b/web/src/backend/ProviderBackend.js
@@ -125,3 +125,23 @@ export function setTelegramWebhook(id) {
     },
   }).then(res => res.json());
 }
+
+export function startWeChatIlinkLogin(id) {
+  return fetch(`${Setting.ServerUrl}/api/start-wechat-ilink-login?id=${encodeURIComponent(id)}`, {
+    method: "POST",
+    credentials: "include",
+    headers: {
+      "Accept-Language": Setting.getAcceptLanguage(),
+    },
+  }).then(res => res.json());
+}
+
+export function waitWeChatIlinkLogin(id, sessionKey) {
+  return fetch(`${Setting.ServerUrl}/api/wait-wechat-ilink-login?id=${encodeURIComponent(id)}&sessionKey=${encodeURIComponent(sessionKey)}`, {
+    method: "POST",
+    credentials: "include",
+    headers: {
+      "Accept-Language": Setting.getAcceptLanguage(),
+    },
+  }).then(res => res.json());
+}


### PR DESCRIPTION
## Summary

- Add WeChat iLink Bot as a Chat provider
- Support QR-code login and long-polling message handling
- Add provider edit UI fields and login controls for WeChat iLink Bot
- Start, sync, and stop WeChat iLink pollers with provider lifecycle changes
- Protect WeChat iLink login endpoints behind admin auth