### PR TITLE
feat: migrate shell pty backend to go-pty

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,6 @@ require (
 	github.com/casibase/go-openrouter v1.0.0
 	github.com/casibase/pdf v1.2.0
 	github.com/cenkalti/backoff/v4 v4.3.0
-	github.com/chromedp/cdproto v0.0.0-20240202021202-6d0b6a386732
 	github.com/chromedp/chromedp v0.9.5
 	github.com/cohere-ai/cohere-go/v2 v2.5.2
 	github.com/denisenkom/go-mssqldb v0.10.0
@@ -96,6 +95,7 @@ require (
 	github.com/bits-and-blooms/bitset v1.20.0 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/carapace-sh/carapace-shlex v1.0.1 // indirect
+	github.com/chromedp/cdproto v0.0.0-20240202021202-6d0b6a386732 // indirect
 	github.com/chromedp/sysutil v1.0.0 // indirect
 	github.com/clbanning/mxj/v2 v2.7.0 // indirect
 	github.com/consensys/gnark-crypto v0.18.0 // indirect
@@ -274,7 +274,7 @@ require (
 	golang.org/x/crypto v0.49.0
 	golang.org/x/exp v0.0.0-20260312153236-7ab1446f8b90 // indirect
 	golang.org/x/mod v0.34.0 // indirect
-	golang.org/x/oauth2 v0.27.0
+	golang.org/x/oauth2 v0.27.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.42.0
 	golang.org/x/term v0.41.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.27.27
 	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.8.0
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.203.0
+	github.com/aymanbagabas/go-pty v0.2.2
 	github.com/baidubce/bce-qianfan-sdk/go/qianfan v0.0.14
 	github.com/beego/beego v1.12.12
 	github.com/carmel/gooxml v0.0.0-20220216072414-40ff56130850
@@ -32,6 +33,7 @@ require (
 	github.com/casibase/go-openrouter v1.0.0
 	github.com/casibase/pdf v1.2.0
 	github.com/cenkalti/backoff/v4 v4.3.0
+	github.com/chromedp/cdproto v0.0.0-20240202021202-6d0b6a386732
 	github.com/chromedp/chromedp v0.9.5
 	github.com/cohere-ai/cohere-go/v2 v2.5.2
 	github.com/denisenkom/go-mssqldb v0.10.0
@@ -94,13 +96,12 @@ require (
 	github.com/bits-and-blooms/bitset v1.20.0 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/carapace-sh/carapace-shlex v1.0.1 // indirect
-	github.com/chromedp/cdproto v0.0.0-20240202021202-6d0b6a386732 // indirect
 	github.com/chromedp/sysutil v1.0.0 // indirect
 	github.com/clbanning/mxj/v2 v2.7.0 // indirect
 	github.com/consensys/gnark-crypto v0.18.0 // indirect
 	github.com/crate-crypto/go-eth-kzg v1.3.0 // indirect
 	github.com/crate-crypto/go-ipa v0.0.0-20240724233137-53bbb0ceb27a // indirect
-	github.com/creack/pty v1.1.18 // indirect
+	github.com/creack/pty v1.1.21 // indirect
 	github.com/deckarep/golang-set/v2 v2.6.0 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.1-0.20230921164230-9754217aff8e // indirect
 	github.com/ethereum/c-kzg-4844/v2 v2.1.0 // indirect
@@ -121,6 +122,7 @@ require (
 	github.com/tidwall/sjson v1.2.5 // indirect
 	github.com/tiendc/go-deepcopy v1.7.2 // indirect
 	github.com/tjfoc/gmsm v1.4.1 // indirect
+	github.com/u-root/u-root v0.11.0 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect
 	github.com/xuri/efp v0.0.1 // indirect
 	github.com/xuri/nfp v0.0.2-0.20250530014748-2ddeb826f9a9 // indirect
@@ -272,7 +274,7 @@ require (
 	golang.org/x/crypto v0.49.0
 	golang.org/x/exp v0.0.0-20260312153236-7ab1446f8b90 // indirect
 	golang.org/x/mod v0.34.0 // indirect
-	golang.org/x/oauth2 v0.27.0 // indirect
+	golang.org/x/oauth2 v0.27.0
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.42.0
 	golang.org/x/term v0.41.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -179,6 +179,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.30.3 h1:ZsDKRLXGWHk8WdtyYMoGNO7bTudr
 github.com/aws/aws-sdk-go-v2/service/sts v1.30.3/go.mod h1:zwySh8fpFyXp9yOr/KVzxOl8SRqgf/IDw5aUt9UKFcQ=
 github.com/aws/smithy-go v1.22.2 h1:6D9hW43xKFrRx/tXXfAlIZc4JI+yQe6snnWcQyxSyLQ=
 github.com/aws/smithy-go v1.22.2/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
+github.com/aymanbagabas/go-pty v0.2.2 h1:YZREB4eSj+1xdbbItIokX0ekjjeifgJOA+ZvxU4/WM8=
+github.com/aymanbagabas/go-pty v0.2.2/go.mod h1:gfvlwH+0U66BCwxJREjJaAOEs9H1OFf3YFjI9WSiZ04=
 github.com/baidubce/bce-qianfan-sdk/go/qianfan v0.0.14 h1:XNP24illv5CWTLinpdF8Xo73YWQ2ZWbmlNT0BTWFCGg=
 github.com/baidubce/bce-qianfan-sdk/go/qianfan v0.0.14/go.mod h1:f/kIWWvAHAcU7bzgkfN30SkpN0I4lLvsJkljVK6v5YY=
 github.com/baidubce/bce-sdk-go v0.9.164 h1:7gswLMsdQyarovMKuv3i6wxFQ3BQgvc5CmyGXb/D/xA=
@@ -289,6 +291,8 @@ github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7Do
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
+github.com/creack/pty v1.1.21 h1:1/QdRyBaHHJP61QkWMXlOIBfsgdDeeKfK8SYVUWJKf0=
+github.com/creack/pty v1.1.21/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/cupcake/rdb v0.0.0-20161107195141-43ba34106c76/go.mod h1:vYwsqCOLxGiisLwp9rITslkFNpZD5rz43tf41QFkTWY=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
@@ -1032,6 +1036,8 @@ github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9R
 github.com/tklauser/numcpus v0.11.0/go.mod h1:z+LwcLq54uWZTX0u/bGobaV34u6V7KNlTZejzM6/3MQ=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tsenart/deadcode v0.0.0-20160724212837-210d2dc333e9/go.mod h1:q+QjxYvZ+fpjMXqs+XEriussHjSYqeXVnAdSV1tkMYk=
+github.com/u-root/u-root v0.11.0 h1:6gCZLOeRyevw7gbTwMj3fKxnr9+yHFlgF3N7udUVNO8=
+github.com/u-root/u-root v0.11.0/go.mod h1:DBkDtiZyONk9hzVEdB/PWI9B4TxDkElWlVTHseglrZY=
 github.com/ua-parser/uap-go v0.0.0-20230823213814-f77b3e91e9dc h1:iT5lwxf894PiMq7cnMMQg/7VOD1pxmu//gQuHWAFy4s=
 github.com/ua-parser/uap-go v0.0.0-20230823213814-f77b3e91e9dc/go.mod h1:BUbeWZiieNxAuuADTBNb3/aeje6on3DhU3rpWsQSB1E=
 github.com/uandersonricardo/uiautomation v0.0.0-20250610195738-b54cd4b8ddde h1:HvpogxTtc3EyQq6LkSfVZynX1SwZHVwhzoI8sO24OLc=

--- a/tool/shell.go
+++ b/tool/shell.go
@@ -174,10 +174,7 @@ func (s *shellBuiltin) GetInputSchema() interface{} {
 }
 
 func (s *shellBuiltin) Execute(ctx context.Context, arguments map[string]interface{}) (*protocol.CallToolResult, error) {
-	if _, ok := arguments["action"]; ok {
-		return shellExecuteBackground(ctx, arguments)
-	}
-	if shellBoolArg(arguments, "background") {
+	if shellBoolArg(arguments, "background") || shellHasAction(arguments) {
 		return shellExecuteBackground(ctx, arguments)
 	}
 
@@ -803,7 +800,7 @@ func shellResizePTY(session *shellSession, cols uint16, rows uint16) error {
 	return shellResizePtyRaw(session.pty, int(cols), int(rows))
 }
 
-func shellResizePtyRaw(ptmx interface{ Resize(int, int) error }, cols int, rows int) error {
+func shellResizePtyRaw(ptmx gopty.Pty, cols int, rows int) error {
 	return ptmx.Resize(cols, rows)
 }
 

--- a/tool/shell.go
+++ b/tool/shell.go
@@ -28,11 +28,10 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"syscall"
 	"time"
 
 	"github.com/ThinkInAIXYZ/go-mcp/protocol"
-	"github.com/creack/pty"
+	gopty "github.com/aymanbagabas/go-pty"
 )
 
 const (
@@ -60,8 +59,9 @@ type shellSession struct {
 	workdir      string
 	usePTY       bool
 	cmd          *exec.Cmd
+	ptyCmd       *gopty.Cmd
 	stdin        io.WriteCloser
-	ptyFile      *os.File
+	pty          gopty.Pty
 	output       *shellRingBuffer
 	done         chan struct{}
 	cancel       context.CancelFunc
@@ -174,7 +174,10 @@ func (s *shellBuiltin) GetInputSchema() interface{} {
 }
 
 func (s *shellBuiltin) Execute(ctx context.Context, arguments map[string]interface{}) (*protocol.CallToolResult, error) {
-	if shellBoolArg(arguments, "background") || shellHasAction(arguments) {
+	if _, ok := arguments["action"]; ok {
+		return shellExecuteBackground(ctx, arguments)
+	}
+	if shellBoolArg(arguments, "background") {
 		return shellExecuteBackground(ctx, arguments)
 	}
 
@@ -197,15 +200,7 @@ func (s *shellBuiltin) Execute(ctx context.Context, arguments map[string]interfa
 	execCtx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSecs)*time.Second)
 	defer cancel()
 
-	cmd, err := shellBuildCommand(execCtx, command)
-	if err != nil {
-		return shellError(err.Error()), nil
-	}
-	if workdir != "" {
-		cmd.Dir = workdir
-	}
-
-	result, runErr := shellRunForeground(execCtx, cmd, usePTY)
+	result, runErr := shellRunForeground(execCtx, command, workdir, usePTY)
 	if execCtx.Err() == context.DeadlineExceeded {
 		return shellError(fmt.Sprintf("Error: command timed out after %.0f seconds", timeoutSecs)), nil
 	}
@@ -246,14 +241,21 @@ func shellStartBackground(ctx context.Context, arguments map[string]interface{})
 	workdir := shellStringArg(arguments, "workdir", "")
 	usePTY := shellBoolArg(arguments, "pty")
 
-	sessionCtx, cancel := context.WithCancel(ctx)
+	sessionCtx := ctx
+	cancel := func() {}
+	if t, ok := arguments["timeout"].(float64); ok && t > 0 {
+		timeoutSecs := t
+		if timeoutSecs > shellMaxTimeoutSeconds {
+			timeoutSecs = shellMaxTimeoutSeconds
+		}
+		sessionCtx, cancel = context.WithTimeout(ctx, time.Duration(timeoutSecs)*time.Second)
+	} else {
+		sessionCtx, cancel = context.WithCancel(ctx)
+	}
 	cmd, err := shellBuildCommand(sessionCtx, command)
 	if err != nil {
 		cancel()
 		return shellError(err.Error()), nil
-	}
-	if workdir != "" {
-		cmd.Dir = workdir
 	}
 
 	session := &shellSession{
@@ -269,26 +271,14 @@ func shellStartBackground(ctx context.Context, arguments map[string]interface{})
 	}
 
 	if usePTY {
-		if runtime.GOOS == "windows" {
+		if err = shellStartPTYBackground(sessionCtx, session, arguments); err != nil {
 			cancel()
-			return shellError("pty mode is not supported on Windows in the current shell implementation"), nil
+			return shellError(err.Error()), nil
 		}
-
-		cmd.Env = shellCommandEnv(true)
-		ptmx, startErr := pty.Start(cmd)
-		if startErr != nil {
-			cancel()
-			return shellError(startErr.Error()), nil
-		}
-		if sizeErr := shellSetPTYSize(ptmx, shellPTYCols(arguments), shellPTYRows(arguments)); sizeErr != nil {
-			_ = ptmx.Close()
-			cancel()
-			return shellError(sizeErr.Error()), nil
-		}
-		session.stdin = ptmx
-		session.ptyFile = ptmx
-		go session.capture(ptmx)
 	} else {
+		if workdir != "" {
+			cmd.Dir = workdir
+		}
 		stdin, pipeErr := cmd.StdinPipe()
 		if pipeErr != nil {
 			cancel()
@@ -397,7 +387,7 @@ func shellWriteBackground(arguments map[string]interface{}) (*protocol.CallToolR
 		return shellError("Missing required parameter: input"), nil
 	}
 
-	n, err := io.WriteString(session.stdin, input)
+	n, err := session.writeString(input)
 	if err != nil {
 		return shellError(err.Error()), nil
 	}
@@ -450,7 +440,7 @@ func shellSendKeysBackground(arguments map[string]interface{}) (*protocol.CallTo
 		seq.WriteString(part)
 	}
 
-	n, err := io.WriteString(session.stdin, seq.String())
+	n, err := session.writeString(seq.String())
 	if err != nil {
 		return shellError(err.Error()), nil
 	}
@@ -471,13 +461,13 @@ func shellResizeBackground(arguments map[string]interface{}) (*protocol.CallTool
 	if session == nil {
 		return shellError(fmt.Sprintf("shell session not found: %s", sessionID)), nil
 	}
-	if !session.usePTY || session.ptyFile == nil {
+	if !session.usePTY || session.pty == nil {
 		return shellError("shell session is not running in pty mode"), nil
 	}
 
 	cols := shellPTYCols(arguments)
 	rows := shellPTYRows(arguments)
-	if err := shellSetPTYSize(session.ptyFile, cols, rows); err != nil {
+	if err := shellResizePTY(session, cols, rows); err != nil {
 		return shellError(err.Error()), nil
 	}
 
@@ -512,16 +502,32 @@ func shellStopBackground(arguments map[string]interface{}) (*protocol.CallToolRe
 }
 
 func shellBuildCommand(ctx context.Context, command string) (*exec.Cmd, error) {
-	if runtime.GOOS == "windows" {
-		return exec.CommandContext(ctx, "cmd", "/C", command), nil
-	}
-	cmd := exec.CommandContext(ctx, "sh", "-c", command)
+	cmd := exec.CommandContext(ctx, shellPlatformShell(), shellPlatformShellArg(), command)
 	cmd.Env = shellCommandEnv(false)
 	return cmd, nil
 }
 
-func shellRunForeground(ctx context.Context, cmd *exec.Cmd, usePTY bool) (string, error) {
+func shellBuildPtyCommand(ctx context.Context, command string) (gopty.Pty, *gopty.Cmd, error) {
+	ptmx, err := gopty.New()
+	if err != nil {
+		return nil, nil, err
+	}
+	cmd := ptmx.CommandContext(ctx, shellPlatformShell(), shellPlatformShellArg(), command)
+	cmd.Env = shellCommandEnv(true)
+	return ptmx, cmd, nil
+}
+
+func shellRunForeground(ctx context.Context, command string, workdir string, usePTY bool) (string, error) {
+	cmd, err := shellBuildCommand(ctx, command)
+	if err != nil {
+		return fmt.Sprintf("Error: %s", err.Error()), err
+	}
+
 	if !usePTY {
+		if workdir != "" {
+			cmd.Dir = workdir
+		}
+
 		var stdout, stderr bytes.Buffer
 		cmd.Stdout = &stdout
 		cmd.Stderr = &stderr
@@ -556,33 +562,34 @@ func shellRunForeground(ctx context.Context, cmd *exec.Cmd, usePTY bool) (string
 		return result, nil
 	}
 
-	if runtime.GOOS == "windows" {
-		err := fmt.Errorf("pty mode is not supported on Windows in the current shell implementation")
-		return err.Error(), err
-	}
-
-	cmd.Env = shellCommandEnv(true)
-	ptmx, err := pty.Start(cmd)
+	ptmx, ptyCmd, err := shellBuildPtyCommand(ctx, command)
 	if err != nil {
 		return fmt.Sprintf("Error: %s", err.Error()), err
 	}
-	if sizeErr := shellSetPTYSize(ptmx, shellDefaultPTYCols, shellDefaultPTYRows); sizeErr != nil {
+	if workdir != "" {
+		ptyCmd.Dir = workdir
+	}
+	if sizeErr := shellResizePtyRaw(ptmx, int(shellDefaultPTYCols), int(shellDefaultPTYRows)); sizeErr != nil {
 		_ = ptmx.Close()
 		return fmt.Sprintf("Error: %s", sizeErr.Error()), sizeErr
+	}
+	if err = ptyCmd.Start(); err != nil {
+		_ = ptmx.Close()
+		return fmt.Sprintf("Error: %s", err.Error()), err
 	}
 
 	var output bytes.Buffer
 	copyDone := make(chan error, 1)
 	go func() {
 		_, copyErr := io.Copy(&output, ptmx)
-		if copyErr != nil && !errors.Is(copyErr, os.ErrClosed) {
+		if copyErr != nil && !errors.Is(copyErr, io.EOF) {
 			copyDone <- copyErr
 			return
 		}
 		copyDone <- nil
 	}()
 
-	runErr := cmd.Wait()
+	runErr := ptyCmd.Wait()
 	_ = ptmx.Close()
 	copyErr := <-copyDone
 
@@ -692,6 +699,20 @@ func shellPTYCols(arguments map[string]interface{}) uint16 {
 	return uint16(cols)
 }
 
+func shellPlatformShell() string {
+	if runtime.GOOS == "windows" {
+		return "cmd.exe"
+	}
+	return "sh"
+}
+
+func shellPlatformShellArg() string {
+	if runtime.GOOS == "windows" {
+		return "/C"
+	}
+	return "-c"
+}
+
 func shellCommandEnv(usePTY bool) []string {
 	env := os.Environ()
 	if usePTY {
@@ -718,16 +739,6 @@ func shellEnsureEnv(env []string, key string, value string) []string {
 		}
 	}
 	return append(env, prefix+value)
-}
-
-func shellSetPTYSize(file *os.File, cols uint16, rows uint16) error {
-	if file == nil {
-		return fmt.Errorf("pty is not available for this shell session")
-	}
-	return pty.Setsize(file, &pty.Winsize{
-		Cols: cols,
-		Rows: rows,
-	})
 }
 
 func shellKeySequence(key string) (string, error) {
@@ -759,6 +770,41 @@ func shellKeySequence(key string) (string, error) {
 	default:
 		return "", fmt.Errorf("unsupported key sequence: %s", key)
 	}
+}
+
+func shellStartPTYBackground(ctx context.Context, session *shellSession, arguments map[string]interface{}) error {
+	ptmx, ptyCmd, err := shellBuildPtyCommand(ctx, session.command)
+	if err != nil {
+		return err
+	}
+	if session.workdir != "" {
+		ptyCmd.Dir = session.workdir
+	}
+	if sizeErr := shellResizePtyRaw(ptmx, int(shellPTYCols(arguments)), int(shellPTYRows(arguments))); sizeErr != nil {
+		_ = ptmx.Close()
+		return sizeErr
+	}
+	if err = ptyCmd.Start(); err != nil {
+		_ = ptmx.Close()
+		return err
+	}
+
+	session.pty = ptmx
+	session.ptyCmd = ptyCmd
+	session.stdin = ptmx
+	go session.capture(ptmx)
+	return nil
+}
+
+func shellResizePTY(session *shellSession, cols uint16, rows uint16) error {
+	if session.pty == nil {
+		return fmt.Errorf("pty is not available for this shell session")
+	}
+	return shellResizePtyRaw(session.pty, int(cols), int(rows))
+}
+
+func shellResizePtyRaw(ptmx interface{ Resize(int, int) error }, cols int, rows int) error {
+	return ptmx.Resize(cols, rows)
 }
 
 func shellText(text string) *protocol.CallToolResult {
@@ -851,6 +897,16 @@ func (s *shellSession) capture(r io.Reader) {
 
 func (s *shellSession) wait() {
 	defer close(s.done)
+	if s.usePTY && s.ptyCmd != nil {
+		s.exitErr = s.ptyCmd.Wait()
+		if s.ptyCmd.ProcessState != nil {
+			code := s.ptyCmd.ProcessState.ExitCode()
+			s.exitCode = &code
+		}
+		s.closeInput()
+		return
+	}
+
 	s.exitErr = s.cmd.Wait()
 	if s.cmd.ProcessState != nil {
 		code := s.cmd.ProcessState.ExitCode()
@@ -869,6 +925,9 @@ func (s *shellSession) isRunning() bool {
 }
 
 func (s *shellSession) processID() int {
+	if s.usePTY && s.ptyCmd != nil && s.ptyCmd.Process != nil {
+		return s.ptyCmd.Process.Pid
+	}
 	if s.cmd == nil || s.cmd.Process == nil {
 		return 0
 	}
@@ -896,29 +955,32 @@ func (s *shellSession) stop() {
 		return
 	}
 	s.closed = true
+
 	if s.cancel != nil {
 		s.cancel()
 	}
 	s.closeInputLocked()
 	done := s.done
 	var process *os.Process
-	if s.cmd != nil {
+	if s.usePTY && s.ptyCmd != nil {
+		process = s.ptyCmd.Process
+	} else if s.cmd != nil {
 		process = s.cmd.Process
 	}
 	s.mu.Unlock()
 
 	// Wait outside the lock so wait() can acquire it to call closeInput().
-	if process != nil {
-		if runtime.GOOS == "windows" {
-			_ = process.Kill()
-		} else {
-			_ = process.Signal(syscall.SIGTERM)
-			select {
-			case <-done:
-			case <-time.After(2 * time.Second):
-				_ = process.Kill()
-			}
-		}
+	if process == nil {
+		return
+	}
+	if err := process.Signal(os.Interrupt); err != nil {
+		_ = process.Kill()
+		return
+	}
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		_ = process.Kill()
 	}
 }
 
@@ -929,16 +991,26 @@ func (s *shellSession) closeInput() {
 }
 
 func (s *shellSession) closeInputLocked() {
-	if s.ptyFile != nil {
-		_ = s.ptyFile.Close()
-		s.ptyFile = nil
-		s.stdin = nil // stdin is the same *os.File as ptyFile in PTY mode
+	if s.pty != nil {
+		_ = s.pty.Close()
+		s.pty = nil
+		s.stdin = nil // stdin is the same PTY handle in PTY mode.
 		return
 	}
 	if s.stdin != nil {
 		_ = s.stdin.Close()
 		s.stdin = nil
 	}
+}
+
+func (s *shellSession) writeString(input string) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed || s.stdin == nil {
+		return 0, fmt.Errorf("shell session is no longer running")
+	}
+	return io.WriteString(s.stdin, input)
 }
 
 func (m *shellSessionManager) nextSessionID() string {
@@ -957,11 +1029,11 @@ func (m *shellSessionManager) put(session *shellSession) {
 func (m *shellSessionManager) get(id string) *shellSession {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	s := m.sessions[id]
-	if s != nil {
-		s.lastActivity = time.Now()
+	session := m.sessions[id]
+	if session != nil {
+		session.lastActivity = time.Now()
 	}
-	return s
+	return session
 }
 
 func (m *shellSessionManager) delete(id string) {
@@ -987,17 +1059,17 @@ func (m *shellSessionManager) cleanupLoop() {
 func (m *shellSessionManager) evictIdle() {
 	m.mu.Lock()
 	var expired []*shellSession
-	for _, s := range m.sessions {
-		if time.Since(s.lastActivity) > shellSessionIdleTimeout {
-			expired = append(expired, s)
+	for _, session := range m.sessions {
+		if time.Since(session.lastActivity) > shellSessionIdleTimeout {
+			expired = append(expired, session)
 		}
 	}
-	for _, s := range expired {
-		delete(m.sessions, s.id)
+	for _, session := range expired {
+		delete(m.sessions, session.id)
 	}
 	m.mu.Unlock()
 
-	for _, s := range expired {
-		s.stop()
+	for _, session := range expired {
+		session.stop()
 	}
 }


### PR DESCRIPTION
## Summary

Replace the shell tool PTY backend with `github.com/aymanbagabas/go-pty` so the implementation can compile cleanly on Windows while keeping the existing single-tool interface and session behavior.

## Changes

- switch `tool/shell.go` from `creack/pty` to `go-pty`
- preserve the existing shell session actions and PTY workflow
- carry forward the recent session close / idle cleanup fixes into the new PTY implementation
- update `go.mod` and `go.sum` for the new dependency chain