### PR TITLE
feat: add Tavily as a web search engine option

### DIFF
--- a/object/init.go
+++ b/object/init.go
@@ -328,6 +328,20 @@ func initBuiltInTools() {
 		},
 		{
 			Owner:       "admin",
+			Name:        "web_search_tavily",
+			Type:        "web_search",
+			SubType:     "Tavily",
+			TestContent: `{"tool":"web_search","arguments":{"query":"hello world"}}`,
+			State:       "Inactive",
+			PromptExamples: []string{
+				"Search for the latest news about artificial intelligence.",
+				"Find the best restaurants in New York City.",
+				"What are the top programming languages in 2025?",
+				"Search for tutorials on how to use OpenAgent.",
+			},
+		},
+		{
+			Owner:       "admin",
 			Name:        "shell",
 			Type:        "shell",
 			SubType:     "Default",

--- a/tool/web_search.go
+++ b/tool/web_search.go
@@ -98,6 +98,7 @@ const (
 	webSearchEngineBing       webSearchEngine = "bing"
 	webSearchEngineGoogle     webSearchEngine = "google"
 	webSearchEngineBaidu      webSearchEngine = "baidu"
+	webSearchEngineTavily     webSearchEngine = "tavily"
 )
 
 var (
@@ -106,6 +107,7 @@ var (
 	bingHTMLSearchEndpoint       = "https://www.bing.com/search"
 	googleJSONSearchEndpoint     = "https://www.googleapis.com/customsearch/v1"
 	baiduWebSearchEndpoint       = "https://qianfan.baidubce.com/v2/ai_search/web_search"
+	tavilySearchEndpoint         = "https://api.tavily.com/search"
 )
 
 type webSearchParams struct {
@@ -161,6 +163,22 @@ type baiduWebSearchMessage struct {
 type baiduWebSearchResourceType struct {
 	Type string `json:"type"`
 	TopK int    `json:"top_k"`
+}
+
+type tavilySearchRequest struct {
+	APIKey     string `json:"api_key"`
+	Query      string `json:"query"`
+	MaxResults int    `json:"max_results"`
+}
+
+type tavilySearchResponse struct {
+	Results []struct {
+		Title   string  `json:"title"`
+		URL     string  `json:"url"`
+		Content string  `json:"content"`
+		Score   float64 `json:"score"`
+	} `json:"results"`
+	Error string `json:"error,omitempty"`
 }
 
 type baiduWebSearchResponse struct {
@@ -322,6 +340,12 @@ func (t *webSearchBuiltin) runWebSearch(ctx context.Context, params webSearchPar
 			return nil, "", err
 		}
 		return results, "baidu", nil
+	case webSearchEngineTavily:
+		results, err := runTavilySearch(ctx, params, t.apiKey, t.endpoint, t.httpClient)
+		if err != nil {
+			return nil, "", err
+		}
+		return results, "tavily", nil
 	default:
 		return nil, "", fmt.Errorf("unsupported web search engine: %s", t.engine)
 	}
@@ -337,6 +361,8 @@ func parseWebSearchEngine(value string) (webSearchEngine, error) {
 		return webSearchEngineGoogle, nil
 	case "Baidu":
 		return webSearchEngineBaidu, nil
+	case "Tavily":
+		return webSearchEngineTavily, nil
 	default:
 		return "", fmt.Errorf("unsupported web search engine subtype: %s", value)
 	}
@@ -482,6 +508,63 @@ func runBaiduSearch(ctx context.Context, params webSearchParams, apiKey string, 
 		return nil, fmt.Errorf("Baidu returned no results")
 	}
 	return limitWebSearchResults(results, params.Count), nil
+}
+
+func runTavilySearch(ctx context.Context, params webSearchParams, apiKey string, endpoint string, httpClient *http.Client) ([]webSearchResult, error) {
+	if strings.TrimSpace(apiKey) == "" {
+		return nil, fmt.Errorf("Tavily search requires an API key in clientSecret")
+	}
+
+	requestBody := tavilySearchRequest{
+		APIKey:     apiKey,
+		Query:      params.Query,
+		MaxResults: params.Count,
+	}
+	requestBytes, err := json.Marshal(requestBody)
+	if err != nil {
+		return nil, err
+	}
+
+	headers := map[string]string{
+		"Content-Type": "application/json",
+	}
+	body, err := fetchWebSearchAPI(ctx, http.MethodPost, resolveWebSearchEndpoint(endpoint, tavilySearchEndpoint), nil, bytes.NewReader(requestBytes), headers, httpClient)
+	if err != nil {
+		return nil, err
+	}
+
+	var response tavilySearchResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, err
+	}
+	if response.Error != "" {
+		return nil, fmt.Errorf("Tavily returned an error: %s", response.Error)
+	}
+
+	results := parseTavilySearchResponse(response)
+	if len(results) == 0 {
+		return nil, fmt.Errorf("Tavily returned no results")
+	}
+	return limitWebSearchResults(results, params.Count), nil
+}
+
+func parseTavilySearchResponse(response tavilySearchResponse) []webSearchResult {
+	results := make([]webSearchResult, 0, len(response.Results))
+	for _, item := range response.Results {
+		title := cleanWebSearchText(item.Title)
+		resultURL := strings.TrimSpace(item.URL)
+		if title == "" || resultURL == "" {
+			continue
+		}
+
+		results = append(results, webSearchResult{
+			Title:    title,
+			URL:      resultURL,
+			Snippet:  cleanWebSearchText(item.Content),
+			SiteName: resolveWebSearchSiteName(resultURL),
+		})
+	}
+	return results
 }
 
 func fetchWebSearchAPI(ctx context.Context, method string, endpoint string, query url.Values, body io.Reader, headers map[string]string, httpClient *http.Client) ([]byte, error) {

--- a/web/src/Setting.js
+++ b/web/src/Setting.js
@@ -2198,6 +2198,7 @@ export function getProviderSubTypeOptions(category, type) {
         {id: "Bing", name: "Bing"},
         {id: "Google", name: "Google"},
         {id: "Baidu", name: "Baidu"},
+        {id: "Tavily", name: "Tavily"},
       ];
     } else if (type === "shell") {
       return [

--- a/web/src/ToolEditPage.js
+++ b/web/src/ToolEditPage.js
@@ -63,7 +63,7 @@ class ToolEditPage extends React.Component {
   }
 
   shouldShowClientSecretInput(tool) {
-    return tool.type === "web_search" && ["Google", "Baidu"].includes(tool.subType);
+    return tool.type === "web_search" && ["Google", "Baidu", "Tavily"].includes(tool.subType);
   }
 
   getClientIdLabel(tool) {

--- a/web/src/locales/en/data.json
+++ b/web/src/locales/en/data.json
@@ -679,6 +679,8 @@
     "Provider test - Tooltip": "Test text for TTS preview",
     "Search engine ID (cx)": "Search engine ID (cx)",
     "Search engine ID (cx) - Tooltip": "Google Programmable Search Engine cx value that scopes custom web search.",
+    "Tavily API Key": "Tavily API Key",
+    "Tavily API Key - Tooltip": "API key for Tavily web search. Obtain one at https://app.tavily.com.",
     "Select model provider": "Select model provider",
     "Set Webhook": "Set Webhook",
     "Speech recognition completed": "Speech recognition completed",

--- a/web/src/locales/zh/data.json
+++ b/web/src/locales/zh/data.json
@@ -679,6 +679,8 @@
     "Provider test - Tooltip": "提供商效果测试",
     "Search engine ID (cx)": "搜索引擎ID（cx）",
     "Search engine ID (cx) - Tooltip": "Google可编程搜索引擎的cx参数，用于限定自定义搜索范围",
+    "Tavily API Key": "Tavily API密钥",
+    "Tavily API Key - Tooltip": "Tavily网络搜索的API密钥，可在 https://app.tavily.com 获取。",
     "Select model provider": "选择模型提供商",
     "Set Webhook": "设置Webhook",
     "Speech recognition completed": "语音识别完成",


### PR DESCRIPTION
## Summary

Adds Tavily as a fifth selectable web search engine in the `web_search` tool, alongside the existing DuckDuckGo, Bing, Google, and Baidu engines. This is an **additive** change — all existing engines remain unchanged.

Tavily Search API is called via raw HTTP POST (same pattern as Google/Baidu), so no new Go module dependencies are needed. The API key is stored in the tool's `clientSecret` database field, consistent with existing engines.

## Changes

### Backend (`tool/web_search.go`)
- Added `webSearchEngineTavily` constant and `tavilySearchEndpoint` URL
- Added `tavilySearchRequest` and `tavilySearchResponse` structs
- Added `runTavilySearch` and `parseTavilySearchResponse` functions
- Extended `parseWebSearchEngine` switch to handle `"Tavily"` subtype
- Extended `runWebSearch` switch to dispatch to Tavily engine

### Frontend
- **`web/src/Setting.js`**: Added `{id: 'Tavily', name: 'Tavily'}` to `web_search` subtype options
- **`web/src/ToolEditPage.js`**: Extended `shouldShowClientSecretInput` to show API key field when subType is `"Tavily"`
- **`web/src/locales/en/data.json`**: Added `"Tavily API Key"` and tooltip string
- **`web/src/locales/zh/data.json`**: Added Chinese translations for Tavily tooltip

### Seed Data (`object/init.go`)
- Added an inactive `web_search_tavily` tool record so admins see Tavily in the tool list and only need to supply their API key to activate it

## Dependency changes
- None (uses existing `net/http` client pattern)

## Environment variable changes
- The Tavily API key is stored in the tool's `clientSecret` DB field (not a process env var), obtained from https://app.tavily.com

## Notes for reviewers
- The Tavily API accepts POST to `https://api.tavily.com/search` with `{api_key, query, max_results}` in the JSON body
- Response maps cleanly to the existing `webSearchResult` struct
- Go compiler was not available in the build environment; syntax was verified manually

### Automated Review

- Passed after 1 attempt(s)
- Final review: The Tavily migration is well-implemented and consistent with the existing provider pattern. All six listed files are correctly modified. The backend adds the engine constant, endpoint, request/response structs, `runTavilySearch`, and extends both switch statements following the same structure as the Baidu provider. The frontend adds the subtype dropdown entry, clientSecret visibility, and locale strings. The seed record in `init.go` is correctly inactive. One minor issue: two i18n locale keys ("Tavily API Key" and "Tavily API Key - Tooltip") are added but never referenced in any JS component — `getClientSecretLabel` uses the generic `"provider:API key"` label for all web_search types, making the new strings dead code.
