### PR TITLE
feat: add Kimi K2.6 and K2.5 model support

### DIFF
--- a/model/context_length_util.go
+++ b/model/context_length_util.go
@@ -206,6 +206,9 @@ func getContextLength(typ string) int {
 	} else if strings.Contains(typ, "dummy") {
 		return 4096
 	} else if strings.Contains(typ, "Moonshot") {
+		if strings.Contains(typ, "k2") || strings.Contains(typ, "kimi-k2") {
+			return 262144
+		}
 		if strings.Contains(typ, "v1") {
 			if strings.Contains(typ, "8k") {
 				return 8192

--- a/model/moonshot.go
+++ b/model/moonshot.go
@@ -46,6 +46,8 @@ Model
 
 | Model                  | Unit Of Charge | Input Price | Output Price |
 |------------------------|----------------|-------------|--------------|
+| kimi-k2.6              | 1M tokens      | 6.5 yuan    | 27 yuan      |
+| kimi-k2.5              | 1M tokens      | 4 yuan      | 21 yuan      |
 | moonshot-v1-8k         | 1M tokens      | 2 yuan      | 10 yuan      |
 | moonshot-v1-32k        | 1M tokens      | 5 yuan      | 20 yuan      |
 | moonshot-v1-128k       | 1M tokens      | 10 yuan     | 30 yuan      |
@@ -61,6 +63,9 @@ Model
 func (p *MoonshotModelProvider) calculatePrice(modelResult *ModelResult, lang string) error {
 	price := 0.0
 	priceTable := map[string][2]float64{
+		"kimi-k2.6": {0.0065, 0.027},
+		"kimi-k2.5": {0.004, 0.021},
+
 		"moonshot-v1-8k":   {0.002, 0.010},
 		"moonshot-v1-32k":  {0.005, 0.020},
 		"moonshot-v1-128k": {0.010, 0.030},

--- a/web/src/Setting.js
+++ b/web/src/Setting.js
@@ -1896,6 +1896,8 @@ export function getModelSubTypeOptions(type) {
     ];
   } else if (type === "Moonshot") {
     return [
+      {id: "kimi-k2.6", name: "kimi-k2.6"},
+      {id: "kimi-k2.5", name: "kimi-k2.5"},
       {id: "moonshot-v1-8k", name: "moonshot-v1-8k"},
       {id: "moonshot-v1-32k", name: "moonshot-v1-32k"},
       {id: "moonshot-v1-128k", name: "moonshot-v1-128k"},


### PR DESCRIPTION
- Add kimi-k2.6 (April 2026): ¥6.5/27 per 1M tokens, 256K context
- Add kimi-k2.5: ¥4/21 per 1M tokens, 256K context
- Fix context length for all K2 series models (256K → 262144)
- Update frontend model dropdown list