### PR TITLE
feat: polish form and table UI

### DIFF
--- a/object/adapter.go
+++ b/object/adapter.go
@@ -398,6 +398,7 @@ func (a *Adapter) createTable() {
 	if err != nil {
 		panic(err)
 	}
+
 	err = a.engine.Sync2(new(Tool))
 	if err != nil {
 		panic(err)

--- a/object/adapter.go
+++ b/object/adapter.go
@@ -398,7 +398,6 @@ func (a *Adapter) createTable() {
 	if err != nil {
 		panic(err)
 	}
-
 	err = a.engine.Sync2(new(Tool))
 	if err != nil {
 		panic(err)

--- a/web/src/ApplicationListPage.js
+++ b/web/src/ApplicationListPage.js
@@ -14,8 +14,8 @@
 
 import React from "react";
 import {Link} from "react-router-dom";
-import {Alert, Button, Popconfirm, Table, Tag, Tooltip} from "antd";
-import {DeleteOutlined, LinkOutlined} from "@ant-design/icons";
+import {Alert, Button, Dropdown, Modal, Popconfirm, Table, Tag, Tooltip} from "antd";
+import {CloudUploadOutlined, DeleteOutlined, EditOutlined, EyeOutlined, LinkOutlined, MoreOutlined} from "@ant-design/icons";
 import moment from "moment";
 import BaseListPage from "./BaseListPage";
 import * as Setting from "./Setting";
@@ -340,40 +340,75 @@ class ApplicationListPage extends BaseListPage {
         title: i18next.t("general:Action"),
         dataIndex: "action",
         key: "action",
-        width: "280px",
+        width: "150px",
         fixed: (Setting.isMobile()) ? "false" : "right",
         render: (text, record, index) => {
+          const moreMenuItems = [];
+          if (record.status === "Not Deployed") {
+            moreMenuItems.push({
+              key: "deploy",
+              icon: <CloudUploadOutlined />,
+              label: i18next.t("application:Deploy"),
+              disabled: this.state.deploying[index],
+            });
+          } else {
+            moreMenuItems.push({
+              key: "view",
+              icon: <EyeOutlined />,
+              label: i18next.t("general:View"),
+            });
+            moreMenuItems.push({
+              key: "undeploy",
+              label: i18next.t("application:Undeploy"),
+              danger: true,
+              disabled: this.state.deploying[index],
+            });
+          }
           return (
-            <div>
-              <Button style={{marginTop: "10px", marginBottom: "10px", marginRight: "10px"}} type="primary" onClick={() => this.props.history.push(`/applications/${record.name}`)}>{i18next.t("general:Edit")}</Button>
-              {
-                record.status === "Not Deployed" ? (
-                  <Button style={{marginBottom: "10px", marginRight: "10px"}} loading={this.state.deploying[index]} onClick={() => this.deployApplication(record, index)}>
-                    {i18next.t("application:Deploy")}
-                  </Button>
-                ) : (
-                  <Popconfirm title={`${i18next.t("general:Sure to undeploy")}: ${record.name} ?`} onConfirm={() => this.undeployApplication(record, index)} okText={i18next.t("general:OK")} cancelText={i18next.t("general:Cancel")}>
-                    <Button style={{marginBottom: "10px", marginRight: "10px"}} loading={this.state.deploying[index]} danger>
-                      {i18next.t("application:Undeploy")}
-                    </Button>
-                  </Popconfirm>
-                )
-              }
-              {
-                record.status !== "Not Deployed" && (
-                  <Button style={{marginBottom: "10px", marginRight: "10px"}} onClick={() => this.props.history.push(`/applications/${record.name}/view`, {application: record})}>
-                    {i18next.t("general:View")}
-                  </Button>
-                )
-              }
+            <div style={{display: "flex", alignItems: "center", gap: "2px", flexWrap: "nowrap"}}>
+              <Button
+                style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}}
+                type="default"
+                icon={<EditOutlined />}
+                onClick={() => this.props.history.push(`/applications/${record.name}`)}
+                title={i18next.t("general:Edit")}
+              />
               <Popconfirm
                 title={`${i18next.t("general:Sure to delete")}: ${record.name} ?`}
                 onConfirm={() => this.deleteApplication(record)}
                 okText={i18next.t("general:OK")}
                 cancelText={i18next.t("general:Cancel")}
               >
-                <Button style={{marginBottom: "10px"}} type="primary" danger>{i18next.t("general:Delete")}</Button>
+                <Button
+                  style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}}
+                  type="primary"
+                  danger
+                  icon={<DeleteOutlined />}
+                />
               </Popconfirm>
+              <Dropdown
+                menu={{
+                  items: moreMenuItems,
+                  onClick: ({key}) => {
+                    if (key === "deploy") {this.deployApplication(record, index);}
+                    if (key === "undeploy") {
+                      Modal.confirm({
+                        title: `${i18next.t("general:Sure to undeploy")}: ${record.name} ?`,
+                        okText: i18next.t("general:OK"),
+                        cancelText: i18next.t("general:Cancel"),
+                        onOk: () => this.undeployApplication(record, index),
+                      });
+                    }
+                    if (key === "view") {this.props.history.push(`/applications/${record.name}/view`, {application: record});}
+                  },
+                }}
+                trigger={["click"]}
+              >
+                <Button
+                  style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}}
+                  icon={<MoreOutlined />}
+                />
+              </Dropdown>
             </div>
           );
         },

--- a/web/src/ArticleListPage.js
+++ b/web/src/ArticleListPage.js
@@ -20,7 +20,7 @@ import BaseListPage from "./BaseListPage";
 import * as Setting from "./Setting";
 import * as ArticleBackend from "./backend/ArticleBackend";
 import i18next from "i18next";
-import {DeleteOutlined} from "@ant-design/icons";
+import {DeleteOutlined, EditOutlined} from "@ant-design/icons";
 
 class ArticleListPage extends BaseListPage {
   constructor(props) {
@@ -157,19 +157,23 @@ class ArticleListPage extends BaseListPage {
         title: i18next.t("general:Action"),
         dataIndex: "action",
         key: "action",
-        width: "180px",
+        width: "130px",
         fixed: (Setting.isMobile()) ? "false" : "right",
         render: (text, record, index) => {
           return (
-            <div>
-              <Button style={{marginTop: "10px", marginBottom: "10px", marginRight: "10px"}} type="primary" onClick={() => this.props.history.push(`/articles/${record.name}`)}>{i18next.t("general:Edit")}</Button>
+            <div style={{display: "flex", alignItems: "center", gap: "2px", flexWrap: "nowrap"}}>
+              <Tooltip title={i18next.t("general:Edit")}>
+                <Button type="text" size="small" icon={<EditOutlined />} style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}} onClick={() => this.props.history.push(`/articles/${record.name}`)} />
+              </Tooltip>
               <Popconfirm
                 title={`${i18next.t("general:Sure to delete")}: ${record.name} ?`}
                 onConfirm={() => this.deleteArticle(record)}
                 okText={i18next.t("general:OK")}
                 cancelText={i18next.t("general:Cancel")}
               >
-                <Button style={{marginBottom: "10px"}} type="primary" danger>{i18next.t("general:Delete")}</Button>
+                <Tooltip title={i18next.t("general:Delete")}>
+                  <Button type="text" size="small" danger icon={<DeleteOutlined />} style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}} />
+                </Tooltip>
               </Popconfirm>
             </div>
           );

--- a/web/src/AssetListPage.js
+++ b/web/src/AssetListPage.js
@@ -14,8 +14,8 @@
 
 import React from "react";
 import {Link} from "react-router-dom";
-import {Button, Select, Table, Tooltip} from "antd";
-import {ReloadOutlined} from "@ant-design/icons";
+import {Button, Popconfirm, Select, Table, Tooltip} from "antd";
+import {DeleteOutlined, EditOutlined, ReloadOutlined} from "@ant-design/icons";
 import moment from "moment";
 import * as Setting from "./Setting";
 import * as AssetBackend from "./backend/AssetBackend";
@@ -23,7 +23,6 @@ import * as ProviderBackend from "./backend/ProviderBackend";
 import * as ScanBackend from "./backend/ScanBackend";
 import i18next from "i18next";
 import BaseListPage from "./BaseListPage";
-import PopconfirmModal from "./modal/PopconfirmModal";
 import {JsonCodeMirrorPopover} from "./common/JsonCodeMirrorWidget";
 import {ScanDetailPopover} from "./common/ScanDetailPopover";
 
@@ -382,18 +381,25 @@ class AssetListPage extends BaseListPage {
         title: i18next.t("general:Action"),
         dataIndex: "",
         key: "op",
-        width: "170px",
+        width: "130px",
         fixed: (Setting.isMobile()) ? "false" : "right",
         render: (text, record, index) => {
           return (
-            <div>
-              <Button style={{marginTop: "10px", marginBottom: "10px", marginRight: "10px"}} type="primary" onClick={() => this.props.history.push(`/assets/${record.name}`)}>{i18next.t("general:Edit")}</Button>
-              <PopconfirmModal
+            <div style={{display: "flex", alignItems: "center", gap: "2px", flexWrap: "nowrap"}}>
+              <Tooltip title={i18next.t("general:Edit")}>
+                <Button type="text" size="small" icon={<EditOutlined />} style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}} onClick={() => this.props.history.push(`/assets/${record.name}`)} />
+              </Tooltip>
+              <Popconfirm
                 title={i18next.t("general:Sure to delete") + `: ${record.name} ?`}
                 onConfirm={() => this.deleteAsset(index)}
                 disabled={!Setting.isAdminUser(this.props.account)}
+                okText={i18next.t("general:OK")}
+                cancelText={i18next.t("general:Cancel")}
               >
-              </PopconfirmModal>
+                <Tooltip title={i18next.t("general:Delete")}>
+                  <Button type="text" size="small" danger icon={<DeleteOutlined />} style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}} />
+                </Tooltip>
+              </Popconfirm>
             </div>
           );
         },

--- a/web/src/ChatListPage.js
+++ b/web/src/ChatListPage.js
@@ -14,7 +14,7 @@
 
 import React from "react";
 import {Link} from "react-router-dom";
-import {Button, Popconfirm, Switch, Table} from "antd";
+import {Button, Popconfirm, Switch, Table, Tooltip} from "antd";
 import moment from "moment";
 import BaseListPage from "./BaseListPage";
 import * as Setting from "./Setting";
@@ -25,7 +25,7 @@ import * as Conf from "./Conf";
 import * as MessageBackend from "./backend/MessageBackend";
 import ChatBox from "./ChatBox";
 import {renderText} from "./ChatMessageRender";
-import {DeleteOutlined} from "@ant-design/icons";
+import {DeleteOutlined, EditOutlined} from "@ant-design/icons";
 
 class ChatListPage extends BaseListPage {
   constructor(props) {
@@ -602,19 +602,23 @@ class ChatListPage extends BaseListPage {
         title: i18next.t("general:Action"),
         dataIndex: "action",
         key: "action",
-        width: "110px",
+        width: "130px",
         fixed: "right",
         render: (text, record, index) => {
           return (
-            <div>
-              <Button style={{marginTop: "10px", marginBottom: "10px", marginRight: "10px"}} type="primary" onClick={() => this.props.history.push(`/chats/${record.name}`)}>{i18next.t("general:Edit")}</Button>
+            <div style={{display: "flex", alignItems: "center", gap: "2px", flexWrap: "nowrap"}}>
+              <Tooltip title={i18next.t("general:Edit")}>
+                <Button type="text" size="small" icon={<EditOutlined />} style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}} onClick={() => this.props.history.push(`/chats/${record.name}`)} />
+              </Tooltip>
               <Popconfirm
                 title={`${i18next.t("general:Sure to delete")}: ${record.name} ?`}
                 onConfirm={() => this.deleteChat(record)}
                 okText={i18next.t("general:OK")}
                 cancelText={i18next.t("general:Cancel")}
               >
-                <Button disabled={!Setting.isLocalAdminUser(this.props.account)} style={{marginBottom: "10px"}} type="primary" danger>{i18next.t("general:Delete")}</Button>
+                <Tooltip title={i18next.t("general:Delete")}>
+                  <Button type="text" size="small" danger icon={<DeleteOutlined />} style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}} disabled={!Setting.isLocalAdminUser(this.props.account)} />
+                </Tooltip>
               </Popconfirm>
             </div>
           );

--- a/web/src/ConnectionListPage.js
+++ b/web/src/ConnectionListPage.js
@@ -16,12 +16,11 @@ import * as ConnectionBackend from "./backend/ConnectionBackend";
 import * as Setting from "./Setting";
 import {Button, Popconfirm, Radio, Table} from "antd";
 import i18next from "i18next";
-import PopconfirmModal from "./modal/PopconfirmModal";
 import BaseListPage from "./BaseListPage";
 import moment from "moment";
 import React from "react";
 import {Link} from "react-router-dom";
-import {DeleteOutlined} from "@ant-design/icons";
+import {DeleteOutlined, PauseCircleOutlined} from "@ant-design/icons";
 
 export const Connected = "connected";
 const Disconnected = "disconnected";
@@ -210,26 +209,46 @@ class ConnectionListPage extends BaseListPage {
         title: i18next.t("general:Action"),
         dataIndex: "action",
         key: "action",
-        width: "120px",
+        width: "150px",
         fixed: (Setting.isMobile()) ? "false" : "right",
         render: (text, record, index) => {
-          return this.state.status === Connected ?
-            (
-              <div>
-                <PopconfirmModal
-                  style={{marginTop: "10px", marginBottom: "10px", marginRight: "10px"}}
-                  text={i18next.t("general:Stop")}
+          if (this.state.status === Connected) {
+            return (
+              <div style={{display: "flex", alignItems: "center", gap: "2px", flexWrap: "nowrap"}}>
+                <Popconfirm
                   title={`${i18next.t("general:Sure to disconnect from")}: ${record.name} ?`}
                   onConfirm={() => this.stopConnection(index)}
-                />
+                  okText={i18next.t("general:OK")}
+                  cancelText={i18next.t("general:Cancel")}
+                >
+                  <Button
+                    style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}}
+                    type="primary"
+                    danger
+                    icon={<PauseCircleOutlined />}
+                    title={i18next.t("general:Stop")}
+                  />
+                </Popconfirm>
               </div>
-            ) : (
-              <PopconfirmModal
-                style={{marginTop: "10px", marginBottom: "10px", marginRight: "10px"}}
+            );
+          }
+          return (
+            <div style={{display: "flex", alignItems: "center", gap: "2px", flexWrap: "nowrap"}}>
+              <Popconfirm
                 title={`${i18next.t("general:Sure to delete")}: ${record.name} ?`}
                 onConfirm={() => this.deleteConnection(index)}
-              />
-            );
+                okText={i18next.t("general:OK")}
+                cancelText={i18next.t("general:Cancel")}
+              >
+                <Button
+                  style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}}
+                  type="primary"
+                  danger
+                  icon={<DeleteOutlined />}
+                />
+              </Popconfirm>
+            </div>
+          );
         },
       },
     ];

--- a/web/src/ContainerListPage.js
+++ b/web/src/ContainerListPage.js
@@ -14,14 +14,13 @@
 
 import React from "react";
 import {Link} from "react-router-dom";
-import {Button, Popconfirm, Table} from "antd";
+import {Button, Popconfirm, Table, Tooltip} from "antd";
 import moment from "moment";
 import * as Setting from "./Setting";
 import * as ContainerBackend from "./backend/ContainerBackend";
 import i18next from "i18next";
 import BaseListPage from "./BaseListPage";
-import PopconfirmModal from "./modal/PopconfirmModal";
-import {DeleteOutlined} from "@ant-design/icons";
+import {DeleteOutlined, EditOutlined} from "@ant-design/icons";
 
 class ContainerListPage extends BaseListPage {
   constructor(props) {
@@ -199,22 +198,25 @@ class ContainerListPage extends BaseListPage {
         title: i18next.t("general:Action"),
         dataIndex: "action",
         key: "action",
-        width: "260px",
+        width: "130px",
         fixed: (Setting.isMobile()) ? "false" : "right",
         render: (text, container, index) => {
           return (
-            <div>
-              <Button
-                style={{marginTop: "10px", marginBottom: "10px", marginRight: "10px"}}
-                onClick={() => this.props.history.push(`/containers/${container.owner}/${container.name}`)}
-              >{i18next.t("general:Edit")}
-              </Button>
-              <PopconfirmModal
+            <div style={{display: "flex", alignItems: "center", gap: "2px", flexWrap: "nowrap"}}>
+              <Tooltip title={i18next.t("general:Edit")}>
+                <Button type="text" size="small" icon={<EditOutlined />} style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}} onClick={() => this.props.history.push(`/containers/${container.owner}/${container.name}`)} />
+              </Tooltip>
+              <Popconfirm
                 disabled={container.owner !== this.props.account.owner}
                 title={i18next.t("general:Sure to delete") + `: ${container.name} ?`}
                 onConfirm={() => this.deleteContainer(index)}
+                okText={i18next.t("general:OK")}
+                cancelText={i18next.t("general:Cancel")}
               >
-              </PopconfirmModal>
+                <Tooltip title={i18next.t("general:Delete")}>
+                  <Button type="text" size="small" danger icon={<DeleteOutlined />} style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}} />
+                </Tooltip>
+              </Popconfirm>
             </div>
           );
         },

--- a/web/src/FileListPage.js
+++ b/web/src/FileListPage.js
@@ -14,14 +14,14 @@
 
 import React from "react";
 import {Link} from "react-router-dom";
-import {Button, Popconfirm, Table} from "antd";
+import {Button, Dropdown, Popconfirm, Table} from "antd";
 import moment from "moment";
 import BaseListPage from "./BaseListPage";
 import * as Setting from "./Setting";
 import * as FileBackend from "./backend/FileBackend";
 import * as StoreBackend from "./backend/StoreBackend";
 import i18next from "i18next";
-import {DeleteOutlined} from "@ant-design/icons";
+import {DeleteOutlined, EditOutlined, MoreOutlined, ReloadOutlined} from "@ant-design/icons";
 
 class FileListPage extends BaseListPage {
   constructor(props) {
@@ -230,25 +230,56 @@ class FileListPage extends BaseListPage {
         title: i18next.t("general:Action"),
         dataIndex: "action",
         key: "action",
-        width: "260px",
+        width: "150px",
         fixed: "right",
         render: (text, record, index) => {
           return (
-            <div>
-              {
-                !Setting.isLocalAdminUser(this.props.account) ? null : (
-                  <Button style={{marginTop: "10px", marginBottom: "10px", marginRight: "10px"}} loading={this.state.refreshing[index]} onClick={() => this.refreshFileVectors(index)}>{i18next.t("general:Refresh Vectors")}</Button>
-                )
-              }
-              <Button style={{marginTop: "10px", marginBottom: "10px", marginRight: "10px"}} type="primary" onClick={() => this.props.history.push(`/files/${encodeURIComponent(record.name)}`)}>{i18next.t("general:View")}</Button>
+            <div style={{display: "flex", alignItems: "center", gap: "2px", flexWrap: "nowrap"}}>
+              <Button
+                style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}}
+                type="default"
+                icon={<EditOutlined />}
+                onClick={() => this.props.history.push(`/files/${encodeURIComponent(record.name)}`)}
+                title={i18next.t("general:View")}
+              />
               <Popconfirm
                 title={`${i18next.t("general:Sure to delete")}: ${record.name} ?`}
                 onConfirm={() => this.deleteFile(record)}
                 okText={i18next.t("general:OK")}
                 cancelText={i18next.t("general:Cancel")}
               >
-                <Button style={{marginBottom: "10px"}} type="primary" danger>{i18next.t("general:Delete")}</Button>
+                <Button
+                  style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}}
+                  type="primary"
+                  danger
+                  icon={<DeleteOutlined />}
+                />
               </Popconfirm>
+              {
+                !Setting.isLocalAdminUser(this.props.account) ? null : (
+                  <Dropdown
+                    menu={{
+                      items: [
+                        {
+                          key: "refresh-vectors",
+                          icon: <ReloadOutlined />,
+                          label: i18next.t("general:Refresh Vectors"),
+                          disabled: this.state.refreshing[index],
+                        },
+                      ],
+                      onClick: ({key}) => {
+                        if (key === "refresh-vectors") {this.refreshFileVectors(index);}
+                      },
+                    }}
+                    trigger={["click"]}
+                  >
+                    <Button
+                      style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}}
+                      icon={<MoreOutlined />}
+                    />
+                  </Dropdown>
+                )
+              }
             </div>
           );
         },

--- a/web/src/FormDataTablePage.js
+++ b/web/src/FormDataTablePage.js
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 import React from "react";
-import {Button, Popconfirm, Table} from "antd";
-import {DeleteOutlined} from "@ant-design/icons";
+import {Button, Popconfirm, Table, Tooltip} from "antd";
+import {DeleteOutlined, EditOutlined} from "@ant-design/icons";
 import BaseListPage from "./BaseListPage";
 import * as Setting from "./Setting";
 import * as FormBackend from "./backend/FormBackend";
@@ -84,19 +84,23 @@ class FormDataPage extends BaseListPage {
         title: i18next.t("general:Action"),
         dataIndex: "action",
         key: "action",
-        width: "180px",
+        width: "130px",
         fixed: (Setting.isMobile()) ? "false" : "right",
         render: (text, record, index) => {
           return (
-            <div>
-              <Button style={{marginTop: "10px", marginBottom: "10px", marginRight: "10px"}} type="primary" onClick={() => this.props.history.push(`/forms/${this.state.formName}/data/${record.name}`)}>{i18next.t("general:Edit")}</Button>
+            <div style={{display: "flex", alignItems: "center", gap: "2px", flexWrap: "nowrap"}}>
+              <Tooltip title={i18next.t("general:Edit")}>
+                <Button type="text" size="small" icon={<EditOutlined />} style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}} onClick={() => this.props.history.push(`/forms/${this.state.formName}/data/${record.name}`)} />
+              </Tooltip>
               <Popconfirm
                 title={`${i18next.t("general:Sure to delete")}: ${record.name} ?`}
                 onConfirm={() => this.deleteFormData(record)}
                 okText={i18next.t("general:OK")}
                 cancelText={i18next.t("general:Cancel")}
               >
-                <Button style={{marginBottom: "10px"}} type="primary" danger>{i18next.t("general:Delete")}</Button>
+                <Tooltip title={i18next.t("general:Delete")}>
+                  <Button type="text" size="small" danger icon={<DeleteOutlined />} style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}} />
+                </Tooltip>
               </Popconfirm>
             </div>
           );

--- a/web/src/FormListPage.js
+++ b/web/src/FormListPage.js
@@ -14,8 +14,8 @@
 
 import React from "react";
 import {Link} from "react-router-dom";
-import {Button, Col, List, Popconfirm, Row, Table} from "antd";
-import {DeleteOutlined} from "@ant-design/icons";
+import {Button, Col, List, Popconfirm, Row, Table, Tooltip} from "antd";
+import {DeleteOutlined, EditOutlined} from "@ant-design/icons";
 import moment from "moment";
 import BaseListPage from "./BaseListPage";
 import * as Setting from "./Setting";
@@ -203,19 +203,23 @@ class FormListPage extends BaseListPage {
         title: i18next.t("general:Action"),
         dataIndex: "action",
         key: "action",
-        width: "180px",
+        width: "130px",
         fixed: (Setting.isMobile()) ? "false" : "right",
         render: (text, record, index) => {
           return (
-            <div>
-              <Button style={{marginTop: "10px", marginBottom: "10px", marginRight: "10px"}} type="primary" onClick={() => this.props.history.push(`/forms/${record.name}`)}>{i18next.t("general:Edit")}</Button>
+            <div style={{display: "flex", alignItems: "center", gap: "2px", flexWrap: "nowrap"}}>
+              <Tooltip title={i18next.t("general:Edit")}>
+                <Button type="text" size="small" icon={<EditOutlined />} style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}} onClick={() => this.props.history.push(`/forms/${record.name}`)} />
+              </Tooltip>
               <Popconfirm
                 title={`${i18next.t("general:Sure to delete")}: ${record.name} ?`}
                 onConfirm={() => this.deleteForm(record)}
                 okText={i18next.t("general:OK")}
                 cancelText={i18next.t("general:Cancel")}
               >
-                <Button style={{marginBottom: "10px"}} type="primary" danger>{i18next.t("general:Delete")}</Button>
+                <Tooltip title={i18next.t("general:Delete")}>
+                  <Button type="text" size="small" danger icon={<DeleteOutlined />} style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}} />
+                </Tooltip>
               </Popconfirm>
             </div>
           );

--- a/web/src/GraphListPage.js
+++ b/web/src/GraphListPage.js
@@ -14,8 +14,8 @@
 
 import React from "react";
 import {Link} from "react-router-dom";
-import {Button, Popconfirm, Popover, Table} from "antd";
-import {DeleteOutlined} from "@ant-design/icons";
+import {Button, Popconfirm, Popover, Table, Tooltip} from "antd";
+import {DeleteOutlined, EditOutlined} from "@ant-design/icons";
 import moment from "moment";
 import BaseListPage from "./BaseListPage";
 import * as Setting from "./Setting";
@@ -230,19 +230,23 @@ class GraphListPage extends BaseListPage {
         title: i18next.t("general:Action"),
         dataIndex: "action",
         key: "action",
-        width: "180px",
+        width: "130px",
         fixed: (Setting.isMobile()) ? "false" : "right",
         render: (text, record, index) => {
           return (
-            <div>
-              <Button style={{marginTop: "10px", marginBottom: "10px", marginRight: "10px"}} type="primary" onClick={() => this.props.history.push(`/graphs/${record.name}`)}>{i18next.t("general:Edit")}</Button>
+            <div style={{display: "flex", alignItems: "center", gap: "2px", flexWrap: "nowrap"}}>
+              <Tooltip title={i18next.t("general:Edit")}>
+                <Button type="text" size="small" icon={<EditOutlined />} style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}} onClick={() => this.props.history.push(`/graphs/${record.name}`)} />
+              </Tooltip>
               <Popconfirm
                 title={`${i18next.t("general:Sure to delete")}: ${record.name} ?`}
                 onConfirm={() => this.deleteGraph(record)}
                 okText={i18next.t("general:OK")}
                 cancelText={i18next.t("general:Cancel")}
               >
-                <Button style={{marginBottom: "10px"}} type="primary" danger>{i18next.t("general:Delete")}</Button>
+                <Tooltip title={i18next.t("general:Delete")}>
+                  <Button type="text" size="small" danger icon={<DeleteOutlined />} style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}} />
+                </Tooltip>
               </Popconfirm>
             </div>
           );

--- a/web/src/ImageListPage.js
+++ b/web/src/ImageListPage.js
@@ -14,15 +14,14 @@
 
 import React from "react";
 import {Link} from "react-router-dom";
-import {Button, Popconfirm, Table} from "antd";
+import {Button, Dropdown, Popconfirm, Table} from "antd";
 import BaseListPage from "./BaseListPage";
 import moment from "moment";
 import * as Setting from "./Setting";
 import * as ImageBackend from "./backend/ImageBackend";
 import i18next from "i18next";
-import PopconfirmModal from "./modal/PopconfirmModal";
 import * as MachineBackend from "./backend/MachineBackend";
-import {DeleteOutlined} from "@ant-design/icons";
+import {DeleteOutlined, EditOutlined, MoreOutlined, PlusOutlined} from "@ant-design/icons";
 
 class ImageListPage extends BaseListPage {
   constructor(props) {
@@ -246,20 +245,53 @@ class ImageListPage extends BaseListPage {
         title: i18next.t("general:Action"),
         dataIndex: "action",
         key: "action",
-        width: "130px",
+        width: "150px",
         fixed: (Setting.isMobile()) ? "false" : "right",
         render: (text, image, index) => {
           return (
-            <div>
-              <Button style={{marginTop: "10px", marginRight: "10px"}} onClick={() => this.props.history.push(`/images/${image.owner}/${image.name}`)}>
-                {i18next.t("general:Edit")}
-              </Button>
-              <Button type="primary" style={{marginTop: "10px", marginBottom: "10px", marginRight: "10px"}} onClick={() => this.createMachine(image)}>
-                {i18next.t("image:Create machine")}
-              </Button>
-              <PopconfirmModal disabled={image.owner !== this.props.account.owner} style={{marginBottom: "10px"}}
-                title={i18next.t("general:Sure to delete") + `: ${image.name} ?`} onConfirm={() => this.deleteImage(index)}>
-              </PopconfirmModal>
+            <div style={{display: "flex", alignItems: "center", gap: "2px", flexWrap: "nowrap"}}>
+              <Button
+                style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}}
+                type="default"
+                icon={<EditOutlined />}
+                onClick={() => this.props.history.push(`/images/${image.owner}/${image.name}`)}
+                title={i18next.t("general:Edit")}
+              />
+              <Popconfirm
+                title={i18next.t("general:Sure to delete") + `: ${image.name} ?`}
+                onConfirm={() => this.deleteImage(index)}
+                disabled={image.owner !== this.props.account.owner}
+                okText={i18next.t("general:OK")}
+                cancelText={i18next.t("general:Cancel")}
+              >
+                <Button
+                  style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}}
+                  type="primary"
+                  danger
+                  disabled={image.owner !== this.props.account.owner}
+                  icon={<DeleteOutlined />}
+                />
+              </Popconfirm>
+              <Dropdown
+                menu={{
+                  items: [
+                    {
+                      key: "create-machine",
+                      icon: <PlusOutlined />,
+                      label: i18next.t("image:Create machine"),
+                    },
+                  ],
+                  onClick: ({key}) => {
+                    if (key === "create-machine") {this.createMachine(image);}
+                  },
+                }}
+                trigger={["click"]}
+              >
+                <Button
+                  style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}}
+                  icon={<MoreOutlined />}
+                />
+              </Dropdown>
             </div>
           );
         },

--- a/web/src/MachineListPage.js
+++ b/web/src/MachineListPage.js
@@ -14,15 +14,13 @@
 
 import React from "react";
 import {Link} from "react-router-dom";
-import {Button, Popconfirm, Table} from "antd";
+import {Button, Dropdown, Popconfirm, Table} from "antd";
 import moment from "moment";
 import * as Setting from "./Setting";
 import * as MachineBackend from "./backend/MachineBackend";
 import i18next from "i18next";
 import BaseListPage from "./BaseListPage";
-import PopconfirmModal from "./modal/PopconfirmModal";
-import ConnectModal from "./modal/ConnectModal";
-import {DeleteOutlined} from "@ant-design/icons";
+import {DeleteOutlined, EditOutlined, LinkOutlined, MoreOutlined} from "@ant-design/icons";
 
 class MachineListPage extends BaseListPage {
   constructor(props) {
@@ -207,28 +205,54 @@ class MachineListPage extends BaseListPage {
         title: i18next.t("general:Action"),
         dataIndex: "action",
         key: "action",
-        width: "260px",
+        width: "150px",
         fixed: (Setting.isMobile()) ? "false" : "right",
         render: (text, machine, index) => {
+          const connectUrl = `access/${machine.owner}/${machine.name}`;
           return (
-            <div>
-              <ConnectModal
-                owner={machine.owner}
-                name={machine.name}
-                category={"Node"}
-                node={machine}
-              />
+            <div style={{display: "flex", alignItems: "center", gap: "2px", flexWrap: "nowrap"}}>
               <Button
-                style={{marginTop: "10px", marginBottom: "10px", marginRight: "10px"}}
+                style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}}
+                type="default"
+                icon={<EditOutlined />}
                 onClick={() => this.props.history.push(`/machines/${machine.owner}/${machine.name}`)}
-              >{i18next.t("general:Edit")}
-              </Button>
-              <PopconfirmModal
-                disabled={machine.owner !== this.props.account.owner}
+                title={i18next.t("general:Edit")}
+              />
+              <Popconfirm
                 title={i18next.t("general:Sure to delete") + `: ${machine.name} ?`}
                 onConfirm={() => this.deleteMachine(index)}
+                disabled={machine.owner !== this.props.account.owner}
+                okText={i18next.t("general:OK")}
+                cancelText={i18next.t("general:Cancel")}
               >
-              </PopconfirmModal>
+                <Button
+                  style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}}
+                  type="primary"
+                  danger
+                  disabled={machine.owner !== this.props.account.owner}
+                  icon={<DeleteOutlined />}
+                />
+              </Popconfirm>
+              <Dropdown
+                menu={{
+                  items: [
+                    {
+                      key: "connect",
+                      icon: <LinkOutlined />,
+                      label: i18next.t("node:Connect"),
+                    },
+                  ],
+                  onClick: ({key}) => {
+                    if (key === "connect") {Setting.openLink(connectUrl);}
+                  },
+                }}
+                trigger={["click"]}
+              >
+                <Button
+                  style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}}
+                  icon={<MoreOutlined />}
+                />
+              </Dropdown>
             </div>
           );
         },

--- a/web/src/MessageListPage.js
+++ b/web/src/MessageListPage.js
@@ -14,7 +14,7 @@
 
 import React from "react";
 import {Link} from "react-router-dom";
-import {Button, Popconfirm, Popover, Switch, Table, Tag} from "antd";
+import {Button, Popconfirm, Popover, Switch, Table, Tag, Tooltip} from "antd";
 import BaseListPage from "./BaseListPage";
 import {ThemeDefault} from "./Conf";
 import * as Setting from "./Setting";
@@ -23,7 +23,7 @@ import * as ProviderBackend from "./backend/ProviderBackend";
 import moment from "moment";
 import i18next from "i18next";
 import * as Conf from "./Conf";
-import {DeleteOutlined} from "@ant-design/icons";
+import {DeleteOutlined, EditOutlined} from "@ant-design/icons";
 import VectorTooltip from "./VectorTooltip";
 
 class MessageListPage extends BaseListPage {
@@ -539,27 +539,23 @@ class MessageListPage extends BaseListPage {
         title: i18next.t("general:Action"),
         dataIndex: "action",
         key: "action",
-        width: "90px",
+        width: "130px",
         fixed: "right",
         render: (text, record, index) => {
           return (
-            <div>
-              <Button
-                style={{marginTop: "10px", marginBottom: "10px", marginRight: "10px"}}
-                type="primary"
-                onClick={() => this.props.history.push(`/messages/${record.name}`)}
-              >
-                {i18next.t("general:Edit")}
-              </Button>
+            <div style={{display: "flex", alignItems: "center", gap: "2px", flexWrap: "nowrap"}}>
+              <Tooltip title={i18next.t("general:Edit")}>
+                <Button type="text" size="small" icon={<EditOutlined />} style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}} onClick={() => this.props.history.push(`/messages/${record.name}`)} />
+              </Tooltip>
               <Popconfirm
                 title={`${i18next.t("general:Sure to delete")}: ${record.name} ?`}
                 onConfirm={() => this.deleteMessage(record)}
                 okText={i18next.t("general:OK")}
                 cancelText={i18next.t("general:Cancel")}
               >
-                <Button disabled={!Setting.isLocalAdminUser(this.props.account)} style={{marginBottom: "10px"}} type="primary" danger>
-                  {i18next.t("general:Delete")}
-                </Button>
+                <Tooltip title={i18next.t("general:Delete")}>
+                  <Button type="text" size="small" danger icon={<DeleteOutlined />} style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}} disabled={!Setting.isLocalAdminUser(this.props.account)} />
+                </Tooltip>
               </Popconfirm>
             </div>
           );

--- a/web/src/NodeListPage.js
+++ b/web/src/NodeListPage.js
@@ -14,15 +14,13 @@
 
 import React from "react";
 import {Link} from "react-router-dom";
-import {Button, Popconfirm, Switch, Table} from "antd";
+import {Button, Dropdown, Popconfirm, Switch, Table} from "antd";
 import BaseListPage from "./BaseListPage";
 import moment from "moment";
 import * as Setting from "./Setting";
 import * as NodeBackend from "./backend/NodeBackend";
 import i18next from "i18next";
-import PopconfirmModal from "./modal/PopconfirmModal";
-import ConnectModal from "./modal/ConnectModal";
-import {DeleteOutlined} from "@ant-design/icons";
+import {DeleteOutlined, EditOutlined, LinkOutlined, MoreOutlined} from "@ant-design/icons";
 
 class NodeListPage extends BaseListPage {
   constructor(props) {
@@ -239,29 +237,57 @@ class NodeListPage extends BaseListPage {
         title: i18next.t("general:Action"),
         dataIndex: "action",
         key: "action",
-        width: "260px",
+        width: "150px",
         fixed: (Setting.isMobile()) ? "false" : "right",
         render: (text, node, index) => {
+          const connectUrl = `access/${node.owner}/${node.name}`;
           return (
-            <div>
-              <ConnectModal
-                disabled={node.owner !== this.props.account.owner}
-                owner={node.owner}
-                name={node.name}
-                category={"Node"}
-                node={node}
-              />
+            <div style={{display: "flex", alignItems: "center", gap: "2px", flexWrap: "nowrap"}}>
               <Button
-                style={{marginTop: "10px", marginBottom: "10px", marginRight: "10px"}}
+                style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}}
+                type="default"
+                icon={<EditOutlined />}
                 onClick={() => this.props.history.push(`/nodes/${node.name}`)}
-              >{i18next.t("general:Edit")}
-              </Button>
-              <PopconfirmModal
-                disabled={node.owner !== this.props.account.owner}
+                title={i18next.t("general:Edit")}
+              />
+              <Popconfirm
                 title={i18next.t("general:Sure to delete") + `: ${node.name} ?`}
                 onConfirm={() => this.deleteNode(index)}
+                disabled={node.owner !== this.props.account.owner}
+                okText={i18next.t("general:OK")}
+                cancelText={i18next.t("general:Cancel")}
               >
-              </PopconfirmModal>
+                <Button
+                  style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}}
+                  type="primary"
+                  danger
+                  disabled={node.owner !== this.props.account.owner}
+                  icon={<DeleteOutlined />}
+                />
+              </Popconfirm>
+              <Dropdown
+                menu={{
+                  items: [
+                    {
+                      key: "connect",
+                      icon: <LinkOutlined />,
+                      label: i18next.t("node:Connect"),
+                      disabled: node.owner !== this.props.account.owner,
+                    },
+                  ],
+                  onClick: ({key}) => {
+                    if (key === "connect") {
+                      Setting.openLink(connectUrl);
+                    }
+                  },
+                }}
+                trigger={["click"]}
+              >
+                <Button
+                  style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}}
+                  icon={<MoreOutlined />}
+                />
+              </Dropdown>
             </div>
           );
         },

--- a/web/src/PodListPage.js
+++ b/web/src/PodListPage.js
@@ -14,14 +14,13 @@
 
 import React from "react";
 import {Link} from "react-router-dom";
-import {Button, Popconfirm, Table} from "antd";
+import {Button, Popconfirm, Table, Tooltip} from "antd";
 import moment from "moment";
 import * as Setting from "./Setting";
 import * as PodBackend from "./backend/PodBackend";
 import i18next from "i18next";
 import BaseListPage from "./BaseListPage";
-import PopconfirmModal from "./modal/PopconfirmModal";
-import {DeleteOutlined} from "@ant-design/icons";
+import {DeleteOutlined, EditOutlined} from "@ant-design/icons";
 
 class PodListPage extends BaseListPage {
   constructor(props) {
@@ -167,22 +166,25 @@ class PodListPage extends BaseListPage {
         title: i18next.t("general:Action"),
         dataIndex: "action",
         key: "action",
-        width: "260px",
+        width: "130px",
         fixed: (Setting.isMobile()) ? "false" : "right",
         render: (text, pod, index) => {
           return (
-            <div>
-              <Button
-                style={{marginTop: "10px", marginBottom: "10px", marginRight: "10px"}}
-                onClick={() => this.props.history.push(`/pods/${pod.owner}/${pod.name}`)}
-              >{i18next.t("general:Edit")}
-              </Button>
-              <PopconfirmModal
+            <div style={{display: "flex", alignItems: "center", gap: "2px", flexWrap: "nowrap"}}>
+              <Tooltip title={i18next.t("general:Edit")}>
+                <Button type="text" size="small" icon={<EditOutlined />} style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}} onClick={() => this.props.history.push(`/pods/${pod.owner}/${pod.name}`)} />
+              </Tooltip>
+              <Popconfirm
                 disabled={pod.owner !== this.props.account.owner}
                 title={i18next.t("general:Sure to delete") + `: ${pod.name} ?`}
                 onConfirm={() => this.deletePod(index)}
+                okText={i18next.t("general:OK")}
+                cancelText={i18next.t("general:Cancel")}
               >
-              </PopconfirmModal>
+                <Tooltip title={i18next.t("general:Delete")}>
+                  <Button type="text" size="small" danger icon={<DeleteOutlined />} style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}} />
+                </Tooltip>
+              </Popconfirm>
             </div>
           );
         },

--- a/web/src/ProviderEditPage.js
+++ b/web/src/ProviderEditPage.js
@@ -317,32 +317,47 @@ class ProviderEditPage extends React.Component {
 
     const sectionCardStyle = {
       marginBottom: "16px",
-      borderRadius: "12px",
+      borderRadius: "14px",
       boxShadow: "0 1px 3px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04)",
+      padding: "18px",
+    };
+
+    const cardHeadStyle = {background: "transparent", borderBottom: "none", fontWeight: 600, fontSize: "15px"};
+
+    const btnStyle = {
+      backgroundColor: "#F8F9FA",
+      borderColor: "rgb(229, 229, 234)",
+      border: "1px solid #E5E5EA",
+      borderRadius: "10px",
+      padding: "6px 10px",
     };
 
     return (
-      <div style={{marginLeft: "5px"}}>
-        <div style={{marginBottom: "16px", display: "flex", alignItems: "center", gap: "12px"}}>
-          <span style={{fontSize: "16px", fontWeight: 600}}>
+      <div>
+        <div style={{marginBottom: "16px", display: "flex", alignItems: "center", justifyContent: "space-between"}}>
+          <span style={{fontSize: "22px", fontWeight: 600}}>
             {isRemote ? i18next.t("general:View") : i18next.t("provider:Edit Provider")}
           </span>
-          {!isRemote && <Button onClick={() => this.submitProviderEdit(false)}>{i18next.t("general:Save")}</Button>}
-          {!isRemote && <Button type="primary" onClick={() => this.submitProviderEdit(true)}>{i18next.t("general:Save & Exit")}</Button>}
-          {!isRemote && this.state.isNewProvider && <Button onClick={() => this.cancelProviderEdit()}>{i18next.t("general:Cancel")}</Button>}
+          {!isRemote && (
+            <div style={{display: "flex", gap: "8px", marginRight: "4px"}}>
+              <Button style={btnStyle} onClick={() => this.submitProviderEdit(false)}>{i18next.t("general:Save")}</Button>
+              <Button style={btnStyle} onClick={() => this.submitProviderEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
+              {this.state.isNewProvider && <Button style={btnStyle} onClick={() => this.cancelProviderEdit()}>{i18next.t("general:Cancel")}</Button>}
+            </div>
+          )}
         </div>
 
         {/* Card 1: General Settings */}
-        <Card size="small" title={i18next.t("provider:General Settings")} style={sectionCardStyle} type="inner">
+        <Card size="small" title={i18next.t("provider:General Settings")} style={sectionCardStyle} headStyle={cardHeadStyle}>
           <Row style={{marginTop: "10px"}} gutter={16}>
             <Col style={{marginTop: "5px"}} span={Setting.isMobile() ? 22 : 11}>
-              <div style={{marginBottom: "4px"}}>{Setting.getLabel(i18next.t("general:ID"), i18next.t("general:Name - Tooltip"))} :</div>
+              <div style={{marginBottom: "4px"}}>{Setting.getLabel(i18next.t("general:ID"), i18next.t("general:Name - Tooltip"))}</div>
               <Input disabled={isRemote} value={provider.name} onChange={e => {
                 this.updateProviderField("name", e.target.value);
               }} />
             </Col>
             <Col style={{marginTop: "5px"}} span={Setting.isMobile() ? 22 : 11}>
-              <div style={{marginBottom: "4px"}}>{Setting.getLabel(i18next.t("general:Display name"), i18next.t("general:Display name - Tooltip"))} :</div>
+              <div style={{marginBottom: "4px"}}>{Setting.getLabel(i18next.t("general:Display name"), i18next.t("general:Display name - Tooltip"))}</div>
               <Input disabled={isRemote} value={provider.displayName} onChange={e => {
                 this.updateProviderField("displayName", e.target.value);
               }} />
@@ -351,7 +366,7 @@ class ProviderEditPage extends React.Component {
           {this.shouldShowProviderDisplayName2Field() ? (
             <Row style={{marginTop: "20px"}} gutter={16}>
               <Col span={colSpan}>
-                <div style={{marginBottom: "4px"}}>{Setting.getLabel(i18next.t("general:Display name 2"), i18next.t("general:Display name 2 - Tooltip"))} :</div>
+                <div style={{marginBottom: "4px"}}>{Setting.getLabel(i18next.t("general:Display name 2"), i18next.t("general:Display name 2 - Tooltip"))}</div>
                 <Input disabled={isRemote} value={provider.displayName2 ?? ""} onChange={e => {
                   this.updateProviderField("displayName2", e.target.value);
                 }} />
@@ -360,7 +375,7 @@ class ProviderEditPage extends React.Component {
           ) : null}
           <Row style={{marginTop: "20px"}} gutter={16}>
             <Col style={{marginTop: "5px"}} span={Setting.isMobile() ? 22 : 7}>
-              <div style={{marginBottom: "4px"}}>{Setting.getLabel(i18next.t("general:Category"), i18next.t("provider:Category - Tooltip"))} :</div>
+              <div style={{marginBottom: "4px"}}>{Setting.getLabel(i18next.t("general:Category"), i18next.t("provider:Category - Tooltip"))}</div>
               <Select virtual={false} disabled={isRemote} style={{width: "100%"}} value={provider.category} onChange={(value => {
                 this.updateProviderField("category", value);
                 if (value === "Storage") {
@@ -410,7 +425,7 @@ class ProviderEditPage extends React.Component {
               </Select>
             </Col>
             <Col style={{marginTop: "5px"}} span={Setting.isMobile() ? 22 : 8}>
-              <div style={{marginBottom: "4px"}}>{Setting.getLabel(i18next.t("general:Type"), i18next.t("general:Type - Tooltip"))} :</div>
+              <div style={{marginBottom: "4px"}}>{Setting.getLabel(i18next.t("general:Type"), i18next.t("general:Type - Tooltip"))}</div>
               <Select virtual={false} disabled={isRemote} style={{width: "100%"}} value={provider.type} onChange={(value => {
                 this.updateProviderField("type", value);
                 if (provider.category === "Model") {
@@ -518,7 +533,7 @@ class ProviderEditPage extends React.Component {
             {
               !["Model", "Embedding", "Text-to-Speech", "Speech-to-Text", "Bot"].includes(provider.category) ? null : (
                 <Col style={{marginTop: "5px"}} span={Setting.isMobile() ? 22 : 7}>
-                  <div style={{marginBottom: "4px"}}>{Setting.getLabel(i18next.t("provider:Sub type"), i18next.t("provider:Sub type - Tooltip"))} :</div>
+                  <div style={{marginBottom: "4px"}}>{Setting.getLabel(i18next.t("provider:Sub type"), i18next.t("provider:Sub type - Tooltip"))}</div>
                   {provider.type === "Ollama" ? (
                     <AutoComplete
                       style={{width: "100%"}}
@@ -559,7 +574,7 @@ class ProviderEditPage extends React.Component {
             (this.state.provider.category === "Model" && this.state.provider.type === "OpenAI Compatible") ? (
               <Row style={{marginTop: "20px"}} >
                 <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                  {this.getProviderUrlLabel(this.state.provider)} :
+                  {this.getProviderUrlLabel(this.state.provider)}
                 </Col>
                 <Col span={22} >
                   <Input prefix={<LinkOutlined />} value={this.state.provider.providerUrl} onChange={e => {
@@ -573,7 +588,7 @@ class ProviderEditPage extends React.Component {
             (this.state.provider.type === "Cohere" && this.state.provider.category === "Embedding") && (
               <Row style={{marginTop: "20px"}} >
                 <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                  {Setting.getLabel(i18next.t("provider:Input type"), i18next.t("provider:Input type - Tooltip"))} :
+                  {Setting.getLabel(i18next.t("provider:Input type"), i18next.t("provider:Input type - Tooltip"))}
                 </Col>
                 <Col span={22} >
                   <Select virtual={false} disabled={isRemote} style={{width: "100%"}} value={this.state.provider.clientId} onChange={(value => {this.updateProviderField("clientId", value);})}>
@@ -590,7 +605,7 @@ class ProviderEditPage extends React.Component {
             this.shouldShowClientIdInput(this.state.provider) ? (
               <Row style={{marginTop: "20px"}} >
                 <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                  {this.getClientIdLabel(this.state.provider)} :
+                  {this.getClientIdLabel(this.state.provider)}
                 </Col>
                 <Col span={22} >
                   <Input disabled={isRemote} value={this.state.provider.clientId} onChange={e => {
@@ -604,7 +619,7 @@ class ProviderEditPage extends React.Component {
             this.state.provider.category === "Chat" ? (
               <Row style={{marginTop: "20px"}} >
                 <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                  {this.getClientIdLabel(this.state.provider)} :
+                  {this.getClientIdLabel(this.state.provider)}
                 </Col>
                 <Col span={22} >
                   <Select virtual={false} disabled={isRemote} style={{width: "100%"}} value={this.state.provider.clientId}
@@ -626,7 +641,7 @@ class ProviderEditPage extends React.Component {
               <>
                 <Row style={{marginTop: "20px"}}>
                   <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                    {Setting.getLabel(i18next.t("provider:Compatible provider"), i18next.t("provider:Compatible provider - Tooltip"))} :
+                    {Setting.getLabel(i18next.t("provider:Compatible provider"), i18next.t("provider:Compatible provider - Tooltip"))}
                   </Col>
                   <Col span={22} >
                     <AutoComplete
@@ -649,7 +664,7 @@ class ProviderEditPage extends React.Component {
               <>
                 <Row style={{marginTop: "20px"}} >
                   <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                    {Setting.getLabel(i18next.t("provider:Input price / 1k tokens"), i18next.t("provider:Input price / 1k tokens - Tooltip"))} :
+                    {Setting.getLabel(i18next.t("provider:Input price / 1k tokens"), i18next.t("provider:Input price / 1k tokens - Tooltip"))}
                   </Col>
                   <Col span={22} >
                     <InputNumber min={0} value={this.state.provider.inputPricePerThousandTokens} onChange={value => {
@@ -659,7 +674,7 @@ class ProviderEditPage extends React.Component {
                 </Row>
                 <Row style={{marginTop: "20px"}} >
                   <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                    {Setting.getLabel(i18next.t("provider:Output price / 1k tokens"), i18next.t("provider:Output price / 1k tokens - Tooltip"))} :
+                    {Setting.getLabel(i18next.t("provider:Output price / 1k tokens"), i18next.t("provider:Output price / 1k tokens - Tooltip"))}
                   </Col>
                   <Col span={22} >
                     <InputNumber min={0} value={this.state.provider.outputPricePerThousandTokens} onChange={value => {
@@ -675,7 +690,7 @@ class ProviderEditPage extends React.Component {
               <>
                 <Row style={{marginTop: "20px"}} >
                   <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                    {Setting.getLabel(i18next.t("provider:Input price / 1k tokens"), i18next.t("provider:Input price / 1k tokens - Tooltip"))} :
+                    {Setting.getLabel(i18next.t("provider:Input price / 1k tokens"), i18next.t("provider:Input price / 1k tokens - Tooltip"))}
                   </Col>
                   <Col span={22} >
                     <InputNumber min={0} value={this.state.provider.inputPricePerThousandTokens} onChange={value => {
@@ -691,7 +706,7 @@ class ProviderEditPage extends React.Component {
               <>
                 <Row style={{marginTop: "20px"}} >
                   <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                    {Setting.getLabel(i18next.t("provider:Currency"), i18next.t("provider:Currency - Tooltip"))} :
+                    {Setting.getLabel(i18next.t("provider:Currency"), i18next.t("provider:Currency - Tooltip"))}
                   </Col>
                   <Col span={22} >
                     <Select virtual={false} disabled={isRemote} style={{width: "100%"}} value={this.state.provider.currency} onChange={(value => {
@@ -722,7 +737,7 @@ class ProviderEditPage extends React.Component {
               <>
                 <Row style={{marginTop: "20px"}}>
                   <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                    {Setting.getLabel(i18next.t("provider:Flavor"), i18next.t("provider:Flavor - Tooltip"))} :
+                    {Setting.getLabel(i18next.t("provider:Flavor"), i18next.t("provider:Flavor - Tooltip"))}
                   </Col>
                   <Col span={22} >
                     <Select virtual={false} disabled={isRemote} style={{width: "100%"}} value={this.state.provider.flavor} onChange={(value => {
@@ -742,7 +757,7 @@ class ProviderEditPage extends React.Component {
             this.shouldShowClientSecretInput(this.state.provider) ? (
               <Row style={{marginTop: "20px"}} >
                 <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                  {this.getClientSecretLabel(this.state.provider)} :
+                  {this.getClientSecretLabel(this.state.provider)}
                 </Col>
                 <Col span={22} >
                   <Input.Password disabled={isRemote} value={this.state.provider.clientSecret} onChange={e => {
@@ -757,7 +772,7 @@ class ProviderEditPage extends React.Component {
               <>
                 <Row style={{marginTop: "20px"}} >
                   <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                    {Setting.getLabel(i18next.t("provider:Enable thinking"), i18next.t("provider:Enable thinking - Tooltip"))} :
+                    {Setting.getLabel(i18next.t("provider:Enable thinking"), i18next.t("provider:Enable thinking - Tooltip"))}
                   </Col>
                   <Col span={22} >
                     <Switch disabled={isRemote} checked={this.state.provider.enableThinking} onChange={checked => {
@@ -769,7 +784,7 @@ class ProviderEditPage extends React.Component {
                   this.state.provider.enableThinking && (
                     <Row style={{marginTop: "20px"}} >
                       <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                        {Setting.getLabel(i18next.t("provider:Thinking tokens"), i18next.t("provider:Thinking tokens - Tooltip"))} :
+                        {Setting.getLabel(i18next.t("provider:Thinking tokens"), i18next.t("provider:Thinking tokens - Tooltip"))}
                       </Col>
                       <Col span={22} >
                         <InputNumber min={1024} max={Setting.getThinkingModelMaxTokens(this.state.provider.subType) - 1} value={this.state.provider.topK || 1024} onChange={value => {
@@ -786,7 +801,7 @@ class ProviderEditPage extends React.Component {
             ["Storage", "Model", "Embedding", "Text-to-Speech", "Speech-to-Text", "Scan"].includes(this.state.provider.category) || (this.state.provider.category === "Blockchain" && this.state.provider.type === "Ethereum") || (this.state.provider.category === "Private Cloud" && this.state.provider.type === "Kubernetes") ? null : (
               <Row style={{marginTop: "20px"}} >
                 <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                  {this.getRegionLabel(this.state.provider)} :
+                  {this.getRegionLabel(this.state.provider)}
                 </Col>
                 <Col span={22} >
                   <Input disabled={isRemote} value={this.state.provider.region} onChange={e => {
@@ -803,7 +818,7 @@ class ProviderEditPage extends React.Component {
                   <>
                     <Row style={{marginTop: "20px"}}>
                       <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                        {Setting.getLabel(i18next.t("provider:Chain"), i18next.t("provider:Chain - Tooltip"))} :
+                        {Setting.getLabel(i18next.t("provider:Chain"), i18next.t("provider:Chain - Tooltip"))}
                       </Col>
                       <Col span={22}>
                         <Input disabled={isRemote} value={this.state.provider.chain} onChange={e => {
@@ -813,7 +828,7 @@ class ProviderEditPage extends React.Component {
                     </Row>
                     <Row style={{marginTop: "20px"}}>
                       <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                        {this.getNetworkLabel(this.state.provider)} :
+                        {this.getNetworkLabel(this.state.provider)}
                       </Col>
                       <Col span={22}>
                         <Input disabled={isRemote} value={this.state.provider.network} onChange={e => {
@@ -827,7 +842,7 @@ class ProviderEditPage extends React.Component {
                   <>
                     <Row style={{marginTop: "20px"}}>
                       <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                        {Setting.getLabel(i18next.t("provider:Auth type"), i18next.t("provider:Auth type - Tooltip"))} :
+                        {Setting.getLabel(i18next.t("provider:Auth type"), i18next.t("provider:Auth type - Tooltip"))}
                       </Col>
                       <Col span={22}>
                         <Select
@@ -846,7 +861,7 @@ class ProviderEditPage extends React.Component {
                     </Row>
                     <Row style={{marginTop: "20px"}} >
                       <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                        {Setting.getLabel(i18next.t("cert:User cert"), i18next.t("cert:User cert - Tooltip"))} :
+                        {Setting.getLabel(i18next.t("cert:User cert"), i18next.t("cert:User cert - Tooltip"))}
                       </Col>
                       <Col span={editorWidth} >
                         <Button style={{marginRight: "10px", marginBottom: "10px"}} disabled={this.state.provider.userCert === ""} onClick={() => {
@@ -869,7 +884,7 @@ class ProviderEditPage extends React.Component {
                       </Col>
                       <Col span={1} />
                       <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                        {Setting.getLabel(i18next.t("cert:User key"), i18next.t("cert:User key - Tooltip"))} :
+                        {Setting.getLabel(i18next.t("cert:User key"), i18next.t("cert:User key - Tooltip"))}
                       </Col>
                       <Col span={editorWidth} >
                         <Button style={{marginRight: "10px", marginBottom: "10px"}} disabled={this.state.provider.userKey === ""} onClick={() => {
@@ -893,7 +908,7 @@ class ProviderEditPage extends React.Component {
                     </Row>
                     <Row style={{marginTop: "20px"}} >
                       <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                        {Setting.getLabel(i18next.t("cert:Sign cert"), i18next.t("cert:Sign cert - Tooltip"))} :
+                        {Setting.getLabel(i18next.t("cert:Sign cert"), i18next.t("cert:Sign cert - Tooltip"))}
                       </Col>
                       <Col span={editorWidth} >
                         <Button style={{marginRight: "10px", marginBottom: "10px"}} disabled={this.state.provider.signCert === ""} onClick={() => {
@@ -916,7 +931,7 @@ class ProviderEditPage extends React.Component {
                       </Col>
                       <Col span={1} />
                       <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                        {Setting.getLabel(i18next.t("cert:Sign key"), i18next.t("cert:Sign key - Tooltip"))} :
+                        {Setting.getLabel(i18next.t("cert:Sign key"), i18next.t("cert:Sign key - Tooltip"))}
                       </Col>
                       <Col span={editorWidth} >
                         <Button style={{marginRight: "10px", marginBottom: "10px"}} disabled={this.state.provider.signKey === ""} onClick={() => {
@@ -944,7 +959,7 @@ class ProviderEditPage extends React.Component {
                   <>
                     <Row style={{marginTop: "20px"}}>
                       <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                        {this.getContractNameLabel(this.state.provider)} :
+                        {this.getContractNameLabel(this.state.provider)}
                       </Col>
                       <Col span={22}>
                         <Input disabled={isRemote} value={this.state.provider.contractName} onChange={e => {
@@ -954,7 +969,7 @@ class ProviderEditPage extends React.Component {
                     </Row>
                     <Row style={{marginTop: "20px"}}>
                       <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                        {Setting.getLabel(i18next.t("provider:Invoke method"), i18next.t("provider:Invoke method - Tooltip"))} :
+                        {Setting.getLabel(i18next.t("provider:Invoke method"), i18next.t("provider:Invoke method - Tooltip"))}
                       </Col>
                       <Col span={22}>
                         <Input disabled={isRemote} value={this.state.provider.contractMethod} onChange={e => {
@@ -966,7 +981,7 @@ class ProviderEditPage extends React.Component {
                 ) : null}
                 <Row style={{marginTop: "20px"}}>
                   <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                    {Setting.getLabel(i18next.t("provider:Browser URL"), i18next.t("provider:Browser URL - Tooltip"))} :
+                    {Setting.getLabel(i18next.t("provider:Browser URL"), i18next.t("provider:Browser URL - Tooltip"))}
                   </Col>
                   <Col span={22}>
                     <Input prefix={<LinkOutlined />} value={this.state.provider.browserUrl}
@@ -981,7 +996,7 @@ class ProviderEditPage extends React.Component {
           }
           <Row style={{marginTop: "20px"}} >
             <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-              {Setting.getLabel(i18next.t("store:Is default"), i18next.t("store:Is default - Tooltip"))} :
+              {Setting.getLabel(i18next.t("store:Is default"), i18next.t("store:Is default - Tooltip"))}
             </Col>
             <Col span={1}>
               <Switch disabled={isRemote} checked={this.state.provider.isDefault} onChange={checked => {
@@ -991,7 +1006,7 @@ class ProviderEditPage extends React.Component {
           </Row>
           <Row style={{marginTop: "20px"}} >
             <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-              {Setting.getLabel(i18next.t("provider:Is remote"), i18next.t("provider:Is remote - Tooltip"))} :
+              {Setting.getLabel(i18next.t("provider:Is remote"), i18next.t("provider:Is remote - Tooltip"))}
             </Col>
             <Col span={1}>
               <Switch disabled checked={this.state.provider.isRemote} />
@@ -999,7 +1014,7 @@ class ProviderEditPage extends React.Component {
           </Row>
           <Row style={{marginTop: "20px"}}>
             <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-              {Setting.getLabel(i18next.t("general:State"), i18next.t("general:State - Tooltip"))} :
+              {Setting.getLabel(i18next.t("general:State"), i18next.t("general:State - Tooltip"))}
             </Col>
             <Col span={22}>
               <Select virtual={false} disabled={isRemote} style={{width: "100%"}} value={this.state.provider.state} onChange={value => {
@@ -1015,7 +1030,7 @@ class ProviderEditPage extends React.Component {
             this.state.provider.category === "Model" ? (
               <Row style={{marginTop: "20px"}} >
                 <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                  {Setting.getLabel(i18next.t("provider:Provider key"), i18next.t("provider:Provider key - Tooltip"))} :
+                  {Setting.getLabel(i18next.t("provider:Provider key"), i18next.t("provider:Provider key - Tooltip"))}
                 </Col>
                 <Col span={22} >
                   <Input.Password
@@ -1033,7 +1048,7 @@ class ProviderEditPage extends React.Component {
 
         {/* Card 2: Advanced Model Parameters */}
         {isModelProvider && (this.isTemperatureEnabled(provider) || this.isTopPEnabled(provider) || (provider.type === "Gemini")) && (
-          <Card size="small" title={i18next.t("provider:Advanced Model Parameters")} style={sectionCardStyle} type="inner">
+          <Card size="small" title={i18next.t("provider:Advanced Model Parameters")} style={sectionCardStyle} headStyle={cardHeadStyle}>
             {this.isTemperatureEnabled(provider) ? (
               <Row style={{marginTop: "10px"}} gutter={16}>
                 <Col span={Setting.isMobile() ? 22 : 14}>
@@ -1178,7 +1193,7 @@ class ProviderEditPage extends React.Component {
             <>
               <Row style={{marginTop: "20px"}}>
                 <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                  {Setting.getLabel(i18next.t("provider:API version"), i18next.t("provider:API version - Tooltip"))} :
+                  {Setting.getLabel(i18next.t("provider:API version"), i18next.t("provider:API version - Tooltip"))}
                 </Col>
                 <Col span={22} >
                   <AutoComplete disabled={isRemote} style={{width: "100%"}} value={this.state.provider.apiVersion}
@@ -1191,7 +1206,7 @@ class ProviderEditPage extends React.Component {
           ) : null
         }
         {/* Card 3: Provider Test */}
-        <Card size="small" title={i18next.t("provider:Provider Test")} style={sectionCardStyle} type="inner">
+        <Card size="small" title={i18next.t("provider:Provider Test")} style={sectionCardStyle} headStyle={cardHeadStyle}>
           <ModelTestWidget
             provider={this.state.provider}
             originalProvider={this.state.originalProvider}
@@ -1225,7 +1240,7 @@ class ProviderEditPage extends React.Component {
           this.state.provider.category === "Chat" ? (
             <Row style={{marginTop: "20px"}} >
               <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                {Setting.getLabel(i18next.t("provider:Domain"), i18next.t("provider:Domain - Tooltip"))} :
+                {Setting.getLabel(i18next.t("provider:Domain"), i18next.t("provider:Domain - Tooltip"))}
               </Col>
               <Col span={22} >
                 <Input prefix={<LinkOutlined />} disabled={isRemote} value={this.state.provider.domain} onChange={e => {
@@ -1239,7 +1254,7 @@ class ProviderEditPage extends React.Component {
           (this.state.provider.category === "Chat" && this.state.provider.type === "Telegram") ? (
             <Row style={{marginTop: "20px"}} >
               <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                {Setting.getLabel(i18next.t("provider:Webhook"), i18next.t("provider:Webhook - Tooltip"))} :
+                {Setting.getLabel(i18next.t("provider:Webhook"), i18next.t("provider:Webhook - Tooltip"))}
               </Col>
               <Col span={22} >
                 <Button disabled={isRemote} type="primary" onClick={() => this.setTelegramWebhook()}>
@@ -1253,7 +1268,7 @@ class ProviderEditPage extends React.Component {
           this.state.provider.category === "Private Cloud" && this.state.provider.type === "Kubernetes" ? (
             <Row style={{marginTop: "20px"}} >
               <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                {Setting.getLabel(i18next.t("provider:Config text"), i18next.t("provider:Config text - Tooltip"))} :
+                {Setting.getLabel(i18next.t("provider:Config text"), i18next.t("provider:Config text - Tooltip"))}
               </Col>
               <Col span={22} >
                 <Editor
@@ -1275,7 +1290,7 @@ class ProviderEditPage extends React.Component {
             <>
               <Row style={{marginTop: "20px"}} >
                 <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                  {Setting.getLabel(i18next.t("scan:Result summary"), i18next.t("scan:Result summary - Tooltip"))} :
+                  {Setting.getLabel(i18next.t("scan:Result summary"), i18next.t("scan:Result summary - Tooltip"))}
                 </Col>
                 <Col span={22} >
                   <Input value={this.state.provider.resultSummary} disabled />
@@ -1283,7 +1298,7 @@ class ProviderEditPage extends React.Component {
               </Row>
               <Row style={{marginTop: "20px"}} >
                 <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                  {Setting.getLabel(i18next.t("scan:Runner"), i18next.t("scan:Runner - Tooltip"))} :
+                  {Setting.getLabel(i18next.t("scan:Runner"), i18next.t("scan:Runner - Tooltip"))}
                 </Col>
                 <Col span={22} >
                   <Input value={this.state.provider.runner} disabled />
@@ -1291,7 +1306,7 @@ class ProviderEditPage extends React.Component {
               </Row>
               <Row style={{marginTop: "20px"}} >
                 <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                  {Setting.getLabel(i18next.t("general:Error"), i18next.t("scan:Error - Tooltip"))} :
+                  {Setting.getLabel(i18next.t("general:Error"), i18next.t("scan:Error - Tooltip"))}
                 </Col>
                 <Col span={22} >
                   <Input.TextArea value={this.state.provider.errorText} disabled rows={4} />
@@ -1304,7 +1319,7 @@ class ProviderEditPage extends React.Component {
           (this.state.provider.category !== "Model" || this.modelCategoryShowsProviderUrlInput(this.state.provider.type)) ? (
             <Row style={{marginTop: "20px"}} >
               <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                {this.getProviderUrlLabel(this.state.provider)} :
+                {this.getProviderUrlLabel(this.state.provider)}
               </Col>
               <Col span={22} >
                 <Input prefix={<LinkOutlined />} value={this.state.provider.providerUrl} onChange={e => {
@@ -1383,19 +1398,11 @@ class ProviderEditPage extends React.Component {
   }
 
   render() {
-    const isRemote = this.state.provider?.isRemote;
     return (
-      <div>
+      <div style={{background: "#F1F3F5", padding: "16px 20px 32px", minHeight: "100vh"}}>
         {
           this.state.provider !== null ? this.renderProvider() : <Loading type="page" tip={i18next.t("general:Loading")} />
         }
-        {!isRemote && (
-          <div style={{marginTop: "20px", marginLeft: "40px"}}>
-            <Button size="large" onClick={() => this.submitProviderEdit(false)}>{i18next.t("general:Save")}</Button>
-            <Button style={{marginLeft: "20px"}} type="primary" size="large" onClick={() => this.submitProviderEdit(true)}>{i18next.t("general:Save & Exit")}</Button>
-            {this.state.isNewProvider && <Button style={{marginLeft: "20px"}} size="large" onClick={() => this.cancelProviderEdit()}>{i18next.t("general:Cancel")}</Button>}
-          </div>
-        )}
       </div>
     );
   }

--- a/web/src/ProviderEditPage.js
+++ b/web/src/ProviderEditPage.js
@@ -310,791 +310,869 @@ class ProviderEditPage extends React.Component {
   renderProvider() {
     const editorWidth = Setting.isMobile() ? 22 : 9;
     const isRemote = this.state.provider.isRemote;
+    const provider = this.state.provider;
+    const isModelProvider = provider.category === "Model";
+
+    const colSpan = Setting.isMobile() ? 22 : 22;
+
+    const sectionCardStyle = {
+      marginBottom: "16px",
+      borderRadius: "12px",
+      boxShadow: "0 1px 3px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04)",
+    };
+
     return (
-      <Card size="small" title={
-        <div>
-          {isRemote ? i18next.t("general:View") : i18next.t("provider:Edit Provider")}&nbsp;&nbsp;&nbsp;&nbsp;
+      <div style={{marginLeft: "5px"}}>
+        <div style={{marginBottom: "16px", display: "flex", alignItems: "center", gap: "12px"}}>
+          <span style={{fontSize: "16px", fontWeight: 600}}>
+            {isRemote ? i18next.t("general:View") : i18next.t("provider:Edit Provider")}
+          </span>
           {!isRemote && <Button onClick={() => this.submitProviderEdit(false)}>{i18next.t("general:Save")}</Button>}
-          {!isRemote && <Button style={{marginLeft: "20px"}} type="primary" onClick={() => this.submitProviderEdit(true)}>{i18next.t("general:Save & Exit")}</Button>}
-          {!isRemote && this.state.isNewProvider && <Button style={{marginLeft: "20px"}} onClick={() => this.cancelProviderEdit()}>{i18next.t("general:Cancel")}</Button>}
+          {!isRemote && <Button type="primary" onClick={() => this.submitProviderEdit(true)}>{i18next.t("general:Save & Exit")}</Button>}
+          {!isRemote && this.state.isNewProvider && <Button onClick={() => this.cancelProviderEdit()}>{i18next.t("general:Cancel")}</Button>}
         </div>
-      } style={{marginLeft: "5px"}} type="inner">
-        <Row style={{marginTop: "10px"}} >
-          <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-            {Setting.getLabel(i18next.t("general:Name"), i18next.t("general:Name - Tooltip"))} :
-          </Col>
-          <Col span={22} >
-            <Input disabled={isRemote} value={this.state.provider.name} onChange={e => {
-              this.updateProviderField("name", e.target.value);
-            }} />
-          </Col>
-        </Row>
-        <Row style={{marginTop: "20px"}} >
-          <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-            {Setting.getLabel(i18next.t("general:Display name"), i18next.t("general:Display name - Tooltip"))} :
-          </Col>
-          <Col span={22} >
-            <Input disabled={isRemote} value={this.state.provider.displayName} onChange={e => {
-              this.updateProviderField("displayName", e.target.value);
-            }} />
-          </Col>
-        </Row>
-        {this.shouldShowProviderDisplayName2Field() ? (
-          <Row style={{marginTop: "20px"}} >
-            <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-              {Setting.getLabel(i18next.t("general:Display name 2"), i18next.t("general:Display name 2 - Tooltip"))} :
+
+        {/* Card 1: General Settings */}
+        <Card size="small" title={i18next.t("provider:General Settings")} style={sectionCardStyle} type="inner">
+          <Row style={{marginTop: "10px"}} gutter={16}>
+            <Col style={{marginTop: "5px"}} span={Setting.isMobile() ? 22 : 11}>
+              <div style={{marginBottom: "4px"}}>{Setting.getLabel(i18next.t("general:ID"), i18next.t("general:Name - Tooltip"))} :</div>
+              <Input disabled={isRemote} value={provider.name} onChange={e => {
+                this.updateProviderField("name", e.target.value);
+              }} />
             </Col>
-            <Col span={22} >
-              <Input disabled={isRemote} value={this.state.provider.displayName2 ?? ""} onChange={e => {
-                this.updateProviderField("displayName2", e.target.value);
+            <Col style={{marginTop: "5px"}} span={Setting.isMobile() ? 22 : 11}>
+              <div style={{marginBottom: "4px"}}>{Setting.getLabel(i18next.t("general:Display name"), i18next.t("general:Display name - Tooltip"))} :</div>
+              <Input disabled={isRemote} value={provider.displayName} onChange={e => {
+                this.updateProviderField("displayName", e.target.value);
               }} />
             </Col>
           </Row>
-        ) : null}
-        <Row style={{marginTop: "20px"}} >
-          <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-            {Setting.getLabel(i18next.t("general:Category"), i18next.t("provider:Category - Tooltip"))} :
-          </Col>
-          <Col span={22} >
-            <Select virtual={false} disabled={isRemote} style={{width: "100%"}} value={this.state.provider.category} onChange={(value => {
-              this.updateProviderField("category", value);
-              if (value === "Storage") {
-                this.updateProviderField("type", "Local File System");
-              } else if (value === "Model") {
-                this.updateProviderField("type", "OpenAI");
-                this.updateProviderField("subType", "gpt-4");
-              } else if (value === "Embedding") {
-                this.updateProviderField("type", "OpenAI");
-                this.updateProviderField("subType", "AdaSimilarity");
-              } else if (value === "Video") {
-                this.updateProviderField("type", "AWS");
-              } else if (value === "Text-to-Speech") {
-                this.updateProviderField("type", "Alibaba Cloud");
-                this.updateProviderField("subType", "cosyvoice-v1");
-              } else if (value === "Speech-to-Text") {
-                this.updateProviderField("type", "Alibaba Cloud");
-                this.updateProviderField("subType", "paraformer-realtime-v1");
-              } else if (value === "Private Cloud") {
-                this.updateProviderField("type", "Kubernetes");
-              } else if (value === "Bot") {
-                this.updateProviderField("type", "Tencent");
-                this.updateProviderField("subType", "WeCom Bot");
-              } else if (value === "Chat") {
-                this.updateProviderField("type", "Telegram");
-              } else if (value === "Scan") {
-                this.updateProviderField("type", "Nmap");
-                this.updateProviderField("subType", "Default");
-              }
-            })}>
-              {
-                [
-                  {id: "Storage", name: "Storage"},
-                  {id: "Model", name: "Model"},
-                  {id: "Embedding", name: "Embedding"},
-                  {id: "Public Cloud", name: "Public Cloud"},
-                  {id: "Private Cloud", name: "Private Cloud"},
-                  {id: "Blockchain", name: "Blockchain"},
-                  {id: "Video", name: "Video"},
-                  {id: "Text-to-Speech", name: "Text-to-Speech"},
-                  {id: "Speech-to-Text", name: "Speech-to-Text"},
-                  {id: "Bot", name: "Bot"},
-                  {id: "Chat", name: "Chat"},
-                  {id: "Scan", name: "Scan"},
-                ].map((item, index) => <Option key={index} value={item.id}>{item.name}</Option>)
-              }
-            </Select>
-          </Col>
-        </Row>
-        <Row style={{marginTop: "20px"}} >
-          <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-            {Setting.getLabel(i18next.t("general:Type"), i18next.t("general:Type - Tooltip"))} :
-          </Col>
-          <Col span={22} >
-            <Select virtual={false} disabled={isRemote} style={{width: "100%"}} value={this.state.provider.type} onChange={(value => {
-              this.updateProviderField("type", value);
-              if (this.state.provider.category === "Model") {
-                if (value === "OpenAI Compatible") {
-                  this.updateProviderField("subType", "gpt-image-2");
-                } else if (value === "OpenAI") {
-                  this.updateProviderField("subType", "gpt-4");
-                } else if (value === "Gemini") {
-                  this.updateProviderField("subType", "gemini-pro");
-                } else if (value === "OpenRouter") {
-                  this.updateProviderField("subType", "openai/gpt-4");
-                } else if (value === "iFlytek") {
-                  this.updateProviderField("subType", "spark4.0-ultra");
-                } else if (value === "Baidu Cloud") {
-                  this.updateProviderField("subType", "ernie-4.0-8k");
-                } else if (value === "MiniMax") {
-                  this.updateProviderField("subType", "MiniMax-Text-01");
-                } else if (value === "Claude") {
-                  this.updateProviderField("subType", "claude-opus-4-0");
-                } else if (value === "Hugging Face") {
-                  this.updateProviderField("subType", "gpt2");
-                } else if (value === "ChatGLM") {
-                  this.updateProviderField("subType", "chatglm2-6b");
-                } else if (value === "Ollama") {
-                  this.updateProviderField("subType", "llama3.3:70b");
-                } else if (value === "Local") {
-                  this.updateProviderField("subType", "custom-model");
-                } else if (value === "Azure") {
-                  this.updateProviderField("subType", "gpt-4");
-                } else if (value === "Cohere") {
-                  this.updateProviderField("subType", "command");
-                } else if (value === "Dummy") {
-                  this.updateProviderField("subType", "Dummy");
-                } else if (value === "Alibaba Cloud") {
-                  this.updateProviderField("subType", "qwen-long");
-                } else if (value === "Moonshot") {
-                  this.updateProviderField("subType", "Moonshot-v1-8k");
-                } else if (value === "Amazon Bedrock") {
-                  this.updateProviderField("subType", "Claude");
-                } else if (value === "Baichuan") {
-                  this.updateProviderField("subType", "Baichuan2-Turbo");
-                } else if (value === "Volcano Engine") {
-                  this.updateProviderField("subType", "Doubao-lite-4k");
-                } else if (value === "DeepSeek") {
-                  this.updateProviderField("subType", "deepseek-v4-pro");
-                } else if (value === "StepFun") {
-                  this.updateProviderField("subType", "step-1-8k");
-                } else if (value === "Tencent Cloud") {
-                  this.updateProviderField("subType", "hunyuan-turbo");
-                } else if (value === "Yi") {
-                  this.updateProviderField("subType", "yi-lightning");
-                } else if (value === "Silicon Flow") {
-                  this.updateProviderField("subType", "deepseek-ai/DeepSeek-R1");
-                } else if (value === "GitHub") {
-                  this.updateProviderField("subType", "gpt-4o");
-                } else if (value === "Writer") {
-                  this.updateProviderField("subType", "palmyra-x5");
-                }
-              } else if (this.state.provider.category === "Embedding") {
-                if (value === "OpenAI") {
-                  this.updateProviderField("subType", "AdaSimilarity");
-                } else if (value === "Gemini") {
-                  this.updateProviderField("subType", "embedding-001");
-                } else if (value === "Hugging Face") {
-                  this.updateProviderField("subType", "sentence-transformers/all-MiniLM-L6-v2");
-                } else if (value === "Cohere") {
-                  this.updateProviderField("subType", "embed-english-v2.0");
-                } else if (value === "Baidu Cloud") {
-                  this.updateProviderField("subType", "Embedding-V1");
-                } else if (value === "Local") {
-                  this.updateProviderField("subType", "custom-embedding");
-                } else if (value === "Azure") {
-                  this.updateProviderField("subType", "AdaSimilarity");
-                } else if (value === "Dummy") {
-                  this.updateProviderField("subType", "Dummy");
-                }
-              } else if (this.state.provider.category === "Text-to-Speech") {
-                if (value === "Alibaba Cloud") {
-                  this.updateProviderField("subType", "cosyvoice-v1");
-                }
-              } else if (this.state.provider.category === "Speech-to-Text") {
-                if (value === "Alibaba Cloud") {
-                  this.updateProviderField("subType", "paraformer-realtime-v1");
-                }
-              } else if (this.state.provider.category === "Bot") {
-                if (value === "Tencent") {
-                  this.updateProviderField("subType", "WeCom Bot");
-                }
-              }
-            })}
-            showSearch
-            filterOption={(input, option) =>
-              option.children[1].toLowerCase().includes(input.toLowerCase())
-            }
-            >
-              {
-                Setting.getProviderTypeOptions(this.state.provider.category)
-                // .sort((a, b) => a.name.localeCompare(b.name))
-                  .map((item, index) => <Option key={index} value={item.name}>
-                    <img width={20} height={20} style={{marginBottom: "3px", marginRight: "10px"}} src={Setting.getProviderLogoURL({category: this.state.provider.category, type: item.name})} alt={item.name} />
-                    {item.name}
-                  </Option>)
-              }
-            </Select>
-          </Col>
-        </Row>
-        {
-          !["Model", "Embedding", "Text-to-Speech", "Speech-to-Text", "Bot"].includes(this.state.provider.category) ? null : (
-            <Row style={{marginTop: "20px"}} >
-              <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                {Setting.getLabel(i18next.t("provider:Sub type"), i18next.t("provider:Sub type - Tooltip"))} :
+          {this.shouldShowProviderDisplayName2Field() ? (
+            <Row style={{marginTop: "20px"}} gutter={16}>
+              <Col span={colSpan}>
+                <div style={{marginBottom: "4px"}}>{Setting.getLabel(i18next.t("general:Display name 2"), i18next.t("general:Display name 2 - Tooltip"))} :</div>
+                <Input disabled={isRemote} value={provider.displayName2 ?? ""} onChange={e => {
+                  this.updateProviderField("displayName2", e.target.value);
+                }} />
               </Col>
-              <Col span={22} >
-                {this.state.provider.type === "Ollama" ? (
-                  <AutoComplete
-                    style={{width: "100%"}}
-                    value={this.state.provider.subType}
-                    disabled={isRemote}
-                    onChange={(value) => {
-                      this.updateProviderField("subType", value);
-                    }}
-                    options={Setting.getProviderSubTypeOptions(this.state.provider.category, this.state.provider.type).map((item) => Setting.getOption(item.name, item.id))}
-                    placeholder="Please select or enter the model name"
-                  />
-                ) : (
-                  <Select
-                    virtual={false}
-                    style={{width: "100%"}}
-                    value={this.state.provider.subType}
-                    disabled={isRemote}
-                    onChange={(value) => {
-                      this.updateProviderField("subType", value);
-                    }}
+            </Row>
+          ) : null}
+          <Row style={{marginTop: "20px"}} gutter={16}>
+            <Col style={{marginTop: "5px"}} span={Setting.isMobile() ? 22 : 7}>
+              <div style={{marginBottom: "4px"}}>{Setting.getLabel(i18next.t("general:Category"), i18next.t("provider:Category - Tooltip"))} :</div>
+              <Select virtual={false} disabled={isRemote} style={{width: "100%"}} value={provider.category} onChange={(value => {
+                this.updateProviderField("category", value);
+                if (value === "Storage") {
+                  this.updateProviderField("type", "Local File System");
+                } else if (value === "Model") {
+                  this.updateProviderField("type", "OpenAI");
+                  this.updateProviderField("subType", "gpt-4");
+                } else if (value === "Embedding") {
+                  this.updateProviderField("type", "OpenAI");
+                  this.updateProviderField("subType", "AdaSimilarity");
+                } else if (value === "Video") {
+                  this.updateProviderField("type", "AWS");
+                } else if (value === "Text-to-Speech") {
+                  this.updateProviderField("type", "Alibaba Cloud");
+                  this.updateProviderField("subType", "cosyvoice-v1");
+                } else if (value === "Speech-to-Text") {
+                  this.updateProviderField("type", "Alibaba Cloud");
+                  this.updateProviderField("subType", "paraformer-realtime-v1");
+                } else if (value === "Private Cloud") {
+                  this.updateProviderField("type", "Kubernetes");
+                } else if (value === "Bot") {
+                  this.updateProviderField("type", "Tencent");
+                  this.updateProviderField("subType", "WeCom Bot");
+                } else if (value === "Chat") {
+                  this.updateProviderField("type", "Telegram");
+                } else if (value === "Scan") {
+                  this.updateProviderField("type", "Nmap");
+                  this.updateProviderField("subType", "Default");
+                }
+              })}>
+                {
+                  [
+                    {id: "Storage", name: "Storage"},
+                    {id: "Model", name: "Model"},
+                    {id: "Embedding", name: "Embedding"},
+                    {id: "Public Cloud", name: "Public Cloud"},
+                    {id: "Private Cloud", name: "Private Cloud"},
+                    {id: "Blockchain", name: "Blockchain"},
+                    {id: "Video", name: "Video"},
+                    {id: "Text-to-Speech", name: "Text-to-Speech"},
+                    {id: "Speech-to-Text", name: "Speech-to-Text"},
+                    {id: "Bot", name: "Bot"},
+                    {id: "Chat", name: "Chat"},
+                    {id: "Scan", name: "Scan"},
+                  ].map((item, index) => <Option key={index} value={item.id}>{item.name}</Option>)
+                }
+              </Select>
+            </Col>
+            <Col style={{marginTop: "5px"}} span={Setting.isMobile() ? 22 : 8}>
+              <div style={{marginBottom: "4px"}}>{Setting.getLabel(i18next.t("general:Type"), i18next.t("general:Type - Tooltip"))} :</div>
+              <Select virtual={false} disabled={isRemote} style={{width: "100%"}} value={provider.type} onChange={(value => {
+                this.updateProviderField("type", value);
+                if (provider.category === "Model") {
+                  if (value === "OpenAI Compatible") {
+                    this.updateProviderField("subType", "gpt-image-2");
+                  } else if (value === "OpenAI") {
+                    this.updateProviderField("subType", "gpt-4");
+                  } else if (value === "Gemini") {
+                    this.updateProviderField("subType", "gemini-pro");
+                  } else if (value === "OpenRouter") {
+                    this.updateProviderField("subType", "openai/gpt-4");
+                  } else if (value === "iFlytek") {
+                    this.updateProviderField("subType", "spark4.0-ultra");
+                  } else if (value === "Baidu Cloud") {
+                    this.updateProviderField("subType", "ernie-4.0-8k");
+                  } else if (value === "MiniMax") {
+                    this.updateProviderField("subType", "MiniMax-Text-01");
+                  } else if (value === "Claude") {
+                    this.updateProviderField("subType", "claude-opus-4-0");
+                  } else if (value === "Hugging Face") {
+                    this.updateProviderField("subType", "gpt2");
+                  } else if (value === "ChatGLM") {
+                    this.updateProviderField("subType", "chatglm2-6b");
+                  } else if (value === "Ollama") {
+                    this.updateProviderField("subType", "llama3.3:70b");
+                  } else if (value === "Local") {
+                    this.updateProviderField("subType", "custom-model");
+                  } else if (value === "Azure") {
+                    this.updateProviderField("subType", "gpt-4");
+                  } else if (value === "Cohere") {
+                    this.updateProviderField("subType", "command");
+                  } else if (value === "Dummy") {
+                    this.updateProviderField("subType", "Dummy");
+                  } else if (value === "Alibaba Cloud") {
+                    this.updateProviderField("subType", "qwen-long");
+                  } else if (value === "Moonshot") {
+                    this.updateProviderField("subType", "Moonshot-v1-8k");
+                  } else if (value === "Amazon Bedrock") {
+                    this.updateProviderField("subType", "Claude");
+                  } else if (value === "Baichuan") {
+                    this.updateProviderField("subType", "Baichuan2-Turbo");
+                  } else if (value === "Volcano Engine") {
+                    this.updateProviderField("subType", "Doubao-lite-4k");
+                  } else if (value === "DeepSeek") {
+                    this.updateProviderField("subType", "deepseek-v4-pro");
+                  } else if (value === "StepFun") {
+                    this.updateProviderField("subType", "step-1-8k");
+                  } else if (value === "Tencent Cloud") {
+                    this.updateProviderField("subType", "hunyuan-turbo");
+                  } else if (value === "Yi") {
+                    this.updateProviderField("subType", "yi-lightning");
+                  } else if (value === "Silicon Flow") {
+                    this.updateProviderField("subType", "deepseek-ai/DeepSeek-R1");
+                  } else if (value === "GitHub") {
+                    this.updateProviderField("subType", "gpt-4o");
+                  } else if (value === "Writer") {
+                    this.updateProviderField("subType", "palmyra-x5");
+                  }
+                } else if (provider.category === "Embedding") {
+                  if (value === "OpenAI") {
+                    this.updateProviderField("subType", "AdaSimilarity");
+                  } else if (value === "Gemini") {
+                    this.updateProviderField("subType", "embedding-001");
+                  } else if (value === "Hugging Face") {
+                    this.updateProviderField("subType", "sentence-transformers/all-MiniLM-L6-v2");
+                  } else if (value === "Cohere") {
+                    this.updateProviderField("subType", "embed-english-v2.0");
+                  } else if (value === "Baidu Cloud") {
+                    this.updateProviderField("subType", "Embedding-V1");
+                  } else if (value === "Local") {
+                    this.updateProviderField("subType", "custom-embedding");
+                  } else if (value === "Azure") {
+                    this.updateProviderField("subType", "AdaSimilarity");
+                  } else if (value === "Dummy") {
+                    this.updateProviderField("subType", "Dummy");
+                  }
+                } else if (provider.category === "Text-to-Speech") {
+                  if (value === "Alibaba Cloud") {
+                    this.updateProviderField("subType", "cosyvoice-v1");
+                  }
+                } else if (provider.category === "Speech-to-Text") {
+                  if (value === "Alibaba Cloud") {
+                    this.updateProviderField("subType", "paraformer-realtime-v1");
+                  }
+                } else if (provider.category === "Bot") {
+                  if (value === "Tencent") {
+                    this.updateProviderField("subType", "WeCom Bot");
+                  }
+                }
+              })}
+              showSearch
+              filterOption={(input, option) =>
+                option.children[1].toLowerCase().includes(input.toLowerCase())
+              }
+              >
+                {
+                  Setting.getProviderTypeOptions(provider.category)
+                    .map((item, index) => <Option key={index} value={item.name}>
+                      <img width={20} height={20} style={{marginBottom: "3px", marginRight: "10px"}} src={Setting.getProviderLogoURL({category: provider.category, type: item.name})} alt={item.name} />
+                      {item.name}
+                    </Option>)
+                }
+              </Select>
+            </Col>
+            {
+              !["Model", "Embedding", "Text-to-Speech", "Speech-to-Text", "Bot"].includes(provider.category) ? null : (
+                <Col style={{marginTop: "5px"}} span={Setting.isMobile() ? 22 : 7}>
+                  <div style={{marginBottom: "4px"}}>{Setting.getLabel(i18next.t("provider:Sub type"), i18next.t("provider:Sub type - Tooltip"))} :</div>
+                  {provider.type === "Ollama" ? (
+                    <AutoComplete
+                      style={{width: "100%"}}
+                      value={provider.subType}
+                      disabled={isRemote}
+                      onChange={(value) => {
+                        this.updateProviderField("subType", value);
+                      }}
+                      options={Setting.getProviderSubTypeOptions(provider.category, provider.type).map((item) => Setting.getOption(item.name, item.id))}
+                      placeholder="Please select or enter the model name"
+                    />
+                  ) : (
+                    <Select
+                      virtual={false}
+                      style={{width: "100%"}}
+                      value={provider.subType}
+                      disabled={isRemote}
+                      onChange={(value) => {
+                        this.updateProviderField("subType", value);
+                      }}
+                      showSearch
+                      filterOption={(input, option) =>
+                        option.children.toLowerCase().includes(input.toLowerCase())
+                      }
+                    >
+                      {Setting.getProviderSubTypeOptions(provider.category, provider.type)
+                        .map((item, index) => (
+                          <Option key={index} value={item.id}>{item.name}</Option>
+                        ))
+                      }
+                    </Select>
+                  )}
+                </Col>
+              )
+            }
+          </Row>
+          {
+            (this.state.provider.category === "Model" && this.state.provider.type === "OpenAI Compatible") ? (
+              <Row style={{marginTop: "20px"}} >
+                <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+                  {this.getProviderUrlLabel(this.state.provider)} :
+                </Col>
+                <Col span={22} >
+                  <Input prefix={<LinkOutlined />} value={this.state.provider.providerUrl} onChange={e => {
+                    this.updateProviderField("providerUrl", e.target.value);
+                  }} />
+                </Col>
+              </Row>
+            ) : null
+          }
+          {
+            (this.state.provider.type === "Cohere" && this.state.provider.category === "Embedding") && (
+              <Row style={{marginTop: "20px"}} >
+                <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+                  {Setting.getLabel(i18next.t("provider:Input type"), i18next.t("provider:Input type - Tooltip"))} :
+                </Col>
+                <Col span={22} >
+                  <Select virtual={false} disabled={isRemote} style={{width: "100%"}} value={this.state.provider.clientId} onChange={(value => {this.updateProviderField("clientId", value);})}>
+                    {
+                      ["search_document", "search_query"]
+                        .map((item, index) => <Option key={index} value={item}>{item}</Option>)
+                    }
+                  </Select>
+                </Col>
+              </Row>
+            )
+          }
+          {
+            this.shouldShowClientIdInput(this.state.provider) ? (
+              <Row style={{marginTop: "20px"}} >
+                <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+                  {this.getClientIdLabel(this.state.provider)} :
+                </Col>
+                <Col span={22} >
+                  <Input disabled={isRemote} value={this.state.provider.clientId} onChange={e => {
+                    this.updateProviderField("clientId", e.target.value);
+                  }} />
+                </Col>
+              </Row>
+            ) : null
+          }
+          {
+            this.state.provider.category === "Chat" ? (
+              <Row style={{marginTop: "20px"}} >
+                <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+                  {this.getClientIdLabel(this.state.provider)} :
+                </Col>
+                <Col span={22} >
+                  <Select virtual={false} disabled={isRemote} style={{width: "100%"}} value={this.state.provider.clientId}
+                    onChange={(value) => this.updateProviderField("clientId", value)}
+                    onDropdownVisibleChange={(open) => {if (open) {this.getModelProviders();}}}
                     showSearch
                     filterOption={(input, option) =>
-                      option.children.toLowerCase().includes(input.toLowerCase())
+                      option.children[1].toLowerCase().includes(input.toLowerCase())
                     }
                   >
-                    {Setting.getProviderSubTypeOptions(this.state.provider.category, this.state.provider.type)
-                      .map((item, index) => (
-                        <Option key={index} value={item.id}>{item.name}</Option>
-                      ))
-                    }
+                    {this.state.modelProviders.map((provider, index) => this.renderModelProviderOption(provider, index))}
                   </Select>
-                )}
-              </Col>
-            </Row>
-          )
-        }
-        {
-          (this.state.provider.category === "Model" && this.state.provider.type === "OpenAI Compatible") ? (
-            <Row style={{marginTop: "20px"}} >
-              <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                {this.getProviderUrlLabel(this.state.provider)} :
-              </Col>
-              <Col span={22} >
-                <Input prefix={<LinkOutlined />} value={this.state.provider.providerUrl} onChange={e => {
-                  this.updateProviderField("providerUrl", e.target.value);
-                }} />
-              </Col>
-            </Row>
-          ) : null
-        }
-        {
-          (this.state.provider.type === "Cohere" && this.state.provider.category === "Embedding") && (
-            <Row style={{marginTop: "20px"}} >
-              <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                {Setting.getLabel(i18next.t("provider:Input type"), i18next.t("provider:Input type - Tooltip"))} :
-              </Col>
-              <Col span={22} >
-                <Select virtual={false} disabled={isRemote} style={{width: "100%"}} value={this.state.provider.clientId} onChange={(value => {this.updateProviderField("clientId", value);})}>
-                  {
-                    ["search_document", "search_query"]
-                      .map((item, index) => <Option key={index} value={item}>{item}</Option>)
-                  }
-                </Select>
-              </Col>
-            </Row>
-          )
-        }
-        {
-          this.shouldShowClientIdInput(this.state.provider) ? (
-            <Row style={{marginTop: "20px"}} >
-              <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                {this.getClientIdLabel(this.state.provider)} :
-              </Col>
-              <Col span={22} >
-                <Input disabled={isRemote} value={this.state.provider.clientId} onChange={e => {
-                  this.updateProviderField("clientId", e.target.value);
-                }} />
-              </Col>
-            </Row>
-          ) : null
-        }
-        {
-          this.state.provider.category === "Chat" ? (
-            <Row style={{marginTop: "20px"}} >
-              <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                {this.getClientIdLabel(this.state.provider)} :
-              </Col>
-              <Col span={22} >
-                <Select virtual={false} disabled={isRemote} style={{width: "100%"}} value={this.state.provider.clientId}
-                  onChange={(value) => this.updateProviderField("clientId", value)}
-                  onDropdownVisibleChange={(open) => {if (open) {this.getModelProviders();}}}
-                  showSearch
-                  filterOption={(input, option) =>
-                    option.children[1].toLowerCase().includes(input.toLowerCase())
-                  }
-                >
-                  {this.state.modelProviders.map((provider, index) => this.renderModelProviderOption(provider, index))}
-                </Select>
-              </Col>
-            </Row>
-          ) : null
-        }
-        {
-          (this.state.provider.type === "Local") ? (
-            <>
-              <Row style={{marginTop: "20px"}}>
+                </Col>
+              </Row>
+            ) : null
+          }
+          {
+            (this.state.provider.type === "Local") ? (
+              <>
+                <Row style={{marginTop: "20px"}}>
+                  <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+                    {Setting.getLabel(i18next.t("provider:Compatible provider"), i18next.t("provider:Compatible provider - Tooltip"))} :
+                  </Col>
+                  <Col span={22} >
+                    <AutoComplete
+                      style={{width: "100%"}}
+                      value={this.state.provider.compatibleProvider}
+                      disabled={isRemote}
+                      onChange={(value) => {
+                        this.updateProviderField("compatibleProvider", value);
+                      }}
+                      options={Setting.getCompatibleProviderOptions(this.state.provider.category).map((item) => Setting.getOption(item.name, item.id))}
+                      placeholder="Please select or enter the compatible provider"
+                    />
+                  </Col>
+                </Row>
+              </>
+            ) : null
+          }
+          {
+            !(this.state.provider.category === "Model" && (this.state.provider.type === "Local" || this.state.provider.type === "Ollama" || this.state.provider.type === "OpenAI Compatible")) ? null : (
+              <>
+                <Row style={{marginTop: "20px"}} >
+                  <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+                    {Setting.getLabel(i18next.t("provider:Input price / 1k tokens"), i18next.t("provider:Input price / 1k tokens - Tooltip"))} :
+                  </Col>
+                  <Col span={22} >
+                    <InputNumber min={0} value={this.state.provider.inputPricePerThousandTokens} onChange={value => {
+                      this.updateProviderField("inputPricePerThousandTokens", value);
+                    }} />
+                  </Col>
+                </Row>
+                <Row style={{marginTop: "20px"}} >
+                  <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+                    {Setting.getLabel(i18next.t("provider:Output price / 1k tokens"), i18next.t("provider:Output price / 1k tokens - Tooltip"))} :
+                  </Col>
+                  <Col span={22} >
+                    <InputNumber min={0} value={this.state.provider.outputPricePerThousandTokens} onChange={value => {
+                      this.updateProviderField("outputPricePerThousandTokens", value);
+                    }} />
+                  </Col>
+                </Row>
+              </>
+            )
+          }
+          {
+            !(this.state.provider.category === "Embedding" && (this.state.provider.type === "Local" || this.state.provider.type === "Ollama")) ? null : (
+              <>
+                <Row style={{marginTop: "20px"}} >
+                  <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+                    {Setting.getLabel(i18next.t("provider:Input price / 1k tokens"), i18next.t("provider:Input price / 1k tokens - Tooltip"))} :
+                  </Col>
+                  <Col span={22} >
+                    <InputNumber min={0} value={this.state.provider.inputPricePerThousandTokens} onChange={value => {
+                      this.updateProviderField("inputPricePerThousandTokens", value);
+                    }} />
+                  </Col>
+                </Row>
+              </>
+            )
+          }
+          {
+            (this.state.provider.type === "Local" || this.state.provider.type === "Ollama" || this.state.provider.type === "OpenAI Compatible") ? (
+              <>
+                <Row style={{marginTop: "20px"}} >
+                  <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+                    {Setting.getLabel(i18next.t("provider:Currency"), i18next.t("provider:Currency - Tooltip"))} :
+                  </Col>
+                  <Col span={22} >
+                    <Select virtual={false} disabled={isRemote} style={{width: "100%"}} value={this.state.provider.currency} onChange={(value => {
+                      this.updateProviderField("currency", value);
+                    })}>
+                      {
+                        [
+                          {id: "USD", name: "USD"},
+                          {id: "CNY", name: "CNY"},
+                          {id: "EUR", name: "EUR"},
+                          {id: "JPY", name: "JPY"},
+                          {id: "GBP", name: "GBP"},
+                          {id: "AUD", name: "AUD"},
+                          {id: "CAD", name: "CAD"},
+                          {id: "CHF", name: "CHF"},
+                          {id: "HKD", name: "HKD"},
+                          {id: "SGD", name: "SGD"},
+                        ].map((item, index) => <Option key={index} value={item.id}>{item.name}</Option>)
+                      }
+                    </Select>
+                  </Col>
+                </Row>
+              </>
+            ) : null
+          }
+          {
+            (this.state.provider.category === "Text-to-Speech" && this.state.provider.type === "Alibaba Cloud" && this.state.provider.subType === "cosyvoice-v1") ? (
+              <>
+                <Row style={{marginTop: "20px"}}>
+                  <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+                    {Setting.getLabel(i18next.t("provider:Flavor"), i18next.t("provider:Flavor - Tooltip"))} :
+                  </Col>
+                  <Col span={22} >
+                    <Select virtual={false} disabled={isRemote} style={{width: "100%"}} value={this.state.provider.flavor} onChange={(value => {
+                      this.updateProviderField("flavor", value);
+                    })}>
+                      {
+                        Setting.getTtsFlavorOptions(this.state.provider.type, this.state.provider.subType)
+                          .map((item, index) => <Option key={index} value={item.id}>{item.name}</Option>)
+                      }
+                    </Select>
+                  </Col>
+                </Row>
+              </>
+            ) : null
+          }
+          {
+            this.shouldShowClientSecretInput(this.state.provider) ? (
+              <Row style={{marginTop: "20px"}} >
                 <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                  {Setting.getLabel(i18next.t("provider:Compatible provider"), i18next.t("provider:Compatible provider - Tooltip"))} :
+                  {this.getClientSecretLabel(this.state.provider)} :
                 </Col>
                 <Col span={22} >
-                  <AutoComplete
-                    style={{width: "100%"}}
-                    value={this.state.provider.compatibleProvider}
-                    disabled={isRemote}
-                    onChange={(value) => {
-                      this.updateProviderField("compatibleProvider", value);
+                  <Input.Password disabled={isRemote} value={this.state.provider.clientSecret} onChange={e => {
+                    this.updateProviderField("clientSecret", e.target.value);
+                  }} />
+                </Col>
+              </Row>
+            ) : null
+          }
+          {
+            (this.state.provider.category === "Model" && this.state.provider.type === "Claude" && Setting.getThinkingModelMaxTokens(this.state.provider.subType) !== 0) ? (
+              <>
+                <Row style={{marginTop: "20px"}} >
+                  <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+                    {Setting.getLabel(i18next.t("provider:Enable thinking"), i18next.t("provider:Enable thinking - Tooltip"))} :
+                  </Col>
+                  <Col span={22} >
+                    <Switch disabled={isRemote} checked={this.state.provider.enableThinking} onChange={checked => {
+                      this.updateProviderField("enableThinking", checked);
+                    }} />
+                  </Col>
+                </Row>
+                {
+                  this.state.provider.enableThinking && (
+                    <Row style={{marginTop: "20px"}} >
+                      <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+                        {Setting.getLabel(i18next.t("provider:Thinking tokens"), i18next.t("provider:Thinking tokens - Tooltip"))} :
+                      </Col>
+                      <Col span={22} >
+                        <InputNumber min={1024} max={Setting.getThinkingModelMaxTokens(this.state.provider.subType) - 1} value={this.state.provider.topK || 1024} onChange={value => {
+                          this.updateProviderField("topK", value);
+                        }} />
+                      </Col>
+                    </Row>
+                  )
+                }
+              </>
+            ) : null
+          }
+          {
+            ["Storage", "Model", "Embedding", "Text-to-Speech", "Speech-to-Text", "Scan"].includes(this.state.provider.category) || (this.state.provider.category === "Blockchain" && this.state.provider.type === "Ethereum") || (this.state.provider.category === "Private Cloud" && this.state.provider.type === "Kubernetes") ? null : (
+              <Row style={{marginTop: "20px"}} >
+                <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+                  {this.getRegionLabel(this.state.provider)} :
+                </Col>
+                <Col span={22} >
+                  <Input disabled={isRemote} value={this.state.provider.region} onChange={e => {
+                    this.updateProviderField("region", e.target.value);
+                  }} />
+                </Col>
+              </Row>
+            )
+          }
+          {
+            this.state.provider.category === "Blockchain" && (
+              <>
+                {this.state.provider.type === "Ethereum" ? null : (
+                  <>
+                    <Row style={{marginTop: "20px"}}>
+                      <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+                        {Setting.getLabel(i18next.t("provider:Chain"), i18next.t("provider:Chain - Tooltip"))} :
+                      </Col>
+                      <Col span={22}>
+                        <Input disabled={isRemote} value={this.state.provider.chain} onChange={e => {
+                          this.updateProviderField("chain", e.target.value);
+                        }} />
+                      </Col>
+                    </Row>
+                    <Row style={{marginTop: "20px"}}>
+                      <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+                        {this.getNetworkLabel(this.state.provider)} :
+                      </Col>
+                      <Col span={22}>
+                        <Input disabled={isRemote} value={this.state.provider.network} onChange={e => {
+                          this.updateProviderField("network", e.target.value);
+                        }} />
+                      </Col>
+                    </Row>
+                  </>
+                )}
+                {this.state.provider.type === "ChainMaker" ? (
+                  <>
+                    <Row style={{marginTop: "20px"}}>
+                      <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+                        {Setting.getLabel(i18next.t("provider:Auth type"), i18next.t("provider:Auth type - Tooltip"))} :
+                      </Col>
+                      <Col span={22}>
+                        <Select
+                          virtual={false}
+                          style={{width: "100%"}}
+                          value={this.state.provider.text}
+                          onChange={value => {
+                            this.updateProviderField("text", value);
+                          }}
+                        >
+                          <Select.Option value="permissionedwithcert">permissionedwithcert</Select.Option>
+                          <Select.Option value="permissionedwithkey">permissionedwithkey</Select.Option>
+                          <Select.Option value="public">public</Select.Option>
+                        </Select>
+                      </Col>
+                    </Row>
+                    <Row style={{marginTop: "20px"}} >
+                      <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+                        {Setting.getLabel(i18next.t("cert:User cert"), i18next.t("cert:User cert - Tooltip"))} :
+                      </Col>
+                      <Col span={editorWidth} >
+                        <Button style={{marginRight: "10px", marginBottom: "10px"}} disabled={this.state.provider.userCert === ""} onClick={() => {
+                          copy(this.state.provider.userCert);
+                          Setting.showMessage("success", i18next.t("general:Copied to clipboard successfully"));
+                        }}
+                        >
+                          {i18next.t("general:Copy")}
+                        </Button>
+                        <Button type="primary" disabled={this.state.provider.userCert === ""} onClick={() => {
+                          const blob = new Blob([this.state.provider.userCert], {type: "text/plain;charset=utf-8"});
+                          FileSaver.saveAs(blob, "user_cert.pem");
+                        }}
+                        >
+                          {i18next.t("general:Download")}
+                        </Button>
+                        <TextArea autoSize={{minRows: 16, maxRows: 16}} value={this.state.provider.userCert} onChange={e => {
+                          this.updateProviderField("userCert", e.target.value);
+                        }} />
+                      </Col>
+                      <Col span={1} />
+                      <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+                        {Setting.getLabel(i18next.t("cert:User key"), i18next.t("cert:User key - Tooltip"))} :
+                      </Col>
+                      <Col span={editorWidth} >
+                        <Button style={{marginRight: "10px", marginBottom: "10px"}} disabled={this.state.provider.userKey === ""} onClick={() => {
+                          copy(this.state.provider.userKey);
+                          Setting.showMessage("success", i18next.t("general:Copied to clipboard successfully"));
+                        }}
+                        >
+                          {i18next.t("general:Copy")}
+                        </Button>
+                        <Button type="primary" disabled={this.state.provider.userKey === ""} onClick={() => {
+                          const blob = new Blob([this.state.provider.userKey], {type: "text/plain;charset=utf-8"});
+                          FileSaver.saveAs(blob, "token_jwt_key.key");
+                        }}
+                        >
+                          {i18next.t("general:Download")}
+                        </Button>
+                        <TextArea autoSize={{minRows: 16, maxRows: 16}} value={this.state.provider.userKey} onChange={e => {
+                          this.updateProviderField("userKey", e.target.value);
+                        }} />
+                      </Col>
+                    </Row>
+                    <Row style={{marginTop: "20px"}} >
+                      <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+                        {Setting.getLabel(i18next.t("cert:Sign cert"), i18next.t("cert:Sign cert - Tooltip"))} :
+                      </Col>
+                      <Col span={editorWidth} >
+                        <Button style={{marginRight: "10px", marginBottom: "10px"}} disabled={this.state.provider.signCert === ""} onClick={() => {
+                          copy(this.state.provider.signCert);
+                          Setting.showMessage("success", i18next.t("general:Copied to clipboard successfully"));
+                        }}
+                        >
+                          {i18next.t("general:Copy")}
+                        </Button>
+                        <Button type="primary" disabled={this.state.provider.signCert === ""} onClick={() => {
+                          const blob = new Blob([this.state.provider.signCert], {type: "text/plain;charset=utf-8"});
+                          FileSaver.saveAs(blob, "user_cert.pem");
+                        }}
+                        >
+                          {i18next.t("general:Download")}
+                        </Button>
+                        <TextArea autoSize={{minRows: 16, maxRows: 16}} value={this.state.provider.signCert} onChange={e => {
+                          this.updateProviderField("signCert", e.target.value);
+                        }} />
+                      </Col>
+                      <Col span={1} />
+                      <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+                        {Setting.getLabel(i18next.t("cert:Sign key"), i18next.t("cert:Sign key - Tooltip"))} :
+                      </Col>
+                      <Col span={editorWidth} >
+                        <Button style={{marginRight: "10px", marginBottom: "10px"}} disabled={this.state.provider.signKey === ""} onClick={() => {
+                          copy(this.state.provider.signKey);
+                          Setting.showMessage("success", i18next.t("general:Copied to clipboard successfully"));
+                        }}
+                        >
+                          {i18next.t("general:Copy")}
+                        </Button>
+                        <Button type="primary" disabled={this.state.provider.signKey === ""} onClick={() => {
+                          const blob = new Blob([this.state.provider.signKey], {type: "text/plain;charset=utf-8"});
+                          FileSaver.saveAs(blob, "token_jwt_key.key");
+                        }}
+                        >
+                          {i18next.t("general:Download")}
+                        </Button>
+                        <TextArea autoSize={{minRows: 16, maxRows: 16}} value={this.state.provider.signKey} onChange={e => {
+                          this.updateProviderField("signKey", e.target.value);
+                        }} />
+                      </Col>
+                    </Row>
+                  </>
+                ) : null}
+                {["Ethereum", "ChainMaker"].includes(this.state.provider.type) ? (
+                  <>
+                    <Row style={{marginTop: "20px"}}>
+                      <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+                        {this.getContractNameLabel(this.state.provider)} :
+                      </Col>
+                      <Col span={22}>
+                        <Input disabled={isRemote} value={this.state.provider.contractName} onChange={e => {
+                          this.updateProviderField("contractName", e.target.value);
+                        }} />
+                      </Col>
+                    </Row>
+                    <Row style={{marginTop: "20px"}}>
+                      <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+                        {Setting.getLabel(i18next.t("provider:Invoke method"), i18next.t("provider:Invoke method - Tooltip"))} :
+                      </Col>
+                      <Col span={22}>
+                        <Input disabled={isRemote} value={this.state.provider.contractMethod} onChange={e => {
+                          this.updateProviderField("contractMethod", e.target.value);
+                        }} />
+                      </Col>
+                    </Row>
+                  </>
+                ) : null}
+                <Row style={{marginTop: "20px"}}>
+                  <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+                    {Setting.getLabel(i18next.t("provider:Browser URL"), i18next.t("provider:Browser URL - Tooltip"))} :
+                  </Col>
+                  <Col span={22}>
+                    <Input prefix={<LinkOutlined />} value={this.state.provider.browserUrl}
+                      placeholder={this.state.provider.type === "ChainMaker" ? "https://explorer-testnet.chainmaker.org.cn/chainmaker_testnet_chain/block/{bh}" : ""}
+                      onChange={e => {
+                        this.updateProviderField("browserUrl", e.target.value);
+                      }} />
+                  </Col>
+                </Row>
+              </>
+            )
+          }
+          <Row style={{marginTop: "20px"}} >
+            <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+              {Setting.getLabel(i18next.t("store:Is default"), i18next.t("store:Is default - Tooltip"))} :
+            </Col>
+            <Col span={1}>
+              <Switch disabled={isRemote} checked={this.state.provider.isDefault} onChange={checked => {
+                this.updateProviderField("isDefault", checked);
+              }} />
+            </Col>
+          </Row>
+          <Row style={{marginTop: "20px"}} >
+            <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+              {Setting.getLabel(i18next.t("provider:Is remote"), i18next.t("provider:Is remote - Tooltip"))} :
+            </Col>
+            <Col span={1}>
+              <Switch disabled checked={this.state.provider.isRemote} />
+            </Col>
+          </Row>
+          <Row style={{marginTop: "20px"}}>
+            <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+              {Setting.getLabel(i18next.t("general:State"), i18next.t("general:State - Tooltip"))} :
+            </Col>
+            <Col span={22}>
+              <Select virtual={false} disabled={isRemote} style={{width: "100%"}} value={this.state.provider.state} onChange={value => {
+                this.updateProviderField("state", value);
+              }}
+              options={[
+                {value: "Active", label: i18next.t("general:Active")},
+                {value: "Inactive", label: i18next.t("general:Inactive")},
+              ].map(item => Setting.getOption(item.label, item.value))} />
+            </Col>
+          </Row>
+          {
+            this.state.provider.category === "Model" ? (
+              <Row style={{marginTop: "20px"}} >
+                <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
+                  {Setting.getLabel(i18next.t("provider:Provider key"), i18next.t("provider:Provider key - Tooltip"))} :
+                </Col>
+                <Col span={22} >
+                  <Input.Password
+                    value={this.state.provider.providerKey}
+                    disabled={!Setting.isAdminUser(this.props.account)}
+                    onChange={e => {
+                      this.updateProviderField("providerKey", e.target.value);
                     }}
-                    options={Setting.getCompatibleProviderOptions(this.state.provider.category).map((item) => Setting.getOption(item.name, item.id))}
-                    placeholder="Please select or enter the compatible provider"
                   />
                 </Col>
               </Row>
-            </>
-          ) : null
-        }
-        {
-          !(this.state.provider.category === "Model" && (this.state.provider.type === "Local" || this.state.provider.type === "Ollama" || this.state.provider.type === "OpenAI Compatible")) ? null : (
-            <>
-              <Row style={{marginTop: "20px"}} >
-                <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                  {Setting.getLabel(i18next.t("provider:Input price / 1k tokens"), i18next.t("provider:Input price / 1k tokens - Tooltip"))} :
+            ) : null
+          }
+        </Card>
+
+        {/* Card 2: Advanced Model Parameters */}
+        {isModelProvider && (this.isTemperatureEnabled(provider) || this.isTopPEnabled(provider) || (provider.type === "Gemini")) && (
+          <Card size="small" title={i18next.t("provider:Advanced Model Parameters")} style={sectionCardStyle} type="inner">
+            {this.isTemperatureEnabled(provider) ? (
+              <Row style={{marginTop: "10px"}} gutter={16}>
+                <Col span={Setting.isMobile() ? 22 : 14}>
+                  <div style={{marginBottom: "4px"}}>{Setting.getLabel(i18next.t("provider:Temperature"), i18next.t("provider:Temperature - Tooltip"))}</div>
+                  <Slider
+                    min={0}
+                    max={["Alibaba Cloud", "Gemini", "OpenAI", "OpenRouter", "Baichuan", "DeepSeek", "StepFun", "Tencent Cloud", "Mistral", "Yi", "Ollama", "Writer"].includes(provider.type) ? 2 : 1}
+                    step={0.01}
+                    value={provider.temperature}
+                    disabled={isRemote}
+                    onChange={(value) => {
+                      this.updateProviderField("temperature", value);
+                    }}
+                  />
                 </Col>
-                <Col span={22} >
-                  <InputNumber min={0} value={this.state.provider.inputPricePerThousandTokens} onChange={value => {
-                    this.updateProviderField("inputPricePerThousandTokens", value);
-                  }} />
-                </Col>
-              </Row>
-              <Row style={{marginTop: "20px"}} >
-                <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                  {Setting.getLabel(i18next.t("provider:Output price / 1k tokens"), i18next.t("provider:Output price / 1k tokens - Tooltip"))} :
-                </Col>
-                <Col span={22} >
-                  <InputNumber min={0} value={this.state.provider.outputPricePerThousandTokens} onChange={value => {
-                    this.updateProviderField("outputPricePerThousandTokens", value);
-                  }} />
-                </Col>
-              </Row>
-            </>
-          )
-        }
-        {
-          !(this.state.provider.category === "Embedding" && (this.state.provider.type === "Local" || this.state.provider.type === "Ollama")) ? null : (
-            <>
-              <Row style={{marginTop: "20px"}} >
-                <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                  {Setting.getLabel(i18next.t("provider:Input price / 1k tokens"), i18next.t("provider:Input price / 1k tokens - Tooltip"))} :
-                </Col>
-                <Col span={22} >
-                  <InputNumber min={0} value={this.state.provider.inputPricePerThousandTokens} onChange={value => {
-                    this.updateProviderField("inputPricePerThousandTokens", value);
-                  }} />
+                <Col span={Setting.isMobile() ? 22 : 2}>
+                  <div style={{marginBottom: "4px"}}>&nbsp;</div>
+                  <InputNumber
+                    min={0}
+                    max={["Alibaba Cloud", "Gemini", "OpenAI", "OpenRouter", "Baichuan", "DeepSeek", "StepFun", "Tencent Cloud", "Mistral", "Yi", "Ollama", "Writer"].includes(provider.type) ? 2 : 1}
+                    step={0.01}
+                    style={{width: "100%"}}
+                    value={provider.temperature}
+                    onChange={(value) => {
+                      this.updateProviderField("temperature", value);
+                    }}
+                    disabled={isRemote}
+                  />
                 </Col>
               </Row>
-            </>
-          )
-        }
-        {
-          (this.state.provider.type === "Local" || this.state.provider.type === "Ollama" || this.state.provider.type === "OpenAI Compatible") ? (
-            <>
-              <Row style={{marginTop: "20px"}} >
-                <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                  {Setting.getLabel(i18next.t("provider:Currency"), i18next.t("provider:Currency - Tooltip"))} :
+            ) : null}
+            {this.isTopPEnabled(provider) ? (
+              <Row style={{marginTop: "20px"}} gutter={16}>
+                <Col span={Setting.isMobile() ? 22 : 14}>
+                  <div style={{marginBottom: "4px"}}>{Setting.getLabel(i18next.t("provider:Top P"), i18next.t("provider:Top P - Tooltip"))}</div>
+                  <Slider
+                    min={0}
+                    max={1.0}
+                    step={0.01}
+                    value={provider.topP}
+                    disabled={isRemote}
+                    onChange={(value) => {
+                      this.updateProviderField("topP", value);
+                    }}
+                  />
                 </Col>
-                <Col span={22} >
-                  <Select virtual={false} disabled={isRemote} style={{width: "100%"}} value={this.state.provider.currency} onChange={(value => {
-                    this.updateProviderField("currency", value);
-                  })}>
-                    {
-                      [
-                        {id: "USD", name: "USD"},
-                        {id: "CNY", name: "CNY"},
-                        {id: "EUR", name: "EUR"},
-                        {id: "JPY", name: "JPY"},
-                        {id: "GBP", name: "GBP"},
-                        {id: "AUD", name: "AUD"},
-                        {id: "CAD", name: "CAD"},
-                        {id: "CHF", name: "CHF"},
-                        {id: "HKD", name: "HKD"},
-                        {id: "SGD", name: "SGD"},
-                      ].map((item, index) => <Option key={index} value={item.id}>{item.name}</Option>)
-                    }
-                  </Select>
-                </Col>
-              </Row>
-            </>
-          ) : null
-        }
-        {
-          (this.state.provider.category === "Text-to-Speech" && this.state.provider.type === "Alibaba Cloud" && this.state.provider.subType === "cosyvoice-v1") ? (
-            <>
-              <Row style={{marginTop: "20px"}}>
-                <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                  {Setting.getLabel(i18next.t("provider:Flavor"), i18next.t("provider:Flavor - Tooltip"))} :
-                </Col>
-                <Col span={22} >
-                  <Select virtual={false} disabled={isRemote} style={{width: "100%"}} value={this.state.provider.flavor} onChange={(value => {
-                    this.updateProviderField("flavor", value);
-                  })}>
-                    {
-                      Setting.getTtsFlavorOptions(this.state.provider.type, this.state.provider.subType)
-                        .map((item, index) => <Option key={index} value={item.id}>{item.name}</Option>)
-                    }
-                  </Select>
+                <Col span={Setting.isMobile() ? 22 : 2}>
+                  <div style={{marginBottom: "4px"}}>&nbsp;</div>
+                  <InputNumber
+                    min={0}
+                    max={1.0}
+                    step={0.01}
+                    style={{width: "100%"}}
+                    value={provider.topP}
+                    onChange={(value) => {
+                      this.updateProviderField("topP", value);
+                    }}
+                    disabled={isRemote}
+                  />
                 </Col>
               </Row>
-            </>
-          ) : null
-        }
-        {
-          this.shouldShowClientSecretInput(this.state.provider) ? (
-            <Row style={{marginTop: "20px"}} >
-              <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                {this.getClientSecretLabel(this.state.provider)} :
-              </Col>
-              <Col span={22} >
-                <Input.Password disabled={isRemote} value={this.state.provider.clientSecret} onChange={e => {
-                  this.updateProviderField("clientSecret", e.target.value);
-                }} />
-              </Col>
-            </Row>
-          ) : null
-        }
-        {
-          (this.state.provider.category === "Model" && this.state.provider.type === "Claude" && Setting.getThinkingModelMaxTokens(this.state.provider.subType) !== 0) ? (
-            <>
-              <Row style={{marginTop: "20px"}} >
-                <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                  {Setting.getLabel(i18next.t("provider:Enable thinking"), i18next.t("provider:Enable thinking - Tooltip"))} :
-                </Col>
-                <Col span={22} >
-                  <Switch disabled={isRemote} checked={this.state.provider.enableThinking} onChange={checked => {
-                    this.updateProviderField("enableThinking", checked);
-                  }} />
-                </Col>
-              </Row>
-              {
-                this.state.provider.enableThinking && (
-                  <Row style={{marginTop: "20px"}} >
-                    <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                      {Setting.getLabel(i18next.t("provider:Thinking tokens"), i18next.t("provider:Thinking tokens - Tooltip"))} :
-                    </Col>
-                    <Col span={22} >
-                      <InputNumber min={1024} max={Setting.getThinkingModelMaxTokens(this.state.provider.subType) - 1} value={this.state.provider.topK || 1024} onChange={value => {
-                        this.updateProviderField("topK", value);
-                      }} />
-                    </Col>
-                  </Row>
-                )
-              }
-            </>
-          ) : null
-        }
-        {
-          ["Storage", "Model", "Embedding", "Text-to-Speech", "Speech-to-Text", "Scan"].includes(this.state.provider.category) || (this.state.provider.category === "Blockchain" && this.state.provider.type === "Ethereum") || (this.state.provider.category === "Private Cloud" && this.state.provider.type === "Kubernetes") ? null : (
-            <Row style={{marginTop: "20px"}} >
-              <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                {this.getRegionLabel(this.state.provider)} :
-              </Col>
-              <Col span={22} >
-                <Input disabled={isRemote} value={this.state.provider.region} onChange={e => {
-                  this.updateProviderField("region", e.target.value);
-                }} />
-              </Col>
-            </Row>
-          )
-        }
-        {
-          this.state.provider.category === "Blockchain" && (
-            <>
-              {this.state.provider.type === "Ethereum" ? null : (
-                <>
-                  <Row style={{marginTop: "20px"}}>
-                    <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                      {Setting.getLabel(i18next.t("provider:Chain"), i18next.t("provider:Chain - Tooltip"))} :
-                    </Col>
-                    <Col span={22}>
-                      <Input disabled={isRemote} value={this.state.provider.chain} onChange={e => {
-                        this.updateProviderField("chain", e.target.value);
-                      }} />
-                    </Col>
-                  </Row>
-                  <Row style={{marginTop: "20px"}}>
-                    <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                      {this.getNetworkLabel(this.state.provider)} :
-                    </Col>
-                    <Col span={22}>
-                      <Input disabled={isRemote} value={this.state.provider.network} onChange={e => {
-                        this.updateProviderField("network", e.target.value);
-                      }} />
-                    </Col>
-                  </Row>
-                </>
-              )}
-              {this.state.provider.type === "ChainMaker" ? (
-                <>
-                  <Row style={{marginTop: "20px"}}>
-                    <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                      {Setting.getLabel(i18next.t("provider:Auth type"), i18next.t("provider:Auth type - Tooltip"))} :
-                    </Col>
-                    <Col span={22}>
-                      <Select
-                        virtual={false}
-                        style={{width: "100%"}}
-                        value={this.state.provider.text}
-                        onChange={value => {
-                          this.updateProviderField("text", value);
-                        }}
-                      >
-                        <Select.Option value="permissionedwithcert">permissionedwithcert</Select.Option>
-                        <Select.Option value="permissionedwithkey">permissionedwithkey</Select.Option>
-                        <Select.Option value="public">public</Select.Option>
-                      </Select>
-                    </Col>
-                  </Row>
-                  <Row style={{marginTop: "20px"}} >
-                    <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                      {Setting.getLabel(i18next.t("cert:User cert"), i18next.t("cert:User cert - Tooltip"))} :
-                    </Col>
-                    <Col span={editorWidth} >
-                      <Button style={{marginRight: "10px", marginBottom: "10px"}} disabled={this.state.provider.userCert === ""} onClick={() => {
-                        copy(this.state.provider.userCert);
-                        Setting.showMessage("success", i18next.t("general:Copied to clipboard successfully"));
+            ) : null}
+            {(isModelProvider && (this.isTemperatureEnabled(provider) || this.isTopPEnabled(provider))) ? (
+              <Row style={{marginTop: "20px"}} gutter={16}>
+                {this.isTemperatureEnabled(provider) ? (
+                  <Col span={Setting.isMobile() ? 22 : 12}>
+                    <div style={{marginBottom: "4px"}}>
+                      {Setting.getLabel(i18next.t("provider:Presence penalty"), i18next.t("provider:Presence penalty - Tooltip"))}
+                    </div>
+                    <Slider
+                      min={provider.type === "OpenAI" ? -2 : 1}
+                      max={2}
+                      step={0.01}
+                      value={provider.presencePenalty ?? 0}
+                      disabled={isRemote}
+                      onChange={(value) => {
+                        this.updateProviderField("presencePenalty", value);
                       }}
-                      >
-                        {i18next.t("general:Copy")}
-                      </Button>
-                      <Button type="primary" disabled={this.state.provider.userCert === ""} onClick={() => {
-                        const blob = new Blob([this.state.provider.userCert], {type: "text/plain;charset=utf-8"});
-                        FileSaver.saveAs(blob, "user_cert.pem");
+                    />
+                    <div style={{textAlign: "right", fontSize: "12px", color: "#888", marginTop: "2px"}}>
+                      {Setting.myParseFloat(provider.presencePenalty ?? 0).toFixed(2)}
+                    </div>
+                  </Col>
+                ) : null}
+                {this.isTopPEnabled(provider) ? (
+                  <Col span={Setting.isMobile() ? 22 : 12}>
+                    <div style={{marginBottom: "4px"}}>
+                      {Setting.getLabel(i18next.t("provider:Frequency penalty"), i18next.t("provider:Frequency penalty - Tooltip"))}
+                    </div>
+                    <Slider
+                      min={-2}
+                      max={2}
+                      step={0.01}
+                      value={provider.frequencyPenalty ?? 0}
+                      disabled={isRemote}
+                      onChange={(value) => {
+                        this.updateProviderField("frequencyPenalty", value);
                       }}
-                      >
-                        {i18next.t("general:Download")}
-                      </Button>
-                      <TextArea autoSize={{minRows: 16, maxRows: 16}} value={this.state.provider.userCert} onChange={e => {
-                        this.updateProviderField("userCert", e.target.value);
-                      }} />
-                    </Col>
-                    <Col span={1} />
-                    <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                      {Setting.getLabel(i18next.t("cert:User key"), i18next.t("cert:User key - Tooltip"))} :
-                    </Col>
-                    <Col span={editorWidth} >
-                      <Button style={{marginRight: "10px", marginBottom: "10px"}} disabled={this.state.provider.userKey === ""} onClick={() => {
-                        copy(this.state.provider.userKey);
-                        Setting.showMessage("success", i18next.t("general:Copied to clipboard successfully"));
-                      }}
-                      >
-                        {i18next.t("general:Copy")}
-                      </Button>
-                      <Button type="primary" disabled={this.state.provider.userKey === ""} onClick={() => {
-                        const blob = new Blob([this.state.provider.userKey], {type: "text/plain;charset=utf-8"});
-                        FileSaver.saveAs(blob, "token_jwt_key.key");
-                      }}
-                      >
-                        {i18next.t("general:Download")}
-                      </Button>
-                      <TextArea autoSize={{minRows: 16, maxRows: 16}} value={this.state.provider.userKey} onChange={e => {
-                        this.updateProviderField("userKey", e.target.value);
-                      }} />
-                    </Col>
-                  </Row>
-                  <Row style={{marginTop: "20px"}} >
-                    <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                      {Setting.getLabel(i18next.t("cert:Sign cert"), i18next.t("cert:Sign cert - Tooltip"))} :
-                    </Col>
-                    <Col span={editorWidth} >
-                      <Button style={{marginRight: "10px", marginBottom: "10px"}} disabled={this.state.provider.signCert === ""} onClick={() => {
-                        copy(this.state.provider.signCert);
-                        Setting.showMessage("success", i18next.t("general:Copied to clipboard successfully"));
-                      }}
-                      >
-                        {i18next.t("general:Copy")}
-                      </Button>
-                      <Button type="primary" disabled={this.state.provider.signCert === ""} onClick={() => {
-                        const blob = new Blob([this.state.provider.signCert], {type: "text/plain;charset=utf-8"});
-                        FileSaver.saveAs(blob, "user_cert.pem");
-                      }}
-                      >
-                        {i18next.t("general:Download")}
-                      </Button>
-                      <TextArea autoSize={{minRows: 16, maxRows: 16}} value={this.state.provider.signCert} onChange={e => {
-                        this.updateProviderField("signCert", e.target.value);
-                      }} />
-                    </Col>
-                    <Col span={1} />
-                    <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                      {Setting.getLabel(i18next.t("cert:Sign key"), i18next.t("cert:Sign key - Tooltip"))} :
-                    </Col>
-                    <Col span={editorWidth} >
-                      <Button style={{marginRight: "10px", marginBottom: "10px"}} disabled={this.state.provider.signKey === ""} onClick={() => {
-                        copy(this.state.provider.signKey);
-                        Setting.showMessage("success", i18next.t("general:Copied to clipboard successfully"));
-                      }}
-                      >
-                        {i18next.t("general:Copy")}
-                      </Button>
-                      <Button type="primary" disabled={this.state.provider.signKey === ""} onClick={() => {
-                        const blob = new Blob([this.state.provider.signKey], {type: "text/plain;charset=utf-8"});
-                        FileSaver.saveAs(blob, "token_jwt_key.key");
-                      }}
-                      >
-                        {i18next.t("general:Download")}
-                      </Button>
-                      <TextArea autoSize={{minRows: 16, maxRows: 16}} value={this.state.provider.signKey} onChange={e => {
-                        this.updateProviderField("signKey", e.target.value);
-                      }} />
-                    </Col>
-                  </Row>
-                </>
-              ) : null}
-              {["Ethereum", "ChainMaker"].includes(this.state.provider.type) ? (
-                <>
-                  <Row style={{marginTop: "20px"}}>
-                    <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                      {this.getContractNameLabel(this.state.provider)} :
-                    </Col>
-                    <Col span={22}>
-                      <Input disabled={isRemote} value={this.state.provider.contractName} onChange={e => {
-                        this.updateProviderField("contractName", e.target.value);
-                      }} />
-                    </Col>
-                  </Row>
-                  <Row style={{marginTop: "20px"}}>
-                    <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                      {Setting.getLabel(i18next.t("provider:Invoke method"), i18next.t("provider:Invoke method - Tooltip"))} :
-                    </Col>
-                    <Col span={22}>
-                      <Input disabled={isRemote} value={this.state.provider.contractMethod} onChange={e => {
-                        this.updateProviderField("contractMethod", e.target.value);
-                      }} />
-                    </Col>
-                  </Row>
-                </>
-              ) : null}
-              <Row style={{marginTop: "20px"}}>
-                <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                  {Setting.getLabel(i18next.t("provider:Browser URL"), i18next.t("provider:Browser URL - Tooltip"))} :
+                    />
+                    <div style={{textAlign: "right", fontSize: "12px", color: "#888", marginTop: "2px"}}>
+                      {Setting.myParseFloat(provider.frequencyPenalty ?? 0).toFixed(2)}
+                    </div>
+                  </Col>
+                ) : null}
+              </Row>
+            ) : null}
+            {(provider.category === "Model" && provider.type === "Gemini") ? (
+              <Row style={{marginTop: "20px"}} gutter={16}>
+                <Col span={Setting.isMobile() ? 22 : 14}>
+                  <div style={{marginBottom: "4px"}}>{Setting.getLabel(i18next.t("provider:Top K"), i18next.t("provider:Top K - Tooltip"))}</div>
+                  <Slider
+                    min={1}
+                    max={6}
+                    step={1}
+                    value={provider.topK}
+                    disabled={isRemote}
+                    onChange={(value) => {
+                      this.updateProviderField("topK", value);
+                    }}
+                  />
                 </Col>
-                <Col span={22}>
-                  <Input prefix={<LinkOutlined />} value={this.state.provider.browserUrl}
-                    placeholder={this.state.provider.type === "ChainMaker" ? "https://explorer-testnet.chainmaker.org.cn/chainmaker_testnet_chain/block/{bh}" : ""}
-                    onChange={e => {
-                      this.updateProviderField("browserUrl", e.target.value);
-                    }} />
+                <Col span={Setting.isMobile() ? 22 : 2}>
+                  <div style={{marginBottom: "4px"}}>&nbsp;</div>
+                  <InputNumber
+                    min={1}
+                    max={6}
+                    step={1}
+                    style={{width: "100%"}}
+                    value={provider.topK}
+                    onChange={(value) => {
+                      this.updateProviderField("topK", value);
+                    }}
+                    disabled={isRemote}
+                  />
                 </Col>
               </Row>
-            </>
-          )
-        }
-        {
-          this.isTemperatureEnabled(this.state.provider) ? (
-            <>
-              <Row style={{marginTop: "20px"}}>
-                <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                  {Setting.getLabel(i18next.t("provider:Temperature"), i18next.t("provider:Temperature - Tooltip"))} :
-                </Col>
-                <this.InputSlider
-                  min={0}
-                  max={["Alibaba Cloud", "Gemini", "OpenAI", "OpenRouter", "Baichuan", "DeepSeek", "StepFun", "Tencent Cloud", "Mistral", "Yi", "Ollama", "Writer"].includes(this.state.provider.type) ? 2 : 1}
-                  step={0.01}
-                  value={this.state.provider.temperature}
-                  disabled={isRemote}
-                  onChange={(value) => {
-                    this.updateProviderField("temperature", value);
-                  }}
-                  isMobile={Setting.isMobile()}
-                />
-              </Row>
-            </>
-          ) : null
-        }
-        {
-          this.isTopPEnabled(this.state.provider) ? (
-            <>
-              <Row style={{marginTop: "20px"}}>
-                <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                  {Setting.getLabel(i18next.t("provider:Top P"), i18next.t("provider:Top P - Tooltip"))} :
-                </Col>
-                <this.InputSlider
-                  min={0}
-                  max={1.0}
-                  step={0.01}
-                  value={this.state.provider.topP}
-                  disabled={isRemote}
-                  onChange={(value) => {
-                    this.updateProviderField("topP", value);
-                  }}
-                  isMobile={Setting.isMobile()}
-                />
-              </Row>
-            </>
-          ) : null
-        }
-        {
-          (this.state.provider.category === "Model" && this.state.provider.type === "Gemini") ? (
-            <>
-              <Row style={{marginTop: "20px"}}>
-                <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                  {Setting.getLabel(i18next.t("provider:Top K"), i18next.t("provider:Top K - Tooltip"))} :
-                </Col>
-                <this.InputSlider
-                  min={1}
-                  max={6}
-                  step={1}
-                  value={this.state.provider.topK}
-                  disabled={isRemote}
-                  onChange={(value) => {
-                    this.updateProviderField("topK", value);
-                  }}
-                  isMobile={Setting.isMobile()}
-                />
-              </Row>
-            </>
-          ) : null
-        }
-        {
-          (this.state.provider.category === "Model" && this.state.provider.type === "OpenAI" && !["o1", "o1-pro", "o3", "o3-mini", "o4-mini"].includes(this.state.provider.subType)) ? (
-            <>
-              <Row style={{marginTop: "20px"}}>
-                <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                  {Setting.getLabel(i18next.t("provider:Presence penalty"), i18next.t("provider:Presence penalty - Tooltip"))} :
-                </Col>
-                <this.InputSlider
-                  label={i18next.t("provider:Presence penalty")}
-                  min={(this.state.provider.type === "OpenAI" ? -2 : 1)}
-                  max={2}
-                  step={0.01}
-                  value={this.state.provider.presencePenalty}
-                  disabled={isRemote}
-                  onChange={(value) => {
-                    this.updateProviderField("presencePenalty", value);
-                  }}
-                  isMobile={Setting.isMobile()}
-                />
-              </Row>
-            </>
-          ) : null
-        }
-        {
-          (this.state.provider.category === "Model" && this.state.provider.type === "OpenAI" && !["o1", "o1-pro", "o3", "o3-mini", "o4-mini"].includes(this.state.provider.subType)) ? (
-            <>
-              <Row style={{marginTop: "20px"}}>
-                <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                  {Setting.getLabel(i18next.t("provider:Frequency penalty"), i18next.t("provider:Frequency penalty - Tooltip"))} :
-                </Col>
-                <this.InputSlider
-                  label={i18next.t("provider:Frequency penalty")}
-                  min={-2}
-                  max={2}
-                  step={0.01}
-                  value={this.state.provider.frequencyPenalty}
-                  disabled={isRemote}
-                  onChange={(value) => {
-                    this.updateProviderField("frequencyPenalty", value);
-                  }}
-                  isMobile={Setting.isMobile()}
-                />
-              </Row>
-            </>
-          ) : null
-        }
+            ) : null}
+          </Card>
+        )}
         {
           ((this.state.provider.category === "Model" || this.state.provider.category === "Embedding") && this.state.provider.type === "Azure") ? (
             <>
@@ -1112,34 +1190,37 @@ class ProviderEditPage extends React.Component {
             </>
           ) : null
         }
-        <ModelTestWidget
-          provider={this.state.provider}
-          originalProvider={this.state.originalProvider}
-          account={this.props.account}
-        />
-        <EmbedTestWidget
-          provider={this.state.provider}
-          originalProvider={this.state.originalProvider}
-          account={this.props.account}
-          onUpdateProvider={this.updateProviderField.bind(this)}
-        />
-        <TtsTestWidget
-          provider={this.state.provider}
-          originalProvider={this.state.originalProvider}
-          account={this.props.account}
-          onUpdateProvider={this.updateProviderField.bind(this)}
-        />
-        <TestMcpWidget
-          provider={this.state.provider}
-          originalProvider={this.state.originalProvider}
-          onUpdateProvider={this.updateProviderField.bind(this)}
-        />
-        <TestScanWidget
-          provider={this.state.provider}
-          originalProvider={this.state.originalProvider}
-          account={this.props.account}
-          onUpdateProvider={this.updateProviderField.bind(this)}
-        />
+        {/* Card 3: Provider Test */}
+        <Card size="small" title={i18next.t("provider:Provider Test")} style={sectionCardStyle} type="inner">
+          <ModelTestWidget
+            provider={this.state.provider}
+            originalProvider={this.state.originalProvider}
+            account={this.props.account}
+          />
+          <EmbedTestWidget
+            provider={this.state.provider}
+            originalProvider={this.state.originalProvider}
+            account={this.props.account}
+            onUpdateProvider={this.updateProviderField.bind(this)}
+          />
+          <TtsTestWidget
+            provider={this.state.provider}
+            originalProvider={this.state.originalProvider}
+            account={this.props.account}
+            onUpdateProvider={this.updateProviderField.bind(this)}
+          />
+          <TestMcpWidget
+            provider={this.state.provider}
+            originalProvider={this.state.originalProvider}
+            onUpdateProvider={this.updateProviderField.bind(this)}
+          />
+          <TestScanWidget
+            provider={this.state.provider}
+            originalProvider={this.state.originalProvider}
+            account={this.props.account}
+            onUpdateProvider={this.updateProviderField.bind(this)}
+          />
+        </Card>
         {
           this.state.provider.category === "Chat" ? (
             <Row style={{marginTop: "20px"}} >
@@ -1164,24 +1245,6 @@ class ProviderEditPage extends React.Component {
                 <Button disabled={isRemote} type="primary" onClick={() => this.setTelegramWebhook()}>
                   {i18next.t("provider:Set Webhook")}
                 </Button>
-              </Col>
-            </Row>
-          ) : null
-        }
-        {
-          this.state.provider.category === "Model" ? (
-            <Row style={{marginTop: "20px"}} >
-              <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                {Setting.getLabel(i18next.t("provider:Provider key"), i18next.t("provider:Provider key - Tooltip"))} :
-              </Col>
-              <Col span={22} >
-                <Input.Password
-                  value={this.state.provider.providerKey}
-                  disabled={!Setting.isAdminUser(this.props.account)}
-                  onChange={e => {
-                    this.updateProviderField("providerKey", e.target.value);
-                  }}
-                />
               </Col>
             </Row>
           ) : null
@@ -1251,39 +1314,7 @@ class ProviderEditPage extends React.Component {
             </Row>
           ) : null
         }
-        <Row style={{marginTop: "20px"}} >
-          <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-            {Setting.getLabel(i18next.t("store:Is default"), i18next.t("store:Is default - Tooltip"))} :
-          </Col>
-          <Col span={1}>
-            <Switch disabled={isRemote} checked={this.state.provider.isDefault} onChange={checked => {
-              this.updateProviderField("isDefault", checked);
-            }} />
-          </Col>
-        </Row>
-        <Row style={{marginTop: "20px"}} >
-          <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-            {Setting.getLabel(i18next.t("provider:Is remote"), i18next.t("provider:Is remote - Tooltip"))} :
-          </Col>
-          <Col span={1}>
-            <Switch disabled checked={this.state.provider.isRemote} />
-          </Col>
-        </Row>
-        <Row style={{marginTop: "20px"}}>
-          <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-            {Setting.getLabel(i18next.t("general:State"), i18next.t("general:State - Tooltip"))} :
-          </Col>
-          <Col span={22}>
-            <Select virtual={false} disabled={isRemote} style={{width: "100%"}} value={this.state.provider.state} onChange={value => {
-              this.updateProviderField("state", value);
-            }}
-            options={[
-              {value: "Active", label: i18next.t("general:Active")},
-              {value: "Inactive", label: i18next.t("general:Inactive")},
-            ].map(item => Setting.getOption(item.label, item.value))} />
-          </Col>
-        </Row>
-      </Card>
+      </div>
     );
   }
 

--- a/web/src/ProviderListPage.js
+++ b/web/src/ProviderListPage.js
@@ -21,7 +21,7 @@ import * as Setting from "./Setting";
 import * as ProviderBackend from "./backend/ProviderBackend";
 import i18next from "i18next";
 import * as Provider from "./Provider";
-import {DeleteOutlined} from "@ant-design/icons";
+import {DeleteOutlined, EditOutlined} from "@ant-design/icons";
 import Highlighter from "react-highlight-words";
 
 class ProviderListPage extends BaseListPage {
@@ -297,18 +297,19 @@ class ProviderListPage extends BaseListPage {
         title: i18next.t("general:Action"),
         dataIndex: "action",
         key: "action",
-        width: "180px",
+        width: "150px",
         fixed: "right",
         render: (text, record, index) => {
+          const editLabel = record.isRemote ? i18next.t("general:View") : i18next.t("general:Edit");
           return (
-            <div>
+            <div style={{display: "flex", alignItems: "center", gap: "2px", flexWrap: "nowrap"}}>
               <Button
-                style={{marginTop: "10px", marginBottom: "10px", marginRight: "10px"}}
-                type={record.isRemote ? "default" : "primary"}
+                style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}}
+                type="default"
+                icon={<EditOutlined />}
                 onClick={() => this.props.history.push(`/providers/${record.name}`)}
-              >
-                {record.isRemote ? i18next.t("general:View") : i18next.t("general:Edit")}
-              </Button>
+                title={editLabel}
+              />
               <Popconfirm
                 title={`${i18next.t("general:Sure to delete")}: ${record.name} ?`}
                 onConfirm={() => this.deleteProvider(record)}
@@ -317,13 +318,12 @@ class ProviderListPage extends BaseListPage {
                 disabled={record.isRemote}
               >
                 <Button
-                  style={{marginBottom: "10px"}}
+                  style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}}
                   type="primary"
                   danger
                   disabled={record.isRemote}
-                >
-                  {i18next.t("general:Delete")}
-                </Button>
+                  icon={<DeleteOutlined />}
+                />
               </Popconfirm>
             </div>
           );

--- a/web/src/ProviderListPage.js
+++ b/web/src/ProviderListPage.js
@@ -14,7 +14,7 @@
 
 import React from "react";
 import {Link} from "react-router-dom";
-import {Button, Popconfirm, Switch, Table} from "antd";
+import {Button, Popconfirm, Switch, Table, Tooltip} from "antd";
 import moment from "moment";
 import BaseListPage from "./BaseListPage";
 import * as Setting from "./Setting";
@@ -303,13 +303,15 @@ class ProviderListPage extends BaseListPage {
           const editLabel = record.isRemote ? i18next.t("general:View") : i18next.t("general:Edit");
           return (
             <div style={{display: "flex", alignItems: "center", gap: "2px", flexWrap: "nowrap"}}>
-              <Button
-                style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}}
-                type="default"
-                icon={<EditOutlined />}
-                onClick={() => this.props.history.push(`/providers/${record.name}`)}
-                title={editLabel}
-              />
+              <Tooltip title={editLabel}>
+                <Button
+                  type="text"
+                  size="small"
+                  icon={<EditOutlined />}
+                  onClick={() => this.props.history.push(`/providers/${record.name}`)}
+                  style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}}
+                />
+              </Tooltip>
               <Popconfirm
                 title={`${i18next.t("general:Sure to delete")}: ${record.name} ?`}
                 onConfirm={() => this.deleteProvider(record)}
@@ -317,13 +319,16 @@ class ProviderListPage extends BaseListPage {
                 cancelText={i18next.t("general:Cancel")}
                 disabled={record.isRemote}
               >
-                <Button
-                  style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}}
-                  type="primary"
-                  danger
-                  disabled={record.isRemote}
-                  icon={<DeleteOutlined />}
-                />
+                <Tooltip title={i18next.t("general:Delete")}>
+                  <Button
+                    type="text"
+                    size="small"
+                    danger
+                    disabled={record.isRemote}
+                    icon={<DeleteOutlined />}
+                    style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}}
+                  />
+                </Tooltip>
               </Popconfirm>
             </div>
           );

--- a/web/src/RecordListPage.js
+++ b/web/src/RecordListPage.js
@@ -21,8 +21,7 @@ import * as RecordBackend from "./backend/RecordBackend";
 import * as ProviderBackend from "./backend/ProviderBackend";
 import i18next from "i18next";
 import BaseListPage from "./BaseListPage";
-import PopconfirmModal from "./modal/PopconfirmModal";
-import {CloseCircleFilled, DeleteOutlined} from "@ant-design/icons";
+import {CloseCircleFilled, DeleteOutlined, EditOutlined, SearchOutlined, UploadOutlined} from "@ant-design/icons";
 import Editor from "./common/Editor";
 import CommitResultWidget from "./component/record/CommitResultWidget";
 
@@ -196,6 +195,14 @@ class RecordListPage extends BaseListPage {
   };
 
   renderTable(records) {
+    const actionIconButtonStyle = {
+      minWidth: "28px",
+      width: "28px",
+      height: "28px",
+      padding: 0,
+      borderRadius: "6px",
+    };
+
     const columns = [
       {
         title: i18next.t("general:Organization"),
@@ -518,7 +525,7 @@ class RecordListPage extends BaseListPage {
         width: "150px",
         sorter: true,
         ...this.getColumnSearchProps("action"),
-        fixed: (Setting.isMobile()) ? "false" : "right",
+        fixed: "right",
         render: (text, record, index) => {
           return text;
         },
@@ -529,7 +536,7 @@ class RecordListPage extends BaseListPage {
         key: "block",
         width: "110px",
         sorter: true,
-        fixed: (Setting.isMobile()) ? "false" : "right",
+        fixed: "right",
         ...this.getColumnSearchProps("block"),
         render: (text, record, index) => {
           return Setting.getBlockBrowserUrl(this.state.providerMap, record, text, true);
@@ -541,7 +548,7 @@ class RecordListPage extends BaseListPage {
         key: "block2",
         width: "110px",
         sorter: true,
-        fixed: (Setting.isMobile()) ? "false" : "right",
+        fixed: "right",
         ...this.getColumnSearchProps("block2"),
         render: (text, record, index) => {
           return Setting.getBlockBrowserUrl(this.state.providerMap, record, text, false);
@@ -554,27 +561,30 @@ class RecordListPage extends BaseListPage {
         title: i18next.t("general:Action"),
         dataIndex: "recordAction",
         key: "recordAction",
-        width: this.state.enableCrossChain ? "370px" : "270px",
-        fixed: (Setting.isMobile()) ? "false" : "right",
+        width: this.state.enableCrossChain ? "180px" : "140px",
+        fixed: "right",
         render: (text, record, index) => {
           return (
             <div style={{
               display: "flex",
-              flexWrap: "wrap",
-              gap: "10px",
+              flexWrap: "nowrap",
+              gap: "2px",
               alignItems: "center",
-              marginTop: "10px",
-              marginBottom: "10px",
             }}>
               {
                 <>
                   {(record.block === "") ? (
-                    <Button
-                      disabled={record.block !== ""}
-                      type="primary" danger
-                      onClick={() => this.commitRecord(index, true)}
-                    >{i18next.t("record:Commit")}
-                    </Button>
+                    <Tooltip title={i18next.t("record:Commit")}>
+                      <Button
+                        disabled={record.block !== ""}
+                        type="text"
+                        danger
+                        size="small"
+                        icon={<UploadOutlined />}
+                        onClick={() => this.commitRecord(index, true)}
+                        style={actionIconButtonStyle}
+                      />
+                    </Tooltip>
                   ) : (
                     <Popover
                       placement="left"
@@ -595,14 +605,18 @@ class RecordListPage extends BaseListPage {
                       }
                       trigger="click"
                     >
-                      <Button
-                        disabled={record.block === ""}
-                        type="primary"
-                        onClick={() => {
-                          this.queryRecord(record, true);
-                        }}
-                      >{i18next.t("general:Query")}
-                      </Button>
+                      <Tooltip title={i18next.t("general:Query")}>
+                        <Button
+                          disabled={record.block === ""}
+                          type="text"
+                          size="small"
+                          icon={<SearchOutlined />}
+                          onClick={() => {
+                            this.queryRecord(record, true);
+                          }}
+                          style={actionIconButtonStyle}
+                        />
+                      </Tooltip>
                     </Popover>
                   )}
                   {this.state.enableCrossChain && (
@@ -610,10 +624,13 @@ class RecordListPage extends BaseListPage {
                       <Tooltip title={record.provider2 === "" ? i18next.t("general:Error") : ""}>
                         <Button
                           disabled={record.provider2 === ""}
-                          type="primary" danger
+                          type="text"
+                          danger
+                          size="small"
+                          icon={<UploadOutlined />}
                           onClick={() => this.commitRecord(index, false)}
-                        >{i18next.t("record:Commit") + " 2"}
-                        </Button>
+                          style={actionIconButtonStyle}
+                        />
                       </Tooltip>
                     ) : (
                       <Popover
@@ -635,31 +652,42 @@ class RecordListPage extends BaseListPage {
                         }
                         trigger="click"
                       >
-                        <Button
-                          disabled={record.block2 === ""}
-                          type="primary"
-                          onClick={() => {
-                            this.queryRecord(record, false);
-                          }}
-                        >{i18next.t("general:Query") + " 2"}
-                        </Button>
+                        <Tooltip title={i18next.t("general:Query") + " 2"}>
+                          <Button
+                            disabled={record.block2 === ""}
+                            type="text"
+                            size="small"
+                            icon={<SearchOutlined />}
+                            onClick={() => {
+                              this.queryRecord(record, false);
+                            }}
+                            style={actionIconButtonStyle}
+                          />
+                        </Tooltip>
                       </Popover>
                     )
                   )}
                 </>
               }
-              <Button
-                // disabled={record.owner !== this.props.account.owner}
-                onClick={() => this.props.history.push(`/records/${record.owner}/${record.id}`)}
-              >{i18next.t("general:View")}
-              </Button>
-              <PopconfirmModal
-                // disabled={record.owner !== this.props.account.owner}
-                fakeDisabled={true}
-                title={i18next.t("general:Sure to delete") + `: ${record.name} ?`}
-                onConfirm={() => this.deleteRecord(index)}
-              >
-              </PopconfirmModal>
+              <Tooltip title={i18next.t("general:View")}>
+                <Button
+                  type="text"
+                  size="small"
+                  icon={<EditOutlined />}
+                  onClick={() => this.props.history.push(`/records/${record.owner}/${record.id}`)}
+                  style={actionIconButtonStyle}
+                />
+              </Tooltip>
+              <Tooltip title={i18next.t("general:Delete")}>
+                <Button
+                  type="text"
+                  size="small"
+                  danger
+                  icon={<DeleteOutlined />}
+                  disabled
+                  style={actionIconButtonStyle}
+                />
+              </Tooltip>
             </div>
           );
         },

--- a/web/src/ResourceListPage.js
+++ b/web/src/ResourceListPage.js
@@ -14,7 +14,7 @@
 
 import React from "react";
 import {Button, Image, Popconfirm, Table, Tag, Upload} from "antd";
-import {UploadOutlined} from "@ant-design/icons";
+import {DeleteOutlined, UploadOutlined} from "@ant-design/icons";
 import copy from "copy-to-clipboard";
 import BaseListPage from "./BaseListPage";
 import * as Setting from "./Setting";
@@ -197,19 +197,24 @@ class ResourceListPage extends BaseListPage {
         title: i18next.t("general:Action"),
         dataIndex: "",
         key: "op",
-        width: "80px",
+        width: "150px",
         fixed: Setting.isMobile() ? "false" : "right",
         render: (_, record, index) => (
-          <Popconfirm
-            title={`${i18next.t("general:Sure to delete")}: ${record.name} ?`}
-            onConfirm={() => this.deleteResource(index)}
-            okText={i18next.t("general:OK")}
-            cancelText={i18next.t("general:Cancel")}
-          >
-            <Button type="primary" danger size="small">
-              {i18next.t("general:Delete")}
-            </Button>
-          </Popconfirm>
+          <div style={{display: "flex", alignItems: "center", gap: "2px", flexWrap: "nowrap"}}>
+            <Popconfirm
+              title={`${i18next.t("general:Sure to delete")}: ${record.name} ?`}
+              onConfirm={() => this.deleteResource(index)}
+              okText={i18next.t("general:OK")}
+              cancelText={i18next.t("general:Cancel")}
+            >
+              <Button
+                style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}}
+                type="primary"
+                danger
+                icon={<DeleteOutlined />}
+              />
+            </Popconfirm>
+          </div>
         ),
       },
     ];

--- a/web/src/ScaleListPage.js
+++ b/web/src/ScaleListPage.js
@@ -5,8 +5,8 @@
 
 import React from "react";
 import {Link} from "react-router-dom";
-import {Button, Popconfirm, Table, Tag} from "antd";
-import {DeleteOutlined} from "@ant-design/icons";
+import {Button, Popconfirm, Table, Tag, Tooltip} from "antd";
+import {DeleteOutlined, EditOutlined} from "@ant-design/icons";
 import moment from "moment";
 import BaseListPage from "./BaseListPage";
 import * as Setting from "./Setting";
@@ -144,26 +144,22 @@ class ScaleListPage extends BaseListPage {
         title: i18next.t("general:Action"),
         dataIndex: "action",
         key: "action",
-        width: "180px",
+        width: "130px",
         fixed: "right",
         render: (text, record) => (
-          <div>
-            <Button
-              style={{marginTop: "10px", marginBottom: "10px", marginRight: "10px"}}
-              type="primary"
-              onClick={() => this.props.history.push(`/scales/${record.owner}/${record.name}`)}
-            >
-              {i18next.t("general:Edit")}
-            </Button>
+          <div style={{display: "flex", alignItems: "center", gap: "2px", flexWrap: "nowrap"}}>
+            <Tooltip title={i18next.t("general:Edit")}>
+              <Button type="text" size="small" icon={<EditOutlined />} style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}} onClick={() => this.props.history.push(`/scales/${record.owner}/${record.name}`)} />
+            </Tooltip>
             <Popconfirm
               title={`${i18next.t("general:Sure to delete")}: ${record.name} ?`}
               onConfirm={() => this.deleteScale(record)}
               okText={i18next.t("general:OK")}
               cancelText={i18next.t("general:Cancel")}
             >
-              <Button style={{marginBottom: "10px"}} type="primary" danger>
-                {i18next.t("general:Delete")}
-              </Button>
+              <Tooltip title={i18next.t("general:Delete")}>
+                <Button type="text" size="small" danger icon={<DeleteOutlined />} style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}} />
+              </Tooltip>
             </Popconfirm>
           </div>
         ),

--- a/web/src/ScanListPage.js
+++ b/web/src/ScanListPage.js
@@ -14,7 +14,8 @@
 
 import React from "react";
 import {Link} from "react-router-dom";
-import {Button, Table, Tag} from "antd";
+import {Button, Popconfirm, Table, Tag, Tooltip} from "antd";
+import {DeleteOutlined, EditOutlined} from "@ant-design/icons";
 import moment from "moment";
 import * as Setting from "./Setting";
 import * as ScanBackend from "./backend/ScanBackend";
@@ -22,7 +23,6 @@ import * as AssetBackend from "./backend/AssetBackend";
 import * as ProviderBackend from "./backend/ProviderBackend";
 import i18next from "i18next";
 import BaseListPage from "./BaseListPage";
-import PopconfirmModal from "./modal/PopconfirmModal";
 import {ScanResultPopover} from "./common/ScanResultPopover";
 
 class ScanListPage extends BaseListPage {
@@ -367,19 +367,26 @@ class ScanListPage extends BaseListPage {
         title: i18next.t("general:Action"),
         dataIndex: "",
         key: "op",
-        width: "200px",
+        width: "130px",
         fixed: (Setting.isMobile()) ? "false" : "right",
         render: (text, record, index) => {
           return (
-            <div>
-              <Button style={{marginTop: "10px", marginBottom: "10px", marginRight: "10px"}} type="primary" onClick={() => this.props.history.push(`/scans/${record.name}`)}>{i18next.t("general:Edit")}</Button>
-              <PopconfirmModal
+            <div style={{display: "flex", alignItems: "center", gap: "2px", flexWrap: "nowrap"}}>
+              <Tooltip title={i18next.t("general:Edit")}>
+                <Button type="text" size="small" icon={<EditOutlined />} style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}} onClick={() => this.props.history.push(`/scans/${record.name}`)} />
+              </Tooltip>
+              <Popconfirm
                 title={i18next.t("general:Sure to delete") + `: ${record.name} ?`}
                 onConfirm={() => this.deleteItem(index).then(() => {
                   this.fetch({pagination: this.state.pagination});
                 })}
+                okText={i18next.t("general:OK")}
+                cancelText={i18next.t("general:Cancel")}
               >
-              </PopconfirmModal>
+                <Tooltip title={i18next.t("general:Delete")}>
+                  <Button type="text" size="small" danger icon={<DeleteOutlined />} style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}} />
+                </Tooltip>
+              </Popconfirm>
             </div>
           );
         },

--- a/web/src/ServerListPage.js
+++ b/web/src/ServerListPage.js
@@ -183,7 +183,7 @@ class ServerListPage extends BaseListPage {
         dataIndex: "action",
         key: "action",
         width: "130px",
-        fixed: (Setting.isMobile()) ? "right" : false,
+        fixed: "right",
         render: (text, record) => (
           <div style={{display: "flex", alignItems: "center", gap: "2px", flexWrap: "nowrap"}}>
             <Tooltip title={i18next.t("general:Edit")}>

--- a/web/src/ServerListPage.js
+++ b/web/src/ServerListPage.js
@@ -14,13 +14,13 @@
 
 import React from "react";
 import {Link} from "react-router-dom";
-import {Button, Popconfirm, Table} from "antd";
+import {Button, Popconfirm, Table, Tooltip} from "antd";
 import moment from "moment";
 import BaseListPage from "./BaseListPage";
 import * as Setting from "./Setting";
 import * as ServerBackend from "./backend/ServerBackend";
 import i18next from "i18next";
-import {DeleteOutlined} from "@ant-design/icons";
+import {DeleteOutlined, EditOutlined} from "@ant-design/icons";
 import ScanServerModal from "./common/modal/ScanServerModal";
 
 class ServerListPage extends BaseListPage {
@@ -182,23 +182,22 @@ class ServerListPage extends BaseListPage {
         title: i18next.t("general:Action"),
         dataIndex: "action",
         key: "action",
-        width: "220px",
+        width: "130px",
         fixed: (Setting.isMobile()) ? "right" : false,
         render: (text, record) => (
-          <div>
-            <Button style={{marginTop: "10px", marginBottom: "10px", marginRight: "10px"}} type="primary"
-              onClick={() => this.props.history.push(`/servers/${record.name}`)}>
-              {i18next.t("general:Edit")}
-            </Button>
+          <div style={{display: "flex", alignItems: "center", gap: "2px", flexWrap: "nowrap"}}>
+            <Tooltip title={i18next.t("general:Edit")}>
+              <Button type="text" size="small" icon={<EditOutlined />} style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}} onClick={() => this.props.history.push(`/servers/${record.name}`)} />
+            </Tooltip>
             <Popconfirm
               title={`${i18next.t("general:Sure to delete")}: ${record.name}?`}
               onConfirm={() => this.deleteServer(record)}
               okText={i18next.t("general:OK")}
               cancelText={i18next.t("general:Cancel")}
             >
-              <Button style={{marginBottom: "10px"}} type="primary" danger icon={<DeleteOutlined />}>
-                {i18next.t("general:Delete")}
-              </Button>
+              <Tooltip title={i18next.t("general:Delete")}>
+                <Button type="text" size="small" danger icon={<DeleteOutlined />} style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}} />
+              </Tooltip>
             </Popconfirm>
           </div>
         ),

--- a/web/src/SessionListPage.js
+++ b/web/src/SessionListPage.js
@@ -15,7 +15,7 @@
 import BaseListPage from "./BaseListPage";
 import * as Setting from "./Setting";
 import i18next from "i18next";
-import {Button, Popconfirm, Table, Tag} from "antd";
+import {Button, Popconfirm, Table, Tag, Tooltip} from "antd";
 import React from "react";
 import * as SessionBackend from "./backend/SessionBackend";
 import {DeleteOutlined} from "@ant-design/icons";
@@ -106,7 +106,7 @@ class SessionListPage extends BaseListPage {
         dataIndex: "action",
         key: "action",
         width: "150px",
-        fixed: (Setting.isMobile()) ? "false" : "right",
+        fixed: "right",
         render: (text, session, index) => {
           return (
             <div style={{display: "flex", alignItems: "center", gap: "2px", flexWrap: "nowrap"}}>
@@ -116,12 +116,15 @@ class SessionListPage extends BaseListPage {
                 okText={i18next.t("general:OK")}
                 cancelText={i18next.t("general:Cancel")}
               >
-                <Button
-                  style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}}
-                  type="primary"
-                  danger
-                  icon={<DeleteOutlined />}
-                />
+                <Tooltip title={i18next.t("general:Delete")}>
+                  <Button
+                    type="text"
+                    size="small"
+                    danger
+                    icon={<DeleteOutlined />}
+                    style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}}
+                  />
+                </Tooltip>
               </Popconfirm>
             </div>
           );

--- a/web/src/SessionListPage.js
+++ b/web/src/SessionListPage.js
@@ -19,7 +19,6 @@ import {Button, Popconfirm, Table, Tag} from "antd";
 import React from "react";
 import * as SessionBackend from "./backend/SessionBackend";
 import {DeleteOutlined} from "@ant-design/icons";
-import PopconfirmModal from "./modal/PopconfirmModal";
 
 class SessionListPage extends BaseListPage {
   deleteItem = async(i) => {
@@ -106,16 +105,24 @@ class SessionListPage extends BaseListPage {
         title: i18next.t("general:Action"),
         dataIndex: "action",
         key: "action",
-        width: "120px",
+        width: "150px",
         fixed: (Setting.isMobile()) ? "false" : "right",
         render: (text, session, index) => {
           return (
-            <div>
-              <PopconfirmModal
-                style={{marginTop: "10px", marginBottom: "10px", marginRight: "10px"}}
+            <div style={{display: "flex", alignItems: "center", gap: "2px", flexWrap: "nowrap"}}>
+              <Popconfirm
                 title={`${i18next.t("general:Sure to delete")}: ${session.name} ?`}
                 onConfirm={() => this.deleteSession(index)}
-              />
+                okText={i18next.t("general:OK")}
+                cancelText={i18next.t("general:Cancel")}
+              >
+                <Button
+                  style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}}
+                  type="primary"
+                  danger
+                  icon={<DeleteOutlined />}
+                />
+              </Popconfirm>
             </div>
           );
         },

--- a/web/src/SiteListPage.js
+++ b/web/src/SiteListPage.js
@@ -14,7 +14,8 @@
 
 import React from "react";
 import {Link} from "react-router-dom";
-import {Button, Popconfirm, Table} from "antd";
+import {Button, Popconfirm, Table, Tooltip} from "antd";
+import {DeleteOutlined, EditOutlined} from "@ant-design/icons";
 import moment from "moment";
 import BaseListPage from "./BaseListPage";
 import * as Setting from "./Setting";
@@ -123,17 +124,13 @@ class SiteListPage extends BaseListPage {
         title: i18next.t("general:Action"),
         dataIndex: "action",
         key: "action",
-        width: "180px",
+        width: "130px",
         fixed: "right",
         render: (text, record) => (
-          <div>
-            <Button
-              style={{marginTop: "10px", marginBottom: "10px", marginRight: "10px"}}
-              type="primary"
-              onClick={() => this.props.history.push(`/sites/${record.name}`)}
-            >
-              {i18next.t("general:Edit")}
-            </Button>
+          <div style={{display: "flex", alignItems: "center", gap: "2px", flexWrap: "nowrap"}}>
+            <Tooltip title={i18next.t("general:Edit")}>
+              <Button type="text" size="small" icon={<EditOutlined />} style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}} onClick={() => this.props.history.push(`/sites/${record.name}`)} />
+            </Tooltip>
             <Popconfirm
               title={`${i18next.t("general:Sure to delete")}: ${record.name} ?`}
               onConfirm={() => this.deleteSite(record)}
@@ -141,14 +138,9 @@ class SiteListPage extends BaseListPage {
               cancelText={i18next.t("general:Cancel")}
               disabled={record.name === "site-built-in"}
             >
-              <Button
-                style={{marginBottom: "10px"}}
-                type="primary"
-                danger
-                disabled={record.name === "site-built-in"}
-              >
-                {i18next.t("general:Delete")}
-              </Button>
+              <Tooltip title={i18next.t("general:Delete")}>
+                <Button type="text" size="small" danger icon={<DeleteOutlined />} style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}} disabled={record.name === "site-built-in"} />
+              </Tooltip>
             </Popconfirm>
           </div>
         ),

--- a/web/src/SkillListPage.js
+++ b/web/src/SkillListPage.js
@@ -169,7 +169,7 @@ class SkillListPage extends BaseListPage {
         dataIndex: "action",
         key: "action",
         width: "220px",
-        fixed: (Setting.isMobile()) ? "right" : false,
+        fixed: "right",
         render: (text, record) => (
           <div>
             <Button

--- a/web/src/StoreListPage.js
+++ b/web/src/StoreListPage.js
@@ -14,7 +14,7 @@
 
 import React from "react";
 import {Link} from "react-router-dom";
-import {Avatar, Button, Popconfirm, Switch, Table} from "antd";
+import {Avatar, Button, Dropdown, Popconfirm, Switch, Table, Tooltip} from "antd";
 import moment from "moment";
 import BaseListPage from "./BaseListPage";
 import * as Setting from "./Setting";
@@ -24,7 +24,7 @@ import * as Conf from "./Conf";
 import * as StorageProviderBackend from "./backend/StorageProviderBackend";
 import * as ProviderBackend from "./backend/ProviderBackend";
 import StoreShareModal from "./StoreShareModal";
-import {CopyOutlined, DeleteOutlined, ShareAltOutlined} from "@ant-design/icons";
+import {CopyOutlined, DeleteOutlined, EditOutlined, ExportOutlined, FileOutlined, MoreOutlined, ReloadOutlined, ShareAltOutlined} from "@ant-design/icons";
 import copy from "copy-to-clipboard";
 
 const defaultPrompt = "You are an expert in your field and you specialize in using your knowledge to answer or solve people's problems.";
@@ -492,60 +492,116 @@ class StoreListPage extends BaseListPage {
         title: i18next.t("general:Action"),
         dataIndex: "action",
         key: "action",
-        width: "430px",
+        width: "150px",
         fixed: "right",
         render: (text, record, index) => {
+          const moreItems = [];
           if (this.state.hideChat) {
-            return (
-              <div>
-                <Button style={{marginTop: "10px", marginBottom: "10px", marginRight: "10px"}} onClick={() => this.props.history.push(`/stores/${record.owner}/${record.name}/view`)}>{i18next.t("general:Files")}</Button>
-                {
-                  !Setting.isLocalAdminUser(this.props.account) ? null : (
-                    <React.Fragment>
-                      <Button style={{marginBottom: "10px", marginRight: "10px"}} icon={<ShareAltOutlined />} onClick={() => this.openShareModal(record)}>{i18next.t("store:Share")}</Button>
-                      <Button style={{marginBottom: "10px", marginRight: "10px"}} type="primary" onClick={() => this.props.history.push(`/stores/${record.owner}/${record.name}`)}>{i18next.t("general:Edit")}</Button>
-                      <Popconfirm
-                        title={`${i18next.t("general:Sure to delete")}: ${record.name} ?`}
-                        onConfirm={() => this.deleteStore(record)}
-                        okText={i18next.t("general:OK")}
-                        cancelText={i18next.t("general:Cancel")}
-                        disabled={record.isDefault || Setting.isUserBoundToStore(this.props.account)}
-                      >
-                        <Button style={{marginBottom: "10px"}} type="primary" danger disabled={record.isDefault || Setting.isUserBoundToStore(this.props.account)}>{i18next.t("general:Delete")}</Button>
-                      </Popconfirm>
-                    </React.Fragment>
-                  )
-                }
-              </div>
+            moreItems.push({
+              key: "files",
+              icon: <FileOutlined />,
+              label: i18next.t("general:Files"),
+              onClick: () => this.props.history.push(`/stores/${record.owner}/${record.name}/view`),
+            });
+            if (Setting.isLocalAdminUser(this.props.account)) {
+              moreItems.push({
+                key: "share",
+                icon: <ShareAltOutlined />,
+                label: i18next.t("store:Share"),
+                onClick: () => this.openShareModal(record),
+              });
+            }
+          } else {
+            moreItems.push(
+              {
+                key: "files",
+                icon: <FileOutlined />,
+                label: i18next.t("general:Files"),
+                onClick: () => this.props.history.push(`/stores/${record.owner}/${record.name}/view`),
+              },
+              {
+                key: "copy-link",
+                icon: <CopyOutlined />,
+                label: i18next.t("general:Copy Link"),
+                onClick: () => {
+                  copy(`${window.location.origin}/${record.owner}/${record.name}/chat`);
+                  Setting.showMessage("success", i18next.t("general:Successfully copied"));
+                },
+              },
+              {
+                key: "open-chat",
+                icon: <ExportOutlined />,
+                label: i18next.t("store:Open Chat"),
+                onClick: () => {
+                  Setting.setStore(record.name);
+                  window.open(`${window.location.origin}/${record.owner}/${record.name}/chat`, "_blank");
+                },
+              }
             );
+            if (Setting.isLocalAdminUser(this.props.account)) {
+              moreItems.push(
+                {
+                  key: "share",
+                  icon: <ShareAltOutlined />,
+                  label: i18next.t("store:Share"),
+                  onClick: () => this.openShareModal(record),
+                },
+                {
+                  key: "refresh-vectors",
+                  icon: <ReloadOutlined />,
+                  label: i18next.t("general:Refresh Vectors"),
+                  disabled: this.state.generating[index],
+                  onClick: () => this.refreshStoreVectors(index),
+                }
+              );
+            }
           }
 
           return (
-            <div>
-              <Button style={{marginTop: "10px", marginBottom: "10px", marginRight: "10px"}} onClick={() => this.props.history.push(`/stores/${record.owner}/${record.name}/view`)}>{i18next.t("general:Files")}</Button>
-              <Button style={{marginBottom: "10px", marginRight: "10px"}} icon={<CopyOutlined />} onClick={() => {copy(`${window.location.origin}/${record.owner}/${record.name}/chat`);Setting.showMessage("success", i18next.t("general:Successfully copied"));}}>{i18next.t("general:Copy Link")}</Button>
-              <Button style={{marginBottom: "10px", marginRight: "10px"}} onClick={() => {
-                Setting.setStore(record.name);
-                window.open(`${window.location.origin}/${record.owner}/${record.name}/chat`, "_blank");
-              }}>{i18next.t("store:Open Chat")}</Button>
-              {
-                !Setting.isLocalAdminUser(this.props.account) ? null : (
-                  <React.Fragment>
-                    <Button style={{marginBottom: "10px", marginRight: "10px"}} icon={<ShareAltOutlined />} onClick={() => this.openShareModal(record)}>{i18next.t("store:Share")}</Button>
-                    <Button style={{marginBottom: "10px", marginRight: "10px"}} loading={this.state.generating[index]} onClick={() => this.refreshStoreVectors(index)}>{i18next.t("general:Refresh Vectors")}</Button>
-                    <Button style={{marginBottom: "10px", marginRight: "10px"}} type="primary" onClick={() => this.props.history.push(`/stores/${record.owner}/${record.name}`)}>{i18next.t("general:Edit")}</Button>
-                    <Popconfirm
-                      title={`${i18next.t("general:Sure to delete")}: ${record.name} ?`}
-                      onConfirm={() => this.deleteStore(record)}
-                      okText={i18next.t("general:OK")}
-                      cancelText={i18next.t("general:Cancel")}
-                      disabled={record.isDefault || Setting.isUserBoundToStore(this.props.account)}
-                    >
-                      <Button style={{marginBottom: "10px"}} type="primary" danger disabled={record.isDefault || Setting.isUserBoundToStore(this.props.account)}>{i18next.t("general:Delete")}</Button>
-                    </Popconfirm>
-                  </React.Fragment>
-                )
-              }
+            <div style={{display: "flex", alignItems: "center", gap: "2px", flexWrap: "nowrap"}}>
+              {Setting.isLocalAdminUser(this.props.account) && (
+                <>
+                  <Tooltip title={i18next.t("general:Edit")}>
+                    <Button
+                      type="text"
+                      size="small"
+                      icon={<EditOutlined />}
+                      onClick={() => this.props.history.push(`/stores/${record.owner}/${record.name}`)}
+                      style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}}
+                    />
+                  </Tooltip>
+                  <Popconfirm
+                    title={`${i18next.t("general:Sure to delete")}: ${record.name} ?`}
+                    onConfirm={() => this.deleteStore(record)}
+                    okText={i18next.t("general:OK")}
+                    cancelText={i18next.t("general:Cancel")}
+                    disabled={record.isDefault || Setting.isUserBoundToStore(this.props.account)}
+                  >
+                    <Tooltip title={i18next.t("general:Delete")}>
+                      <Button
+                        type="text"
+                        size="small"
+                        danger
+                        icon={<DeleteOutlined />}
+                        disabled={record.isDefault || Setting.isUserBoundToStore(this.props.account)}
+                        style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}}
+                      />
+                    </Tooltip>
+                  </Popconfirm>
+                </>
+              )}
+              {moreItems.length > 0 && (
+                <Dropdown menu={{items: moreItems}} trigger={["click"]} placement="bottomRight">
+                  <Tooltip title={i18next.t("general:More")}>
+                    <Button
+                      type="text"
+                      size="small"
+                      icon={<MoreOutlined />}
+                      style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}}
+                    />
+                  </Tooltip>
+                </Dropdown>
+              )}
             </div>
           );
         },

--- a/web/src/TaskListPage.js
+++ b/web/src/TaskListPage.js
@@ -14,8 +14,8 @@
 
 import React from "react";
 import {Link} from "react-router-dom";
-import {Button, Input, Popconfirm, Popover, Table, Tag} from "antd";
-import {DeleteOutlined, FilePdfOutlined, FileWordOutlined} from "@ant-design/icons";
+import {Button, Input, Popconfirm, Popover, Table, Tag, Tooltip} from "antd";
+import {DeleteOutlined, EditOutlined, FilePdfOutlined, FileWordOutlined} from "@ant-design/icons";
 import moment from "moment";
 import BaseListPage from "./BaseListPage";
 import * as Setting from "./Setting";
@@ -403,31 +403,23 @@ class TaskListPage extends BaseListPage {
         title: i18next.t("general:Action"),
         dataIndex: "action",
         key: "action",
-        width: "180px",
+        width: "130px",
         fixed: "right",
         render: (text, record, index) => {
           return (
-            <div>
-              <Button
-                style={{marginTop: "10px", marginBottom: "10px", marginRight: "10px"}}
-                type="primary"
-                onClick={() => this.props.history.push(`/tasks/${record.owner}/${record.name}`)}
-              >
-                {i18next.t("general:Edit")}
-              </Button>
+            <div style={{display: "flex", alignItems: "center", gap: "2px", flexWrap: "nowrap"}}>
+              <Tooltip title={i18next.t("general:Edit")}>
+                <Button type="text" size="small" icon={<EditOutlined />} style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}} onClick={() => this.props.history.push(`/tasks/${record.owner}/${record.name}`)} />
+              </Tooltip>
               <Popconfirm
                 title={`${i18next.t("general:Sure to delete")}: ${record.name} ?`}
                 onConfirm={() => this.deleteTask(record)}
                 okText={i18next.t("general:OK")}
                 cancelText={i18next.t("general:Cancel")}
               >
-                <Button
-                  style={{marginBottom: "10px"}}
-                  type="primary"
-                  danger
-                >
-                  {i18next.t("general:Delete")}
-                </Button>
+                <Tooltip title={i18next.t("general:Delete")}>
+                  <Button type="text" size="small" danger icon={<DeleteOutlined />} style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}} />
+                </Tooltip>
               </Popconfirm>
             </div>
           );

--- a/web/src/TemplateListPage.js
+++ b/web/src/TemplateListPage.js
@@ -15,7 +15,7 @@
 import React from "react";
 import {Link} from "react-router-dom";
 import {Button, Popconfirm, Table, Tooltip} from "antd";
-import {DeleteOutlined} from "@ant-design/icons";
+import {DeleteOutlined, EditOutlined} from "@ant-design/icons";
 import moment from "moment";
 import BaseListPage from "./BaseListPage";
 import * as Setting from "./Setting";
@@ -185,19 +185,23 @@ spec:
         title: i18next.t("general:Action"),
         dataIndex: "action",
         key: "action",
-        width: "180px",
+        width: "130px",
         fixed: (Setting.isMobile()) ? "false" : "right",
         render: (text, record, index) => {
           return (
-            <div>
-              <Button style={{marginTop: "10px", marginBottom: "10px", marginRight: "10px"}} type="primary" onClick={() => this.props.history.push(`/templates/${record.name}`)}>{i18next.t("general:Edit")}</Button>
+            <div style={{display: "flex", alignItems: "center", gap: "2px", flexWrap: "nowrap"}}>
+              <Tooltip title={i18next.t("general:Edit")}>
+                <Button type="text" size="small" icon={<EditOutlined />} style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}} onClick={() => this.props.history.push(`/templates/${record.name}`)} />
+              </Tooltip>
               <Popconfirm
                 title={`${i18next.t("general:Sure to delete")}: ${record.name} ?`}
                 onConfirm={() => this.deleteTemplate(record)}
                 okText={i18next.t("general:OK")}
                 cancelText={i18next.t("general:Cancel")}
               >
-                <Button style={{marginBottom: "10px"}} type="primary" danger>{i18next.t("general:Delete")}</Button>
+                <Tooltip title={i18next.t("general:Delete")}>
+                  <Button type="text" size="small" danger icon={<DeleteOutlined />} style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}} />
+                </Tooltip>
               </Popconfirm>
             </div>
           );

--- a/web/src/ToolListPage.js
+++ b/web/src/ToolListPage.js
@@ -165,7 +165,7 @@ class ToolListPage extends BaseListPage {
         dataIndex: "action",
         key: "action",
         width: "130px",
-        fixed: (Setting.isMobile()) ? "right" : false,
+        fixed: "right",
         render: (text, record) => (
           <div style={{display: "flex", alignItems: "center", gap: "2px", flexWrap: "nowrap"}}>
             <Tooltip title={i18next.t("general:Edit")}>

--- a/web/src/ToolListPage.js
+++ b/web/src/ToolListPage.js
@@ -14,13 +14,13 @@
 
 import React from "react";
 import {Link} from "react-router-dom";
-import {Button, Popconfirm, Switch, Table, Tag} from "antd";
+import {Button, Popconfirm, Switch, Table, Tag, Tooltip} from "antd";
 import moment from "moment";
 import BaseListPage from "./BaseListPage";
 import * as Setting from "./Setting";
 import * as ToolBackend from "./backend/ToolBackend";
 import i18next from "i18next";
-import {DeleteOutlined} from "@ant-design/icons";
+import {DeleteOutlined, EditOutlined} from "@ant-design/icons";
 
 class ToolListPage extends BaseListPage {
   constructor(props) {
@@ -164,23 +164,22 @@ class ToolListPage extends BaseListPage {
         title: i18next.t("general:Action"),
         dataIndex: "action",
         key: "action",
-        width: "220px",
+        width: "130px",
         fixed: (Setting.isMobile()) ? "right" : false,
         render: (text, record) => (
-          <div>
-            <Button style={{marginTop: "10px", marginBottom: "10px", marginRight: "10px"}} type="primary"
-              onClick={() => this.props.history.push(`/tools/${record.name}`)}>
-              {i18next.t("general:Edit")}
-            </Button>
+          <div style={{display: "flex", alignItems: "center", gap: "2px", flexWrap: "nowrap"}}>
+            <Tooltip title={i18next.t("general:Edit")}>
+              <Button type="text" size="small" icon={<EditOutlined />} style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}} onClick={() => this.props.history.push(`/tools/${record.name}`)} />
+            </Tooltip>
             <Popconfirm
               title={`${i18next.t("general:Sure to delete")}: ${record.name}?`}
               onConfirm={() => this.deleteTool(record)}
               okText={i18next.t("general:OK")}
               cancelText={i18next.t("general:Cancel")}
             >
-              <Button style={{marginBottom: "10px"}} type="primary" danger icon={<DeleteOutlined />}>
-                {i18next.t("general:Delete")}
-              </Button>
+              <Tooltip title={i18next.t("general:Delete")}>
+                <Button type="text" size="small" danger icon={<DeleteOutlined />} style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}} />
+              </Tooltip>
             </Popconfirm>
           </div>
         ),

--- a/web/src/VectorListPage.js
+++ b/web/src/VectorListPage.js
@@ -20,7 +20,7 @@ import BaseListPage from "./BaseListPage";
 import * as Setting from "./Setting";
 import * as VectorBackend from "./backend/VectorBackend";
 import i18next from "i18next";
-import {DeleteOutlined} from "@ant-design/icons";
+import {DeleteOutlined, EditOutlined} from "@ant-design/icons";
 import Editor from "./common/Editor";
 
 class VectorListPage extends BaseListPage {
@@ -234,20 +234,23 @@ class VectorListPage extends BaseListPage {
         title: i18next.t("general:Action"),
         dataIndex: "action",
         key: "action",
-        width: "150px",
+        width: "130px",
         fixed: "right",
         render: (text, record, index) => {
           return (
-            <div>
-              {/* <Button style={{marginBottom: "10px", marginRight: "10px"}} disabled={this.state.generating} onClick={() => Setting.showMessage("error", "Not implemented")}>{i18next.t("general:Refresh")}</Button>*/}
-              <Button style={{marginTop: "10px", marginBottom: "10px", marginRight: "10px"}} type="primary" onClick={() => this.props.history.push(`/vectors/${record.name}`)}>{i18next.t("general:Edit")}</Button>
+            <div style={{display: "flex", alignItems: "center", gap: "2px", flexWrap: "nowrap"}}>
+              <Tooltip title={i18next.t("general:Edit")}>
+                <Button type="text" size="small" icon={<EditOutlined />} style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}} onClick={() => this.props.history.push(`/vectors/${record.name}`)} />
+              </Tooltip>
               <Popconfirm
                 title={`${i18next.t("general:Sure to delete")}: ${record.name} ?`}
                 onConfirm={() => this.deleteVector(record)}
                 okText={i18next.t("general:OK")}
                 cancelText={i18next.t("general:Cancel")}
               >
-                <Button style={{marginBottom: "10px"}} type="primary" danger>{i18next.t("general:Delete")}</Button>
+                <Tooltip title={i18next.t("general:Delete")}>
+                  <Button type="text" size="small" danger icon={<DeleteOutlined />} style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}} />
+                </Tooltip>
               </Popconfirm>
             </div>
           );

--- a/web/src/VideoListPage.js
+++ b/web/src/VideoListPage.js
@@ -14,8 +14,8 @@
 
 import React from "react";
 import {Link} from "react-router-dom";
-import {Button, List, Popconfirm, Table, Tooltip, Upload} from "antd";
-import {DeleteOutlined, DownloadOutlined, UploadOutlined} from "@ant-design/icons";
+import {Button, Dropdown, List, Popconfirm, Table, Tooltip, Upload} from "antd";
+import {DeleteOutlined, DownloadOutlined, EditOutlined, ExportOutlined, MoreOutlined, UploadOutlined} from "@ant-design/icons";
 import moment from "moment";
 import BaseListPage from "./BaseListPage";
 import * as Setting from "./Setting";
@@ -487,15 +487,16 @@ class VideoListPage extends BaseListPage {
         width: "150px",
         fixed: "right",
         render: (text, record, index) => {
+          const editLabel = (this.requireUserOrAdmin(record)) ? i18next.t("general:View") : i18next.t("general:Edit");
           return (
-            <div>
-              <Button style={{marginTop: "10px", marginBottom: "10px", marginRight: "10px"}} onClick={() => Setting.openLink(`/videos/${record.owner}/${record.name}`)}>{i18next.t("general:Open")}</Button>
-              <Button style={{marginBottom: "10px", marginRight: "10px"}} type="primary" onClick={() => this.props.history.push(`/videos/${record.owner}/${record.name}`)}>
-                {
-                  (this.requireUserOrAdmin(record)) ? i18next.t("general:View") :
-                    i18next.t("general:Edit")
-                }
-              </Button>
+            <div style={{display: "flex", alignItems: "center", gap: "2px", flexWrap: "nowrap"}}>
+              <Button
+                style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}}
+                type="default"
+                icon={<EditOutlined />}
+                onClick={() => this.props.history.push(`/videos/${record.owner}/${record.name}`)}
+                title={editLabel}
+              />
               <Popconfirm
                 disabled={this.requireUserOrAdmin(record)}
                 title={`${i18next.t("general:Sure to delete")}: ${record.name} ?`}
@@ -503,8 +504,36 @@ class VideoListPage extends BaseListPage {
                 okText={i18next.t("general:OK")}
                 cancelText={i18next.t("general:Cancel")}
               >
-                <Button disabled={this.requireUserOrAdmin(record)} style={{marginBottom: "10px"}} type="primary" danger>{i18next.t("general:Delete")}</Button>
+                <Button
+                  style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}}
+                  type="primary"
+                  danger
+                  disabled={this.requireUserOrAdmin(record)}
+                  icon={<DeleteOutlined />}
+                />
               </Popconfirm>
+              <Dropdown
+                menu={{
+                  items: [
+                    {
+                      key: "open",
+                      icon: <ExportOutlined />,
+                      label: i18next.t("general:Open"),
+                    },
+                  ],
+                  onClick: ({key}) => {
+                    if (key === "open") {
+                      Setting.openLink(`/videos/${record.owner}/${record.name}`);
+                    }
+                  },
+                }}
+                trigger={["click"]}
+              >
+                <Button
+                  style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}}
+                  icon={<MoreOutlined />}
+                />
+              </Dropdown>
             </div>
           );
         },

--- a/web/src/WorkflowListPage.js
+++ b/web/src/WorkflowListPage.js
@@ -21,7 +21,7 @@ import * as Setting from "./Setting";
 import * as WorkflowBackend from "./backend/WorkflowBackend";
 import i18next from "i18next";
 import BpmnComponent from "./BpmnComponent";
-import {DeleteOutlined} from "@ant-design/icons";
+import {DeleteOutlined, EditOutlined} from "@ant-design/icons";
 import Editor from "./common/Editor";
 
 class WorkflowListPage extends BaseListPage {
@@ -268,12 +268,14 @@ class WorkflowListPage extends BaseListPage {
         title: i18next.t("general:Action"),
         dataIndex: "action",
         key: "action",
-        width: "180px",
+        width: "130px",
         fixed: (Setting.isMobile()) ? "false" : "right",
         render: (text, record, index) => {
           return (
-            <div>
-              <Button style={{marginTop: "10px", marginBottom: "10px", marginRight: "10px"}} type="primary" onClick={() => this.props.history.push(`/workflows/${record.name}`)}>{i18next.t("general:Edit")}</Button>
+            <div style={{display: "flex", alignItems: "center", gap: "2px", flexWrap: "nowrap"}}>
+              <Tooltip title={i18next.t("general:Edit")}>
+                <Button type="text" size="small" icon={<EditOutlined />} style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}} onClick={() => this.props.history.push(`/workflows/${record.name}`)} />
+              </Tooltip>
               <Popconfirm
                 placement="topLeft"
                 title={`${i18next.t("general:Sure to delete")}: ${record.name} ?`}
@@ -281,7 +283,9 @@ class WorkflowListPage extends BaseListPage {
                 okText={i18next.t("general:OK")}
                 cancelText={i18next.t("general:Cancel")}
               >
-                <Button style={{marginBottom: "10px"}} type="primary" danger>{i18next.t("general:Delete")}</Button>
+                <Tooltip title={i18next.t("general:Delete")}>
+                  <Button type="text" size="small" danger icon={<DeleteOutlined />} style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}} />
+                </Tooltip>
               </Popconfirm>
             </div>
           );

--- a/web/src/chat/ChatInput.js
+++ b/web/src/chat/ChatInput.js
@@ -174,17 +174,14 @@ const ChatInput = React.forwardRef(({
             </div>
           </div>
         )}
-        <div
-          className={inputShellClassName || "chat-input-wrapper"}
-          style={{
-            "--chat-input-shell-border-color": inputShellBorderColor,
-            "--chat-input-shell-box-shadow": inputShellBoxShadow,
-            borderRadius: "24px",
-            boxShadow: inputShellBoxShadow,
-            overflow: "hidden",
-            border: `1px solid ${inputShellBorderColor}`,
-            transition: "border-color 0.25s ease, box-shadow 0.25s ease",
-          }}>
+        <div className={inputShellClassName} style={{
+          "--chat-input-shell-border-color": inputShellBorderColor,
+          "--chat-input-shell-box-shadow": inputShellBoxShadow,
+          borderRadius: "16px",
+          boxShadow: inputShellBoxShadow,
+          overflow: "hidden",
+          border: `1px solid ${inputShellBorderColor}`,
+        }}>
           <Sender
             ref={senderRef}
             prefix={
@@ -200,7 +197,7 @@ const ChatInput = React.forwardRef(({
             }
             loading={loading}
             disabled={disableInput}
-            style={{flex: 1, borderRadius: "24px", background: isDark ? "#1a1a1a" : "#fff", border: "none", boxShadow: "none"}}
+            style={{flex: 1, borderRadius: "16px", background: isDark ? "#1a1a1a" : "#fff", border: "none", boxShadow: "none"}}
             placeholder={messageError ? "" : i18next.t("chat:Type message here")}
             value={(files.length > 0 && value === "") ? " " + value : value}
             onChange={onChange}

--- a/web/src/chat/ChatInput.js
+++ b/web/src/chat/ChatInput.js
@@ -174,14 +174,17 @@ const ChatInput = React.forwardRef(({
             </div>
           </div>
         )}
-        <div className={inputShellClassName} style={{
-          "--chat-input-shell-border-color": inputShellBorderColor,
-          "--chat-input-shell-box-shadow": inputShellBoxShadow,
-          borderRadius: "16px",
-          boxShadow: inputShellBoxShadow,
-          overflow: "hidden",
-          border: `1px solid ${inputShellBorderColor}`,
-        }}>
+        <div
+          className={inputShellClassName || "chat-input-wrapper"}
+          style={{
+            "--chat-input-shell-border-color": inputShellBorderColor,
+            "--chat-input-shell-box-shadow": inputShellBoxShadow,
+            borderRadius: "24px",
+            boxShadow: inputShellBoxShadow,
+            overflow: "hidden",
+            border: `1px solid ${inputShellBorderColor}`,
+            transition: "border-color 0.25s ease, box-shadow 0.25s ease",
+          }}>
           <Sender
             ref={senderRef}
             prefix={
@@ -197,7 +200,7 @@ const ChatInput = React.forwardRef(({
             }
             loading={loading}
             disabled={disableInput}
-            style={{flex: 1, borderRadius: "16px", background: isDark ? "#1a1a1a" : "#fff", border: "none", boxShadow: "none"}}
+            style={{flex: 1, borderRadius: "24px", background: isDark ? "#1a1a1a" : "#fff", border: "none", boxShadow: "none"}}
             placeholder={messageError ? "" : i18next.t("chat:Type message here")}
             value={(files.length > 0 && value === "") ? " " + value : value}
             onChange={onChange}


### PR DESCRIPTION
## Summary

This PR polishes the admin UI for form-heavy and table-heavy pages to make editing workflows cleaner and more consistent.

The update focuses on three areas:
- unify input styling across the app
- simplify crowded table action columns
- restructure large edit forms into clearer sections

## What changed

### 1. Input styling refresh
- Updated shared input styles in `web/src/index.css`
- Applied a more rounded input appearance across the app
- Added a clearer focus/active highlight so editable controls are easier to scan
<img width="1389" height="704" alt="image" src="https://github.com/user-attachments/assets/15eea1f9-10b8-4392-9ab0-027dbfd37abc" />

### 2. Chat input polish
- Refined `web/src/chat/ChatInput.js`
- Increased the chat input radius and improved the outer focus treatment
- Kept behavior unchanged while making the composer feel more intentional
<img width="1389" height="704" alt="image" src="https://github.com/user-attachments/assets/15eea1f9-10b8-4392-9ab0-027dbfd37abc" />

### 3. Store form restructure
- Reworked `web/src/StoreEditPage.js`
- Preserved all existing fields and save behavior
- Reorganized the page into cards with multi-column layout:
  - `General Settings`
  - `Providers`
  - `Chat`
  - `Options`
  - `File tree`
- Unified the top and bottom action areas for save-related actions
- Reduced the “single long column of inputs” feel and made the page closer in structure to the provider edit experience
<img width="1360" height="718" alt="1f53d1059eb34a8c45637f98ebb2ab73" src="https://github.com/user-attachments/assets/06d39c3d-9919-46e3-9eaa-56c47e43ce8c" />
<img width="1384" height="715" alt="479323122490fd6e1f1c0c50a8d5919f" src="https://github.com/user-attachments/assets/c1173232-4bb7-48f4-9f63-67a4b924c2f9" />

### 4. Table action cleanup
- Refactored action columns across list pages to reduce visual noise
- Replaced text-heavy Edit/Delete actions with compact icon buttons where appropriate
- Consolidated secondary actions into a `More` dropdown on affected pages
<img width="1386" height="728" alt="212f47bfacc1dbfea12a7c79c2d50ab8" src="https://github.com/user-attachments/assets/478c6a00-56ff-4ebd-bf8d-884cfe0289a4" />

### 5. Provider form restructure
- Reworked `web/src/ProviderEditPage.js`
- Split the long provider form into clearer cards:
  - `General Settings`
  - `Advanced Model Parameters`
  - `Provider Test`
- Improved spacing and grouping for dense provider configuration fields
- Hid the advanced parameter card when the selected provider does not expose relevant tuning controls
<img width="1383" height="695" alt="1b3ad21ade165510b102f731be604790" src="https://github.com/user-attachments/assets/9353cdb8-1792-4198-9b51-14bcabc8796f" />
<img width="1386" height="712" alt="cc68aef320bfd28cee932fcf6a75b82e" src="https://github.com/user-attachments/assets/62a2d213-d422-4723-9b52-82848f732bc9" />


## Why

Large admin forms and crowded table action columns were visually dense and harder to scan.
These changes improve readability, reduce repeated UI noise, and make the edit experience feel more structured without changing underlying data fields or backend behavior.

## Testing

- Ran `eslint` through the repo’s `lint-staged` flow during amend
- Ran `yarn build` in `web/`
- Verified the store edit page in Chrome at:
  - `http://localhost:13001/stores/admin/store-built-in`

## Notes

- This is intended as a UI/UX polish pass only
- No backend API contracts were changed
- Field coverage for provider/store forms remains intact
