### PR TITLE
feat: preserve reasoning content across tool calls

### DIFF
--- a/model/local.go
+++ b/model/local.go
@@ -262,9 +262,10 @@ func (p *LocalModelProvider) QueryText(question string, writer io.Writer, histor
 
 		isLeadingReturn := true
 		var (
-			answerData   strings.Builder
-			toolCalls    []openai.ToolCall
-			toolCallsMap map[int]int
+			answerData    strings.Builder
+			reasoningData strings.Builder
+			toolCalls     []openai.ToolCall
+			toolCallsMap  map[int]int
 		)
 
 		for {
@@ -292,8 +293,9 @@ func (p *LocalModelProvider) QueryText(question string, writer io.Writer, histor
 
 				// Check if we have reasoning content (think_content)
 				if completion.Choices[0].Delta.ReasoningContent != "" {
-					reasoningData := completion.Choices[0].Delta.ReasoningContent
-					err = flushThink(reasoningData, "reason", writer, lang)
+					data := completion.Choices[0].Delta.ReasoningContent
+					reasoningData.WriteString(data)
+					err = flushThink(data, "reason", writer, lang)
 					if err != nil {
 						return nil, err
 					}
@@ -340,6 +342,7 @@ func (p *LocalModelProvider) QueryText(question string, writer io.Writer, histor
 		}
 
 		if toolSession != nil && toolSession.ToolMessages != nil {
+			toolSession.ToolMessages.ReasoningContent = reasoningData.String()
 			toolSession.ToolMessages.ToolCalls = toolCalls
 		}
 

--- a/model/local_gptvision.go
+++ b/model/local_gptvision.go
@@ -116,7 +116,8 @@ func OpenaiRawMessagesToGptVisionMessages(messages []*RawMessage) ([]openai.Chat
 		urls, messageText := extractImagesURL(message.Text)
 
 		item := openai.ChatCompletionMessage{
-			Role: role,
+			Role:             role,
+			ReasoningContent: message.ReasoningContent,
 		}
 
 		if role == openai.ChatMessageRoleTool {

--- a/model/mcp.go
+++ b/model/mcp.go
@@ -29,8 +29,9 @@ import (
 )
 
 type ToolMessages struct {
-	Messages  []*RawMessage
-	ToolCalls any
+	Messages         []*RawMessage
+	ReasoningContent string
+	ToolCalls        any
 }
 
 type ToolSession struct {
@@ -134,9 +135,10 @@ func QueryTextWithTools(p ModelProvider, question string, writer io.Writer, hist
 			serverName, toolName := mcp.GetServerNameAndToolNameFromId(toolCall.Function.Name)
 
 			messages = append(messages, &RawMessage{
-				Text:     "Call result from " + toolCall.Function.Name,
-				Author:   "AI",
-				ToolCall: toolCall,
+				Text:             "Call result from " + toolCall.Function.Name,
+				Author:           "AI",
+				ReasoningContent: toolSession.ToolMessages.ReasoningContent,
+				ToolCall:         toolCall,
 			})
 
 			messages, err = callMcpTool(toolCall, serverName, toolName, toolSession.McpToolSet, messages, writer, lang)

--- a/model/openai_util.go
+++ b/model/openai_util.go
@@ -132,8 +132,9 @@ func OpenaiRawMessagesToMessages(messages []*RawMessage) []openai.ChatCompletion
 		}
 
 		item := openai.ChatCompletionMessage{
-			Role:    role,
-			Content: message.Text,
+			Role:             role,
+			Content:          message.Text,
+			ReasoningContent: message.ReasoningContent,
 		}
 		if role == openai.ChatMessageRoleTool {
 			item.ToolCallID = message.ToolCallID

--- a/model/util.go
+++ b/model/util.go
@@ -27,11 +27,12 @@ import (
 )
 
 type RawMessage struct {
-	Text           string
-	Author         string
-	TextTokenCount int
-	ToolCall       openai.ToolCall
-	ToolCallID     string
+	Text             string
+	Author           string
+	TextTokenCount   int
+	ReasoningContent string
+	ToolCall         openai.ToolCall
+	ToolCallID       string
 }
 
 type SearchResult struct {


### PR DESCRIPTION
## Summary
- Preserve `reasoning_content` from OpenAI-compatible thinking model stream responses.
- Attach the saved reasoning content to the assistant tool-call message before sending tool results back to the model.
- Forward reasoning content through OpenAI-compatible message conversion paths.