### PR TITLE
fix: add default usage metadata when Casdoor is unavailable

### DIFF
--- a/controllers/usage.go
+++ b/controllers/usage.go
@@ -42,7 +42,7 @@ func (c *ApiController) GetUsages() {
 	if conf.IsCasdoorAvailable() {
 		usageMetadata, err = object.GetUsageMetadata(c.GetAcceptLanguage())
 	} else {
-		usageMetadata = &object.UsageMetadata{}
+		usageMetadata = object.GetDefaultUsageMetadata()
 	}
 	if err != nil {
 		c.ResponseError(err.Error())
@@ -75,7 +75,7 @@ func (c *ApiController) GetRangeUsages() {
 	if conf.IsCasdoorAvailable() {
 		usageMetadata, err = object.GetUsageMetadata(c.GetAcceptLanguage())
 	} else {
-		usageMetadata = &object.UsageMetadata{}
+		usageMetadata = object.GetDefaultUsageMetadata()
 	}
 	if err != nil {
 		c.ResponseError(err.Error())

--- a/object/usage.go
+++ b/object/usage.go
@@ -216,6 +216,13 @@ func GetUsageMetadata(lang string) (*UsageMetadata, error) {
 	return res, nil
 }
 
+func GetDefaultUsageMetadata() *UsageMetadata {
+	return &UsageMetadata{
+		Organization: "OpenAgent",
+		Application:  "OpenAgent",
+	}
+}
+
 func GetUsers(storeName, user string) ([]string, error) {
 	users := []string{}
 	userMap := map[string]bool{}


### PR DESCRIPTION
When Casdoor is not configured, the Usage page now displays 'OpenAgent' as the default Organization and Application name instead of showing '0'.

Changes:
- Add GetDefaultUsageMetadata() in object/usage.go
- Update GetUsages() and GetRangeUsages() to use default metadata