### PR TITLE
fix: add properties to empty tool parameters.

### DIFF
--- a/model/mcp.go
+++ b/model/mcp.go
@@ -63,6 +63,11 @@ func reverseToolsToOpenAi(tools []*protocol.Tool) ([]openai.Tool, error) {
 		if err := json.Unmarshal(schemaBytes, &parameters); err != nil {
 			return nil, err
 		}
+		if parameters["type"] == "object" {
+			if _, ok := parameters["properties"]; !ok {
+				parameters["properties"] = map[string]interface{}{}
+			}
+		}
 		openaiTools = append(openaiTools, openai.Tool{
 			Type: "function",
 			Function: &openai.FunctionDefinition{

--- a/model/mcp.go
+++ b/model/mcp.go
@@ -63,11 +63,7 @@ func reverseToolsToOpenAi(tools []*protocol.Tool) ([]openai.Tool, error) {
 		if err := json.Unmarshal(schemaBytes, &parameters); err != nil {
 			return nil, err
 		}
-		if parameters["type"] == "object" {
-			if _, ok := parameters["properties"]; !ok {
-				parameters["properties"] = map[string]interface{}{}
-			}
-		}
+		normalizeToolParametersSchema(parameters)
 		openaiTools = append(openaiTools, openai.Tool{
 			Type: "function",
 			Function: &openai.FunctionDefinition{
@@ -78,6 +74,14 @@ func reverseToolsToOpenAi(tools []*protocol.Tool) ([]openai.Tool, error) {
 		})
 	}
 	return openaiTools, nil
+}
+
+func normalizeToolParametersSchema(parameters map[string]interface{}) {
+	if parameters["type"] == "object" {
+		if _, ok := parameters["properties"]; !ok {
+			parameters["properties"] = map[string]interface{}{}
+		}
+	}
 }
 
 func handleToolCallsParameters(toolCall openai.ToolCall, toolCalls []openai.ToolCall, toolCallsMap map[int]int) ([]openai.ToolCall, map[int]int) {

--- a/model/openai.go
+++ b/model/openai.go
@@ -765,6 +765,7 @@ func reverseMcpToolsToOpenAi(tools []*protocol.Tool) ([]responses.ToolUnionParam
 		if err := json.Unmarshal(schemaBytes, &parameters); err != nil {
 			return nil, err
 		}
+		normalizeToolParametersSchema(parameters)
 		openaiTools = append(openaiTools, responses.ToolUnionParam{
 			OfFunction: &responses.FunctionToolParam{
 				Type:        "function",


### PR DESCRIPTION
Fix OpenAI tool schema compatibility by adding an empty properties object for object-type tool parameters when missing. This prevents strict OpenAI validation from rejecting no-argument tools.