### PR TITLE
fix: add missing Tool table creation in createTable()

### DIFF
--- a/object/adapter.go
+++ b/object/adapter.go
@@ -394,6 +394,11 @@ func (a *Adapter) createTable() {
 		panic(err)
 	}
 
+	err = a.engine.Sync2(new(Tool))
+	if err != nil {
+		panic(err)
+	}
+
 	err = a.engine.Sync2(new(Server))
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
createTable() was missing Sync2(new(Tool)), causing initBuiltInTools() to panic with "Table 'casibase.tool' doesn't exist" on fresh installs.