### PR TITLE
feat: update Claude models and pricing (Opus 4.7, Sonnet 4.6, Haiku 4.5)

### DIFF
--- a/model/claude.go
+++ b/model/claude.go
@@ -44,22 +44,32 @@ https://docs.anthropic.com/en/docs/about-claude/pricing
 
 | Model family        | Context window | Input Pricing         | Output Pricing        |
 |---------------------|----------------|-----------------------|-----------------------|
-| Claude Opus 4.5     | 200,000 tokens | $5.00/million tokens  | $25.00/million tokens |
-| Claude Opus 4.1     | 200,000 tokens | $15.00/million tokens | $75.00/million tokens |
-| Claude Opus 4       | 200,000 tokens | $15.00/million tokens | $75.00/million tokens |
-| Claude Sonnet 4     | 200,000 tokens | $3.00/million tokens  | $15.00/million tokens |
-| Claude Sonnet 3.7   | 200,000 tokens | $3.00/million tokens  | $15.00/million tokens |
-| Claude Sonnet 3.5   | 200,000 tokens | $3.00/million tokens  | $15.00/million tokens |
-| Claude Haiku 3.5    | 200,000 tokens | $0.80/million tokens  | $4.00/million tokens  |
-| Claude Opus 3       | 200,000 tokens | $15.00/million tokens | $75.00/million tokens |
-| Claude Haiku 3      | 200,000 tokens | $0.25/million tokens  | $1.25/million tokens  |
+| Claude Opus 4.7     | 1M tokens      | $5.00/million tokens  | $25.00/million tokens |
+| Claude Opus 4.6     | 1M tokens      | $5.00/million tokens  | $25.00/million tokens |
+| Claude Opus 4.5     | 200K tokens    | $5.00/million tokens  | $25.00/million tokens |
+| Claude Sonnet 4.6   | 1M tokens      | $3.00/million tokens  | $15.00/million tokens |
+| Claude Sonnet 4.5   | 200K tokens    | $3.00/million tokens  | $15.00/million tokens |
+| Claude Haiku 4.5    | 200K tokens    | $1.00/million tokens  | $5.00/million tokens  |
+| Claude Opus 4.1     | 200K tokens    | $15.00/million tokens | $75.00/million tokens |
+| Claude Opus 4       | 200K tokens    | $15.00/million tokens | $75.00/million tokens |
+| Claude Sonnet 4     | 200K tokens    | $3.00/million tokens  | $15.00/million tokens |
+| Claude Sonnet 3.7   | 200K tokens    | $3.00/million tokens  | $15.00/million tokens |
+| Claude Sonnet 3.5   | 200K tokens    | $3.00/million tokens  | $15.00/million tokens |
+| Claude Haiku 3.5    | 200K tokens    | $0.80/million tokens  | $4.00/million tokens  |
+| Claude Opus 3       | 200K tokens    | $15.00/million tokens | $75.00/million tokens |
+| Claude Haiku 3      | 200K tokens    | $0.25/million tokens  | $1.25/million tokens  |
 `
 }
 
 func (p *ClaudeModelProvider) calculatePrice(modelResult *ModelResult, lang string) error {
 	var inputPricePerThousandTokens, outputPricePerThousandTokens float64
 	priceTable := map[string][]float64{
+		"claude-opus-4-7":            {0.005, 0.025},
+		"claude-opus-4-6":            {0.005, 0.025},
 		"claude-opus-4-5":            {0.005, 0.025},
+		"claude-sonnet-4-6":          {0.003, 0.015},
+		"claude-sonnet-4-5":          {0.003, 0.015},
+		"claude-haiku-4-5":           {0.001, 0.005},
 		"claude-opus-4-1":            {0.015, 0.075},
 		"claude-opus-4-0":            {0.015, 0.075},
 		"claude-opus-4-20250514":     {0.015, 0.075},

--- a/model/context_length_util.go
+++ b/model/context_length_util.go
@@ -122,12 +122,13 @@ func getContextLength(typ string) int {
 			return 1048576
 		}
 	} else if strings.Contains(typ, "claude") {
-		if strings.Contains(typ, "4") {
-			if strings.Contains(typ, "sonnet") {
-				return 64000
-			} else if strings.Contains(typ, "opus") {
-				return 32000
+		if strings.Contains(typ, "4-7") || strings.Contains(typ, "4-6") {
+			return 1000000
+		} else if strings.Contains(typ, "4") {
+			if strings.Contains(typ, "haiku") {
+				return 200000
 			}
+			return 200000
 		} else if strings.Contains(typ, "3-7") {
 			if strings.Contains(typ, "sonnet") {
 				return 64000

--- a/web/src/Setting.js
+++ b/web/src/Setting.js
@@ -1696,7 +1696,12 @@ export function getModelSubTypeOptions(type) {
     ];
   } else if (type === "Claude") {
     return [
+      {id: "claude-opus-4-7", name: "claude-opus-4-7"},
+      {id: "claude-opus-4-6", name: "claude-opus-4-6"},
       {id: "claude-opus-4-5", name: "claude-opus-4-5"},
+      {id: "claude-sonnet-4-6", name: "claude-sonnet-4-6"},
+      {id: "claude-sonnet-4-5", name: "claude-sonnet-4-5"},
+      {id: "claude-haiku-4-5", name: "claude-haiku-4-5"},
       {id: "claude-opus-4-1", name: "claude-opus-4-1"},
       {id: "claude-opus-4-0", name: "claude-opus-4-0"},
       {id: "claude-opus-4-20250514", name: "claude-opus-4-20250514"},


### PR DESCRIPTION
- Add Claude Opus 4.7 (April 2026): $5/$25 per 1M tokens, 1M context
- Add Claude Opus 4.6: $5/$25 per 1M tokens, 1M context
- Add Claude Sonnet 4.6: $3/$15 per 1M tokens, 1M context
- Add Claude Sonnet 4.5: $3/$15 per 1M tokens, 200K context
- Add Claude Haiku 4.5: $1/$5 per 1M tokens, 200K context
- Fix context length: Opus/Sonnet 4.6+ → 1M, other 4.x → 200K
- Update frontend model dropdown list