### PR TITLE
feat: update GLM (ChatGLM) models and pricing for GLM-5.x series

### DIFF
--- a/model/chatglm.go
+++ b/model/chatglm.go
@@ -36,26 +36,35 @@ func NewChatGLMModelProvider(subType string, clientSecret string) (*ChatGLMModel
 
 func (c *ChatGLMModelProvider) GetPricing() string {
 	return `URL:
-https://open.bigmodel.cn/pricing
+	https://open.bigmodel.cn/pricing
 
-Generate Model:
-
-| Model        | Context Length | Unit Price (Per 1,000 tokens) |
-|--------------|----------------|-------------------------------|
-| GLM-3-Turbo  | 128K           | 0.005 yuan / K tokens         |
-| GLM-4        | 128K           | 0.1 yuan / K tokens           |
-| GLM-4V       | 2K             | 0.1 yuan / K tokens           |
-`
+	| Model         | Context  | Input Price          | Output Price         |
+	|---------------|----------|----------------------|----------------------|
+	| glm-5.1       | 200K     | 0.006 yuan/K tokens  | 0.024 yuan/K tokens  |
+	| glm-5         | 200K     | 0.004 yuan/K tokens  | 0.018 yuan/K tokens  |
+	| glm-5-turbo   | 200K     | 0.005 yuan/K tokens  | 0.022 yuan/K tokens  |
+	| glm-4         | 128K     | 0.100 yuan/K tokens  | 0.100 yuan/K tokens  |
+	| glm-4V        | 2K       | 0.100 yuan/K tokens  | 0.100 yuan/K tokens  |
+	| glm-3-turbo   | 128K     | 0.005 yuan/K tokens  | 0.005 yuan/K tokens  |
+	`
 }
 
 func (p *ChatGLMModelProvider) calculatePrice(modelResult *ModelResult, lang string) error {
 	price := 0.0
-	switch p.subType {
-	case "glm-3-turbo":
-		price = getPrice(modelResult.TotalTokenCount, 0.005)
-	case "glm-4", "glm-4v":
-		price = getPrice(modelResult.TotalTokenCount, 0.1)
-	default:
+	priceTable := map[string][2]float64{
+		"glm-5.1":     {0.006, 0.024},
+		"glm-5":       {0.004, 0.018},
+		"glm-5-turbo": {0.005, 0.022},
+		"glm-4":       {0.010, 0.010},
+		"glm-4v":      {0.010, 0.010},
+		"glm-3-turbo": {0.005, 0.005},
+	}
+
+	if priceItem, ok := priceTable[p.subType]; ok {
+		inputPrice := getPrice(modelResult.PromptTokenCount, priceItem[0])
+		outputPrice := getPrice(modelResult.ResponseTokenCount, priceItem[1])
+		price = inputPrice + outputPrice
+	} else {
 		return fmt.Errorf(i18n.Translate(lang, "embedding:calculatePrice() error: unknown model type: %s"), p.subType)
 	}
 

--- a/model/context_length_util.go
+++ b/model/context_length_util.go
@@ -257,7 +257,9 @@ func getContextLength(typ string) int {
 	} else if strings.Contains(typ, "yi") {
 		return 16384
 	} else if strings.Contains(typ, "glm") {
-		if strings.Contains(typ, "3-turbo") {
+		if strings.Contains(typ, "5") {
+			return 200000
+		} else if strings.Contains(typ, "3-turbo") {
 			return 131072
 		} else if strings.Contains(typ, "4V") {
 			return 8192

--- a/web/src/Setting.js
+++ b/web/src/Setting.js
@@ -1859,9 +1859,12 @@ export function getModelSubTypeOptions(type) {
     ];
   } else if (type === "ChatGLM") {
     return [
-      {id: "glm-3-turbo", name: "glm-3-turbo"},
+      {id: "glm-5.1", name: "glm-5.1"},
+      {id: "glm-5", name: "glm-5"},
+      {id: "glm-5-turbo", name: "glm-5-turbo"},
       {id: "glm-4", name: "glm-4"},
       {id: "glm-4V", name: "glm-4V"},
+      {id: "glm-3-turbo", name: "glm-3-turbo"},
     ];
   } else if (type === "MiniMax") {
     return [


### PR DESCRIPTION
- Add glm-5.1, glm-5, glm-5-turbo models with official BigModel pricing
- Update pricing to CNY per-thousand-tokens (glm-5.1: ¥0.006/0.024 input/output)
- Add context length entries for GLM-5.x models (200K)
- Refactor calculatePrice to use input/output separated pricing
- Update frontend model dropdown list