### PR TITLE
fix: handle local PDF parse panics as tool errors

### DIFF
--- a/tool/local_file.go
+++ b/tool/local_file.go
@@ -212,7 +212,12 @@ func localFileSliceText(text string, offset, limit int) (string, bool) {
 	return string(runes[offset:end]), truncated
 }
 
-func localFileReadDocument(path, ext, lang string) (string, error) {
+func localFileReadDocument(path, ext, lang string) (text string, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("failed to parse document: %v", r)
+		}
+	}()
 	return txt.GetParsedTextFromUrl(path, ext, lang)
 }
 


### PR DESCRIPTION
## Summary

- Convert document parser panics into normal tool errors inside the `local_file` tool boundary.
- Prevent malformed or unsupported PDFs from crashing the chat response during local document scans.
- Keep scan behavior resilient: one bad document reports an error while other files continue to be processed.