### PR TITLE
feat: add OpenAgent Chrome extension browser use mode

### DIFF
--- a/controllers/browser_use_extension.go
+++ b/controllers/browser_use_extension.go
@@ -1,0 +1,24 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import "github.com/the-open-agent/openagent/tool"
+
+// BrowserUseChromeExtension upgrades a local Chrome extension connection to
+// the in-process browser bridge used by the browser_use tool.
+func (c *ApiController) BrowserUseChromeExtension() {
+	c.EnableRender = false
+	tool.HandleBrowserUseChromeExtWebSocket(c.Ctx.ResponseWriter, c.Ctx.Request)
+}

--- a/routers/authz_filter.go
+++ b/routers/authz_filter.go
@@ -63,6 +63,8 @@ func permissionFilter(ctx *context.Context) {
 	exemptedPaths := []string{
 		// Auth endpoints — must remain public
 		"signin", "signout", "health",
+		// Local Chrome extension browser bridge
+		"chrome-connect",
 		// Get paths accessible to regular users
 		"get-account", "get-signin-options", "get-chats", "get-forms", "get-global-videos", "get-videos", "get-video", "get-messages",
 		"delete-welcome-message", "get-message-answer", "get-answer",

--- a/routers/cors_filter.go
+++ b/routers/cors_filter.go
@@ -48,6 +48,10 @@ func setCorsHeaders(ctx *context.Context, origin string) {
 }
 
 func CorsFilter(ctx *context.Context) {
+	if ctx.Request.URL.Path == "/api/chrome-connect" {
+		return
+	}
+
 	origin := ctx.Input.Header(headerOrigin)
 
 	if origin == "" || origin == "null" {

--- a/routers/router.go
+++ b/routers/router.go
@@ -45,6 +45,7 @@ func initAPI() {
 	beego.Router("/api/get-account", &controllers.ApiController{}, "GET:GetAccount")
 	beego.Router("/api/update-account", &controllers.ApiController{}, "POST:UpdateAccount")
 	beego.Router("/api/get-signin-options", &controllers.ApiController{}, "GET:GetSigninOptions")
+	beego.Router("/api/chrome-connect", &controllers.ApiController{}, "GET:BrowserUseChromeExtension")
 
 	beego.Router("/api/get-global-sites", &controllers.ApiController{}, "GET:GetGlobalSites")
 	beego.Router("/api/get-sites", &controllers.ApiController{}, "GET:GetSites")

--- a/tool/browser_use.go
+++ b/tool/browser_use.go
@@ -80,6 +80,7 @@ func (p *BrowserUseTool) BuiltinTools() []BuiltinTool {
 		&browserUsePlayMediaBuiltin{provider: p},
 		&browserUseTabsBuiltin{provider: p},
 		&browserUseSwitchTabBuiltin{provider: p},
+		&browserUseCloseTabBuiltin{provider: p},
 		&browserUseCloseBuiltin{provider: p},
 	}
 }
@@ -634,11 +635,13 @@ type browserUseElement struct {
 }
 
 type browserUseTab struct {
-	Index  int
-	ID     target.ID
-	Title  string
-	URL    string
-	Active bool
+	Index      int
+	ID         target.ID
+	Title      string
+	URL        string
+	Active     bool
+	Controlled bool
+	Protected  bool
 }
 
 func (s *browserUseSession) pageTargetsLocked() ([]*target.Info, error) {
@@ -753,6 +756,10 @@ func (s *browserUseSession) switchToNewTargetLocked(before map[target.ID]bool, p
 }
 
 func browserUseListTabs(provider *BrowserUseTool) ([]browserUseTab, error) {
+	if provider.isChromeExtMode() {
+		return browserUseChromeExtTabs(context.Background())
+	}
+
 	var tabs []browserUseTab
 	err := provider.runSession(func(session *browserUseSession) error {
 		activeTargetID := session.currentTargetIDLocked()
@@ -781,11 +788,21 @@ func browserUseFormatTabs(tabs []browserUseTab) string {
 	var builder strings.Builder
 	builder.WriteString("Browser tabs:\n")
 	for _, tab := range tabs {
-		active := ""
+		markers := []string{}
 		if tab.Active {
-			active = " active"
+			markers = append(markers, "active")
 		}
-		builder.WriteString(fmt.Sprintf("[%d]%s %s\n", tab.Index, active, strings.TrimSpace(tab.Title)))
+		if tab.Controlled {
+			markers = append(markers, "controlled")
+		}
+		if tab.Protected {
+			markers = append(markers, "protected")
+		}
+		markerText := ""
+		if len(markers) > 0 {
+			markerText = " " + strings.Join(markers, " ")
+		}
+		builder.WriteString(fmt.Sprintf("[%d]%s %s\n", tab.Index, markerText, strings.TrimSpace(tab.Title)))
 		if strings.TrimSpace(tab.URL) != "" {
 			builder.WriteString(fmt.Sprintf("    %s\n", tab.URL))
 		}
@@ -841,6 +858,10 @@ func browserUsePlayMediaScript() string {
 }
 
 func browserUseCurrentState(provider *BrowserUseTool) (string, error) {
+	if provider.isChromeExtMode() {
+		return browserUseChromeExtCurrentState(context.Background())
+	}
+
 	var title, rawURL, mediaState string
 	var activeTargetID target.ID
 	var tabs []*target.Info
@@ -1124,6 +1145,10 @@ func browserUseFormatSnapshot(rawURL, title, visibleText string, elements []brow
 }
 
 func browserUseSnapshot(provider *BrowserUseTool) (string, error) {
+	if provider.isChromeExtMode() {
+		return browserUseChromeExtSnapshot(context.Background())
+	}
+
 	var elements []browserUseElement
 	var title, rawURL, visibleText string
 	err := provider.run(
@@ -1147,7 +1172,7 @@ type browserUseOpenBuiltin struct{ provider *BrowserUseTool }
 func (b *browserUseOpenBuiltin) GetName() string { return "browser_use_open" }
 
 func (b *browserUseOpenBuiltin) GetDescription() string {
-	return "Open or reuse the managed visible browser and navigate the active tab to a URL. Use this for real browser tasks only; do not claim a page was opened unless this tool succeeds. The browser keeps tabs, cookies, and media state across related user requests. This tool returns a fresh snapshot plus current browser state; use the returned element indexes only until the next page-changing action."
+	return "Open or reuse the managed visible browser and navigate the Browser Use controlled tab to a URL. In extension mode, OpenAgent UI tabs are protected and Browser Use uses a separate controlled tab. Use this for real browser tasks only; do not claim a page was opened unless this tool succeeds. The browser keeps tabs, cookies, and media state across related user requests. This tool returns a fresh snapshot plus current browser state; use the returned element indexes only until the next page-changing action."
 }
 
 func (b *browserUseOpenBuiltin) GetInputSchema() interface{} {
@@ -1171,6 +1196,17 @@ func (b *browserUseOpenBuiltin) Execute(ctx context.Context, arguments map[strin
 	}
 	rawURL = strings.TrimSpace(rawURL)
 
+	if b.provider.isChromeExtMode() {
+		if err := browserUseChromeExtOpen(ctx, rawURL); err != nil {
+			return browserUseErrorWithState(b.provider, fmt.Sprintf("browser use open failed for %s: %s", rawURL, err.Error())), nil
+		}
+		snapshot, err := browserUseChromeExtSnapshot(ctx)
+		if err != nil {
+			return browserUseErrorWithState(b.provider, fmt.Sprintf("browser use snapshot failed after opening %s: %s", rawURL, err.Error())), nil
+		}
+		return browserUseTextWithState(b.provider, snapshot), nil
+	}
+
 	if err := b.provider.run(chromedp.Navigate(rawURL), chromedp.WaitReady("body", chromedp.ByQuery)); err != nil {
 		return browserUseErrorWithState(b.provider, fmt.Sprintf("browser use open failed for %s: %s", rawURL, err.Error())), nil
 	}
@@ -1190,7 +1226,7 @@ type browserUseSnapshotBuiltin struct{ provider *BrowserUseTool }
 func (b *browserUseSnapshotBuiltin) GetName() string { return "browser_use_snapshot" }
 
 func (b *browserUseSnapshotBuiltin) GetDescription() string {
-	return "Read the active tab in the existing managed browser and return visible text, indexed interactive elements, URL, title, active tab index, tab count, and media state. Treat this as the source of truth before acting. Use it at the start of a follow-up request and after every navigation, click, type, or key press before reusing element indexes. Do not invent page contents or completed browser actions that are not visible in this tool result."
+	return "Read the Browser Use controlled tab in the existing managed browser and return visible text, indexed interactive elements, URL, title, controlled tab index, tab count, and media state. Treat this as the source of truth before acting. Use it at the start of a follow-up request and after every navigation, click, type, or key press before reusing element indexes. Do not invent page contents or completed browser actions that are not visible in this tool result."
 }
 
 func (b *browserUseSnapshotBuiltin) GetInputSchema() interface{} {
@@ -1239,6 +1275,13 @@ func (b *browserUseClickBuiltin) GetInputSchema() interface{} {
 }
 
 func (b *browserUseClickBuiltin) Execute(ctx context.Context, arguments map[string]interface{}) (*protocol.CallToolResult, error) {
+	if b.provider.isChromeExtMode() {
+		if err := browserUseChromeExtClick(ctx, arguments); err != nil {
+			return browserUseErrorWithState(b.provider, fmt.Sprintf("browser use click failed: %s", err.Error())), nil
+		}
+		return browserUseTextWithState(b.provider, "Clicked. Call browser_use_snapshot before the next indexed action."), nil
+	}
+
 	selector, err := browserUseSelector(arguments)
 	if err != nil {
 		return browserToolError(err.Error()), nil
@@ -1321,6 +1364,13 @@ func (b *browserUseTypeBuiltin) GetInputSchema() interface{} {
 }
 
 func (b *browserUseTypeBuiltin) Execute(ctx context.Context, arguments map[string]interface{}) (*protocol.CallToolResult, error) {
+	if b.provider.isChromeExtMode() {
+		if err := browserUseChromeExtType(ctx, arguments); err != nil {
+			return browserUseErrorWithState(b.provider, fmt.Sprintf("browser use type failed: %s", err.Error())), nil
+		}
+		return browserUseTextWithState(b.provider, "Typed. Call browser_use_snapshot before the next indexed action or before claiming the page accepted the input."), nil
+	}
+
 	selector, err := browserUseSelector(arguments)
 	if err != nil {
 		return browserToolError(err.Error()), nil
@@ -1415,6 +1465,13 @@ func (b *browserUsePressBuiltin) Execute(ctx context.Context, arguments map[stri
 	}
 	key = browserUseKey(strings.TrimSpace(key))
 
+	if b.provider.isChromeExtMode() {
+		if err := browserUseChromeExtPress(ctx, key); err != nil {
+			return browserUseErrorWithState(b.provider, fmt.Sprintf("browser use press failed for %s: %s", key, err.Error())), nil
+		}
+		return browserUseTextWithState(b.provider, "Key pressed. Call browser_use_snapshot before the next indexed action."), nil
+	}
+
 	switchedTab := false
 	err := b.provider.runSession(func(session *browserUseSession) error {
 		var previousURL string
@@ -1493,7 +1550,7 @@ type browserUsePlayMediaBuiltin struct{ provider *BrowserUseTool }
 func (b *browserUsePlayMediaBuiltin) GetName() string { return "browser_use_play_media" }
 
 func (b *browserUsePlayMediaBuiltin) GetDescription() string {
-	return "Play and unmute visible audio or video elements on the current browser tab. Use this after opening a page with music or video if playback is paused, muted, or silent. The result includes media playback state; do not tell the user audio is playing unless the returned state says a media element is playing."
+	return "Play and unmute visible audio or video elements on the Browser Use controlled tab. Use this after opening a page with music or video if playback is paused, muted, or silent. The result includes media playback state; do not tell the user audio is playing unless the returned state says a media element is playing."
 }
 
 func (b *browserUsePlayMediaBuiltin) GetInputSchema() interface{} {
@@ -1505,6 +1562,14 @@ func (b *browserUsePlayMediaBuiltin) GetInputSchema() interface{} {
 }
 
 func (b *browserUsePlayMediaBuiltin) Execute(ctx context.Context, arguments map[string]interface{}) (*protocol.CallToolResult, error) {
+	if b.provider.isChromeExtMode() {
+		result, err := browserUseChromeExtPlayMedia(ctx)
+		if err != nil {
+			return browserUseErrorWithState(b.provider, fmt.Sprintf("browser use play media failed: %s", err.Error())), nil
+		}
+		return browserUseTextWithState(b.provider, result), nil
+	}
+
 	var result string
 	err := b.provider.run(chromedp.Evaluate(browserUsePlayMediaScript(), &result))
 	if err != nil {
@@ -1522,7 +1587,7 @@ type browserUseTabsBuiltin struct{ provider *BrowserUseTool }
 func (b *browserUseTabsBuiltin) GetName() string { return "browser_use_tabs" }
 
 func (b *browserUseTabsBuiltin) GetDescription() string {
-	return "List open browser tabs in the managed Browser Use window, including the active tab marker, titles, and URLs. Use this when a click opens a new tab, when the current page does not match what the user sees, or before switching tabs."
+	return "List open browser tabs available to Browser Use, including active, controlled, and protected tab markers, titles, and URLs. Use this when a click opens a new tab, when the current page does not match what the user sees, or before switching tabs."
 }
 
 func (b *browserUseTabsBuiltin) GetInputSchema() interface{} {
@@ -1550,7 +1615,7 @@ type browserUseSwitchTabBuiltin struct{ provider *BrowserUseTool }
 func (b *browserUseSwitchTabBuiltin) GetName() string { return "browser_use_switch_tab" }
 
 func (b *browserUseSwitchTabBuiltin) GetDescription() string {
-	return "Switch Browser Use to a tab returned by browser_use_tabs. The switch changes the active tab used by all Browser Use tools. This tool returns a fresh snapshot and browser state for the selected tab."
+	return "Switch Browser Use to a tab returned by browser_use_tabs. The switch sets the selected tab as the controlled tab used by Browser Use tools; protected OpenAgent UI tabs cannot be controlled. This tool returns a fresh snapshot and browser state for the selected tab."
 }
 
 func (b *browserUseSwitchTabBuiltin) GetInputSchema() interface{} {
@@ -1577,6 +1642,17 @@ func (b *browserUseSwitchTabBuiltin) Execute(ctx context.Context, arguments map[
 		return browserToolError(err.Error()), nil
 	}
 
+	if b.provider.isChromeExtMode() {
+		if err = browserUseChromeExtSwitchTab(ctx, index); err != nil {
+			return browserUseErrorWithState(b.provider, fmt.Sprintf("browser use switch tab failed: %s", err.Error())), nil
+		}
+		snapshot, err := browserUseChromeExtSnapshot(ctx)
+		if err != nil {
+			return browserUseErrorWithState(b.provider, fmt.Sprintf("browser use snapshot failed after switching tabs: %s", err.Error())), nil
+		}
+		return browserUseTextWithState(b.provider, snapshot), nil
+	}
+
 	err = b.provider.runSession(func(session *browserUseSession) error {
 		tabs, err := session.pageTargetsLocked()
 		if err != nil {
@@ -1596,6 +1672,89 @@ func (b *browserUseSwitchTabBuiltin) Execute(ctx context.Context, arguments map[
 		return browserUseErrorWithState(b.provider, fmt.Sprintf("browser use snapshot failed after switching tabs: %s", err.Error())), nil
 	}
 	return browserUseTextWithState(b.provider, snapshot), nil
+}
+
+// ---------------------------------------------------------------------------
+// browser_use_close_tab
+// ---------------------------------------------------------------------------
+
+type browserUseCloseTabBuiltin struct{ provider *BrowserUseTool }
+
+func (b *browserUseCloseTabBuiltin) GetName() string { return "browser_use_close_tab" }
+
+func (b *browserUseCloseTabBuiltin) GetDescription() string {
+	return "Close a browser tab returned by browser_use_tabs without closing the whole Browser Use session. Use browser_use_tabs first, then pass the tab index to close."
+}
+
+func (b *browserUseCloseTabBuiltin) GetInputSchema() interface{} {
+	return map[string]interface{}{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties": map[string]interface{}{
+			"index": map[string]interface{}{
+				"type":        "integer",
+				"description": "Tab index returned by browser_use_tabs.",
+			},
+		},
+		"required": []string{"index"},
+	}
+}
+
+func (b *browserUseCloseTabBuiltin) Execute(ctx context.Context, arguments map[string]interface{}) (*protocol.CallToolResult, error) {
+	rawIndex, ok := arguments["index"]
+	if !ok {
+		return browserToolError("missing required parameter: index"), nil
+	}
+	index, err := browserUsePositiveInt(rawIndex, "index")
+	if err != nil {
+		return browserToolError(err.Error()), nil
+	}
+
+	if b.provider.isChromeExtMode() {
+		if err = browserUseChromeExtCloseTab(ctx, index); err != nil {
+			return browserUseErrorWithState(b.provider, fmt.Sprintf("browser use close tab failed: %s", err.Error())), nil
+		}
+		return browserUseTextWithState(b.provider, fmt.Sprintf("Closed tab %d.", index)), nil
+	}
+
+	err = b.provider.runSession(func(session *browserUseSession) error {
+		tabs, err := session.pageTargetsLocked()
+		if err != nil {
+			return err
+		}
+		if index > len(tabs) {
+			return fmt.Errorf("tab index %d is out of range; there are %d tabs", index, len(tabs))
+		}
+
+		targetID := tabs[index-1].TargetID
+		active := targetID == session.currentTargetIDLocked()
+		chromeContext := chromedp.FromContext(session.browserCtx)
+		if chromeContext == nil || chromeContext.Browser == nil {
+			return fmt.Errorf("browser context is not ready")
+		}
+		timeoutCtx, cancel := context.WithTimeout(session.browserCtx, browserUseDefaultTimeout)
+		defer cancel()
+		if err = target.CloseTarget(targetID).Do(cdp.WithExecutor(timeoutCtx, chromeContext.Browser)); err != nil {
+			return err
+		}
+		if active {
+			time.Sleep(300 * time.Millisecond)
+			tabs, err = session.pageTargetsLocked()
+			if err != nil {
+				return err
+			}
+			if len(tabs) > 0 {
+				return session.switchToTargetLocked(tabs[0].TargetID)
+			}
+			session.activeTargetID = ""
+			session.ctx = session.browserCtx
+		}
+		return nil
+	})
+	if err != nil {
+		return browserUseErrorWithState(b.provider, fmt.Sprintf("browser use close tab failed: %s", err.Error())), nil
+	}
+	return browserUseTextWithState(b.provider, fmt.Sprintf("Closed tab %d.", index)), nil
 }
 
 // ---------------------------------------------------------------------------
@@ -1619,6 +1778,11 @@ func (b *browserUseCloseBuiltin) GetInputSchema() interface{} {
 }
 
 func (b *browserUseCloseBuiltin) Execute(ctx context.Context, arguments map[string]interface{}) (*protocol.CallToolResult, error) {
+	if b.provider.isChromeExtMode() {
+		_ = globalBrowserUseChromeExtBridge.requestDisconnect(ctx)
+		globalBrowserUseChromeExtBridge.disconnect()
+		return browserToolText("OpenAgent Chrome extension bridge disconnected. Chrome tabs were left open."), nil
+	}
 	b.provider.close()
 	return browserToolText("Browser Use session closed."), nil
 }

--- a/tool/browser_use_chrome_ext.go
+++ b/tool/browser_use_chrome_ext.go
@@ -1,0 +1,539 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tool
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/chromedp/cdproto/target"
+	"github.com/gorilla/websocket"
+)
+
+const (
+	browserUseModeChromeExt       = "OpenAgent Chrome Extension"
+	browserUseChromeExtBridgePath = "/api/chrome-connect"
+	browserUseChromeExtTimeout    = 45 * time.Second
+)
+
+type browserUseChromeExtBridge struct {
+	mu         sync.Mutex
+	writeMu    sync.Mutex
+	conn       *websocket.Conn
+	name       string
+	version    string
+	pending    map[string]chan browserUseChromeExtResponse
+	requestSeq uint64
+}
+
+type browserUseChromeExtMessage struct {
+	Type    string          `json:"type"`
+	ID      string          `json:"id,omitempty"`
+	Command string          `json:"command,omitempty"`
+	Name    string          `json:"name,omitempty"`
+	Version string          `json:"version,omitempty"`
+	Payload json.RawMessage `json:"payload,omitempty"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	OK      *bool           `json:"ok,omitempty"`
+	Error   string          `json:"error,omitempty"`
+}
+
+type browserUseChromeExtCallMessage struct {
+	Type    string      `json:"type"`
+	ID      string      `json:"id"`
+	Command string      `json:"command"`
+	Payload interface{} `json:"payload,omitempty"`
+}
+
+type browserUseChromeExtResponse struct {
+	result json.RawMessage
+	err    error
+}
+
+type browserUseChromeExtTab struct {
+	ID         int    `json:"id"`
+	WindowID   int    `json:"windowId"`
+	Index      int    `json:"index"`
+	Title      string `json:"title"`
+	URL        string `json:"url"`
+	Active     bool   `json:"active"`
+	Controlled bool   `json:"controlled"`
+	Protected  bool   `json:"protected"`
+}
+
+type browserUseChromeExtTabsResult struct {
+	Tabs []browserUseChromeExtTab `json:"tabs"`
+}
+
+type browserUseChromeExtSnapshotResult struct {
+	Tab         browserUseChromeExtTab `json:"tab"`
+	URL         string                 `json:"url"`
+	Title       string                 `json:"title"`
+	VisibleText string                 `json:"visibleText"`
+	MediaState  string                 `json:"mediaState"`
+	Elements    []browserUseElement    `json:"elements"`
+}
+
+type browserUseChromeExtState struct {
+	Mode            string                 `json:"mode"`
+	Connected       bool                   `json:"connected"`
+	Name            string                 `json:"name"`
+	Version         string                 `json:"version"`
+	Tab             browserUseChromeExtTab `json:"tab"`
+	TabCount        int                    `json:"tabCount"`
+	ControlledIndex int                    `json:"controlledIndex"`
+	MediaState      string                 `json:"mediaState"`
+}
+
+var globalBrowserUseChromeExtBridge = &browserUseChromeExtBridge{
+	pending: map[string]chan browserUseChromeExtResponse{},
+}
+
+func (p *BrowserUseTool) isChromeExtMode() bool {
+	return p.mode == browserUseModeChromeExt
+}
+
+func HandleBrowserUseChromeExtWebSocket(w http.ResponseWriter, r *http.Request) {
+	globalBrowserUseChromeExtBridge.handleWebSocket(w, r)
+}
+
+func (b *browserUseChromeExtBridge) handleWebSocket(w http.ResponseWriter, r *http.Request) {
+	if !browserUseIsLocalRequest(r) {
+		http.Error(w, "browser extension bridge only accepts localhost connections", http.StatusForbidden)
+		return
+	}
+	if expectedToken := strings.TrimSpace(os.Getenv("OPENAGENT_CHROME_EXTENSION_TOKEN")); expectedToken != "" {
+		if r.URL.Query().Get("token") != expectedToken {
+			http.Error(w, "invalid browser extension bridge token", http.StatusUnauthorized)
+			return
+		}
+	}
+
+	upgrader := websocket.Upgrader{
+		ReadBufferSize:  8192,
+		WriteBufferSize: 8192,
+		CheckOrigin: func(r *http.Request) bool {
+			return browserUseIsChromeExtensionOrigin(r.Header.Get("Origin"))
+		},
+	}
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		return
+	}
+
+	b.attach(conn)
+	defer b.detach(conn, fmt.Errorf("OpenAgent Chrome extension disconnected"))
+
+	_ = b.writeJSON(conn, map[string]interface{}{
+		"type":        "server_hello",
+		"name":        "openagent",
+		"version":     "2",
+		"heartbeatMs": 20000,
+	})
+
+	for {
+		_, data, err := conn.ReadMessage()
+		if err != nil {
+			return
+		}
+		var message browserUseChromeExtMessage
+		if err = json.Unmarshal(data, &message); err != nil {
+			continue
+		}
+		b.handleMessage(message)
+	}
+}
+
+func (b *browserUseChromeExtBridge) attach(conn *websocket.Conn) {
+	b.mu.Lock()
+	oldConn := b.conn
+	pending := b.pending
+	if oldConn != nil && oldConn != conn {
+		b.pending = map[string]chan browserUseChromeExtResponse{}
+	}
+	b.conn = conn
+	b.name = ""
+	b.version = ""
+	defer b.mu.Unlock()
+
+	if oldConn != nil && oldConn != conn {
+		_ = oldConn.Close()
+		for _, ch := range pending {
+			ch <- browserUseChromeExtResponse{err: fmt.Errorf("OpenAgent Chrome extension reconnected before the command completed")}
+		}
+	}
+}
+
+func (b *browserUseChromeExtBridge) detach(conn *websocket.Conn, err error) {
+	b.mu.Lock()
+	if b.conn != conn {
+		b.mu.Unlock()
+		return
+	}
+	_ = conn.Close()
+	b.conn = nil
+	b.name = ""
+	b.version = ""
+	pending := b.pending
+	b.pending = map[string]chan browserUseChromeExtResponse{}
+	b.mu.Unlock()
+
+	for _, ch := range pending {
+		ch <- browserUseChromeExtResponse{err: err}
+	}
+}
+
+func (b *browserUseChromeExtBridge) handleMessage(message browserUseChromeExtMessage) {
+	switch message.Type {
+	case "hello":
+		b.mu.Lock()
+		b.name = message.Name
+		b.version = message.Version
+		b.mu.Unlock()
+	case "ping":
+		b.mu.Lock()
+		conn := b.conn
+		b.mu.Unlock()
+		if conn != nil {
+			_ = b.writeJSON(conn, map[string]interface{}{
+				"type": "pong",
+				"ts":   time.Now().UnixMilli(),
+			})
+		}
+	case "result":
+		b.resolve(message.ID, message.Result, message.Error, message.OK)
+	case "error":
+		errText := message.Error
+		if errText == "" {
+			errText = "browser extension returned an error"
+		}
+		b.resolve(message.ID, nil, errText, nil)
+	}
+}
+
+func (b *browserUseChromeExtBridge) resolve(id string, result json.RawMessage, errorText string, ok *bool) {
+	if id == "" {
+		return
+	}
+	b.mu.Lock()
+	ch, okPending := b.pending[id]
+	if okPending {
+		delete(b.pending, id)
+	}
+	b.mu.Unlock()
+	if !okPending {
+		return
+	}
+	if ok != nil && !*ok && errorText == "" {
+		errorText = "browser extension command failed"
+	}
+	if errorText != "" {
+		ch <- browserUseChromeExtResponse{err: fmt.Errorf("%s", errorText)}
+		return
+	}
+	ch <- browserUseChromeExtResponse{result: result}
+}
+
+func (b *browserUseChromeExtBridge) call(ctx context.Context, command string, payload interface{}) (json.RawMessage, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	timeoutCtx, cancel := context.WithTimeout(ctx, browserUseChromeExtTimeout)
+	defer cancel()
+
+	id := strconv.FormatUint(atomic.AddUint64(&b.requestSeq, 1), 10)
+	ch := make(chan browserUseChromeExtResponse, 1)
+
+	b.mu.Lock()
+	conn := b.conn
+	if conn == nil {
+		b.mu.Unlock()
+		return nil, fmt.Errorf("OpenAgent Chrome extension is not connected. Install the OpenAgent Chrome extension, open the popup, enter http://127.0.0.1:14000, and click Connect")
+	}
+	b.pending[id] = ch
+	b.mu.Unlock()
+
+	if err := b.writeJSON(conn, browserUseChromeExtCallMessage{
+		Type:    "call",
+		ID:      id,
+		Command: command,
+		Payload: payload,
+	}); err != nil {
+		b.mu.Lock()
+		delete(b.pending, id)
+		b.mu.Unlock()
+		return nil, err
+	}
+
+	select {
+	case response := <-ch:
+		return response.result, response.err
+	case <-timeoutCtx.Done():
+		b.mu.Lock()
+		delete(b.pending, id)
+		b.mu.Unlock()
+		return nil, fmt.Errorf("browser extension command %q timed out", command)
+	}
+}
+
+func (b *browserUseChromeExtBridge) writeJSON(conn *websocket.Conn, value interface{}) error {
+	b.writeMu.Lock()
+	defer b.writeMu.Unlock()
+	return conn.WriteJSON(value)
+}
+
+func (b *browserUseChromeExtBridge) disconnect() {
+	b.mu.Lock()
+	conn := b.conn
+	pending := b.pending
+	b.conn = nil
+	b.name = ""
+	b.version = ""
+	b.pending = map[string]chan browserUseChromeExtResponse{}
+	b.mu.Unlock()
+
+	if conn != nil {
+		_ = conn.Close()
+	}
+	for _, ch := range pending {
+		ch <- browserUseChromeExtResponse{err: fmt.Errorf("OpenAgent Chrome extension bridge closed")}
+	}
+}
+
+func (b *browserUseChromeExtBridge) requestDisconnect(ctx context.Context) error {
+	_, err := b.call(ctx, "disconnect", map[string]interface{}{})
+	return err
+}
+
+func (b *browserUseChromeExtBridge) connectionInfo() (bool, string, string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.conn != nil, b.name, b.version
+}
+
+func browserUseIsLocalRequest(r *http.Request) bool {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		host = r.RemoteAddr
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return host == "localhost"
+	}
+	return ip.IsLoopback()
+}
+
+func browserUseIsChromeExtensionOrigin(origin string) bool {
+	if strings.TrimSpace(origin) == "" {
+		return false
+	}
+	u, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+	return u.Scheme == "chrome-extension" && u.Host != "" && u.Path == "" && u.RawQuery == "" && u.Fragment == ""
+}
+
+func browserUseChromeExtCall(ctx context.Context, command string, payload interface{}, out interface{}) error {
+	raw, err := globalBrowserUseChromeExtBridge.call(ctx, command, payload)
+	if err != nil {
+		return err
+	}
+	if out == nil {
+		return nil
+	}
+	if len(raw) == 0 {
+		return fmt.Errorf("browser extension returned an empty response for %s", command)
+	}
+	return json.Unmarshal(raw, out)
+}
+
+func browserUseChromeExtOpen(ctx context.Context, rawURL string) error {
+	return browserUseChromeExtCall(ctx, "open", map[string]interface{}{"url": rawURL}, nil)
+}
+
+func browserUseChromeExtSnapshot(ctx context.Context) (string, error) {
+	var snapshot browserUseChromeExtSnapshotResult
+	if err := browserUseChromeExtCall(ctx, "snapshot", map[string]interface{}{}, &snapshot); err != nil {
+		return "", err
+	}
+	if snapshot.URL == "" {
+		snapshot.URL = snapshot.Tab.URL
+	}
+	if snapshot.Title == "" {
+		snapshot.Title = snapshot.Tab.Title
+	}
+	return browserUseFormatSnapshot(snapshot.URL, snapshot.Title, snapshot.VisibleText, snapshot.Elements), nil
+}
+
+func browserUseChromeExtCurrentState(ctx context.Context) (string, error) {
+	var state browserUseChromeExtState
+	err := browserUseChromeExtCall(ctx, "state", map[string]interface{}{}, &state)
+	if err != nil {
+		connected, name, version := globalBrowserUseChromeExtBridge.connectionInfo()
+		if !connected {
+			return "", err
+		}
+		state = browserUseChromeExtState{
+			Mode:      browserUseModeChromeExt,
+			Connected: true,
+			Name:      name,
+			Version:   version,
+		}
+	}
+
+	if strings.TrimSpace(state.Mode) == "" {
+		state.Mode = browserUseModeChromeExt
+	}
+	if strings.TrimSpace(state.MediaState) == "" {
+		state.MediaState = "none"
+	}
+	activeText := "unknown"
+	if state.TabCount > 0 && state.ControlledIndex > 0 {
+		activeText = fmt.Sprintf("%d/%d", state.ControlledIndex, state.TabCount)
+	} else if state.TabCount > 0 {
+		activeText = fmt.Sprintf("unknown/%d", state.TabCount)
+	}
+
+	var builder strings.Builder
+	builder.WriteString("Current browser state:\n")
+	builder.WriteString(fmt.Sprintf("- Mode: %s\n", state.Mode))
+	builder.WriteString(fmt.Sprintf("- Controlled tab: %s\n", activeText))
+	builder.WriteString(fmt.Sprintf("- Title: %s\n", strings.TrimSpace(state.Tab.Title)))
+	builder.WriteString(fmt.Sprintf("- URL: %s\n", strings.TrimSpace(state.Tab.URL)))
+	if state.Name != "" || state.Version != "" {
+		builder.WriteString(fmt.Sprintf("- Extension: %s %s\n", strings.TrimSpace(state.Name), strings.TrimSpace(state.Version)))
+	}
+	builder.WriteString("- Media:\n")
+	for _, line := range strings.Split(strings.TrimSpace(state.MediaState), "\n") {
+		if strings.TrimSpace(line) != "" {
+			builder.WriteString(fmt.Sprintf("  %s\n", strings.TrimSpace(line)))
+		}
+	}
+	return builder.String(), nil
+}
+
+func browserUseChromeExtClick(ctx context.Context, arguments map[string]interface{}) error {
+	payload, err := browserUseChromeExtTargetPayload(arguments)
+	if err != nil {
+		return err
+	}
+	return browserUseChromeExtCall(ctx, "click", payload, nil)
+}
+
+func browserUseChromeExtType(ctx context.Context, arguments map[string]interface{}) error {
+	payload, err := browserUseChromeExtTargetPayload(arguments)
+	if err != nil {
+		return err
+	}
+	text, ok := arguments["text"].(string)
+	if !ok {
+		return fmt.Errorf("missing required parameter: text")
+	}
+	payload["text"] = text
+	clear := true
+	if value, ok := arguments["clear"].(bool); ok {
+		clear = value
+	}
+	payload["clear"] = clear
+	return browserUseChromeExtCall(ctx, "type", payload, nil)
+}
+
+func browserUseChromeExtPress(ctx context.Context, key string) error {
+	return browserUseChromeExtCall(ctx, "press", map[string]interface{}{"key": key}, nil)
+}
+
+func browserUseChromeExtPlayMedia(ctx context.Context) (string, error) {
+	var result struct {
+		Text string `json:"text"`
+	}
+	if err := browserUseChromeExtCall(ctx, "playMedia", map[string]interface{}{}, &result); err != nil {
+		return "", err
+	}
+	return result.Text, nil
+}
+
+func browserUseChromeExtTabs(ctx context.Context) ([]browserUseTab, error) {
+	var result browserUseChromeExtTabsResult
+	if err := browserUseChromeExtCall(ctx, "tabs", map[string]interface{}{}, &result); err != nil {
+		return nil, err
+	}
+	return browserUseChromeExtTabsToBrowserUseTabs(result.Tabs), nil
+}
+
+func browserUseChromeExtSwitchTab(ctx context.Context, index int) error {
+	var result browserUseChromeExtTabsResult
+	if err := browserUseChromeExtCall(ctx, "tabs", map[string]interface{}{}, &result); err != nil {
+		return err
+	}
+	if index > len(result.Tabs) {
+		return fmt.Errorf("tab index %d is out of range; there are %d tabs", index, len(result.Tabs))
+	}
+	return browserUseChromeExtCall(ctx, "switchTab", map[string]interface{}{"tabId": result.Tabs[index-1].ID}, nil)
+}
+
+func browserUseChromeExtCloseTab(ctx context.Context, index int) error {
+	var result browserUseChromeExtTabsResult
+	if err := browserUseChromeExtCall(ctx, "tabs", map[string]interface{}{}, &result); err != nil {
+		return err
+	}
+	if index > len(result.Tabs) {
+		return fmt.Errorf("tab index %d is out of range; there are %d tabs", index, len(result.Tabs))
+	}
+	return browserUseChromeExtCall(ctx, "closeTab", map[string]interface{}{"tabId": result.Tabs[index-1].ID}, nil)
+}
+
+func browserUseChromeExtTargetPayload(arguments map[string]interface{}) (map[string]interface{}, error) {
+	payload := map[string]interface{}{}
+	if rawIndex, ok := arguments["index"]; ok {
+		index, err := browserUsePositiveInt(rawIndex, "index")
+		if err != nil {
+			return nil, err
+		}
+		payload["index"] = index
+		return payload, nil
+	}
+	if selector, ok := arguments["selector"].(string); ok && strings.TrimSpace(selector) != "" {
+		payload["selector"] = strings.TrimSpace(selector)
+		return payload, nil
+	}
+	return nil, fmt.Errorf("missing required parameter: index or selector")
+}
+
+func browserUseChromeExtTabsToBrowserUseTabs(tabs []browserUseChromeExtTab) []browserUseTab {
+	res := make([]browserUseTab, 0, len(tabs))
+	for index, tab := range tabs {
+		res = append(res, browserUseTab{
+			Index:      index + 1,
+			ID:         target.ID(strconv.Itoa(tab.ID)),
+			Title:      tab.Title,
+			URL:        tab.URL,
+			Active:     tab.Active,
+			Controlled: tab.Controlled,
+			Protected:  tab.Protected,
+		})
+	}
+	return res
+}

--- a/web/src/ToolEditPage.js
+++ b/web/src/ToolEditPage.js
@@ -14,7 +14,7 @@
 
 import React from "react";
 import Loading from "./common/Loading";
-import {Button, Card, Col, Input, Row, Select, Switch, Table, Tag} from "antd";
+import {Alert, Button, Card, Col, Input, Row, Select, Switch, Table, Tag} from "antd";
 import * as ToolBackend from "./backend/ToolBackend";
 import * as Setting from "./Setting";
 import i18next from "i18next";
@@ -256,7 +256,20 @@ class ToolEditPage extends React.Component {
               >
                 <Option value="User Chrome">{i18next.t("tool:User Chrome")}</Option>
                 <Option value="Chrome for Testing">{i18next.t("tool:Chrome for Testing")}</Option>
+                <Option value="OpenAgent Chrome Extension">OpenAgent Chrome Extension</Option>
               </Select>
+            </Col>
+          </Row>
+        ) : null}
+        {this.state.tool.type === "browser_use" && this.state.tool.mode === "OpenAgent Chrome Extension" ? (
+          <Row style={{marginTop: "20px"}}>
+            <Col span={(Setting.isMobile()) ? 22 : 2} />
+            <Col span={22}>
+              <Alert
+                type="info"
+                showIcon
+                message="Install the OpenAgent Chrome extension, open the extension popup, enter http://127.0.0.1:14000, click Connect, then Browser Use will operate your current Chrome tabs."
+              />
             </Col>
           </Row>
         ) : null}


### PR DESCRIPTION
## Summary

Add an OpenAgent Chrome Extension mode for `browser_use`, allowing OpenAgent to control the user’s existing Chrome session through a local WebSocket bridge.

This keeps the existing `browser_use_*` tool API, but routes browser actions through the OpenAgent Chrome extension when the new mode is selected.

## Changes

- Add local WebSocket bridge endpoint for the Chrome extension.
- Add `OpenAgent Chrome Extension` mode to Browser Use.
- Route `open`, `snapshot`, `click`, `type`, `press`, `play_media`, `tabs`, `switch_tab`, and `close_tab` through the extension bridge in this mode.
- Add `browser_use_close_tab` for closing a single browser tab without ending the whole Browser Use session.
- Protect OpenAgent UI tabs by using a separate controlled tab model.
- Add Tool page option for selecting the extension mode.