### PR TITLE
feat: support PDF OCR recognition

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,7 +24,7 @@ builds:
       - arm64
 
 # Release raw executables — no zip/tar.gz wrapper.
-# conf/, web/build/, and skills/ are baked into the binary via go:embed.
+# conf/, web/build/, skills/, and deploy/ocr-service/ are baked into the binary via go:embed.
 archives:
   - format: binary
     name_template: >-

--- a/deploy/ocr-service/Dockerfile
+++ b/deploy/ocr-service/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.10-slim-bookworm
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libglib2.0-0 libgomp1 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir -r requirements.txt \
+    && pip uninstall -y opencv-python \
+    && pip install --no-cache-dir opencv-python-headless
+
+COPY app.py .
+
+EXPOSE 8001
+
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/deploy/ocr-service/README.md
+++ b/deploy/ocr-service/README.md
@@ -1,0 +1,50 @@
+# OpenAgent OCR Service
+
+This service provides the OCR endpoint used by the `local_file` tool.
+
+## API
+
+- `GET /health`
+- `POST /ocr/pdf`
+  - `multipart/form-data`
+  - file field: `file`
+  - response: `{"text":"recognized text"}`
+
+## Run with OpenAgent
+
+OpenAgent starts this service automatically on startup.
+
+The managed Python environment is created under:
+
+```text
+tmp/ocr-service/.venv
+```
+
+If the `local_file` tool Provider URL is empty, OpenAgent uses the managed endpoint:
+
+```text
+http://127.0.0.1:8001/ocr/pdf
+```
+
+Python 3.10+ must already be installed on the machine. OpenAgent installs the Python package dependencies into the managed virtual environment.
+
+## Run with Docker
+
+From the OpenAgent repository root:
+
+```bash
+docker compose -f docker-compose.ocr.yml up --build
+```
+
+To force OpenAgent to use the Docker service instead of the managed service, set the `local_file` tool Provider URL to:
+
+```text
+http://127.0.0.1:8001/ocr/pdf
+```
+
+## Test
+
+```bash
+curl http://127.0.0.1:8001/health
+curl -F "file=@/absolute/path/to/scanned.pdf" http://127.0.0.1:8001/ocr/pdf
+```

--- a/deploy/ocr-service/README.md
+++ b/deploy/ocr-service/README.md
@@ -12,7 +12,7 @@ This service provides the OCR endpoint used by the `local_file` tool.
 
 ## Run with OpenAgent
 
-OpenAgent starts the managed OCR service lazily on the first `local_pdf_ocr_read` call when the `local_file` tool Provider URL is empty.
+When an active store enables the `local_file` tool and the tool Provider URL is empty, OpenAgent warms up the managed OCR service in the background during startup. If the first `local_pdf_ocr_read` call arrives before warmup finishes, that call waits for the same managed OCR startup instead of starting a second service.
 
 The managed Python environment is created under:
 
@@ -26,7 +26,7 @@ If the `local_file` tool Provider URL is empty, OpenAgent uses the managed endpo
 http://127.0.0.1:8001/ocr/pdf
 ```
 
-Python 3.10+ must already be installed on the machine. OpenAgent installs the Python package dependencies into the managed virtual environment during the first managed OCR startup.
+Python 3.10+ must already be installed on the machine. OpenAgent installs the Python package dependencies into the managed virtual environment during the first managed OCR startup or background warmup.
 
 ## Run with Docker
 

--- a/deploy/ocr-service/README.md
+++ b/deploy/ocr-service/README.md
@@ -12,7 +12,7 @@ This service provides the OCR endpoint used by the `local_file` tool.
 
 ## Run with OpenAgent
 
-OpenAgent starts this service automatically on startup.
+OpenAgent starts the managed OCR service lazily on the first `local_pdf_ocr_read` call when the `local_file` tool Provider URL is empty.
 
 The managed Python environment is created under:
 
@@ -20,13 +20,13 @@ The managed Python environment is created under:
 tmp/ocr-service/.venv
 ```
 
-If the `local_file` tool Provider URL is empty, OpenAgent uses the managed endpoint:
+If the `local_file` tool Provider URL is empty, OpenAgent uses the managed endpoint by default:
 
 ```text
 http://127.0.0.1:8001/ocr/pdf
 ```
 
-Python 3.10+ must already be installed on the machine. OpenAgent installs the Python package dependencies into the managed virtual environment.
+Python 3.10+ must already be installed on the machine. OpenAgent installs the Python package dependencies into the managed virtual environment during the first managed OCR startup.
 
 ## Run with Docker
 

--- a/deploy/ocr-service/app.py
+++ b/deploy/ocr-service/app.py
@@ -1,0 +1,73 @@
+import os
+import tempfile
+from threading import Lock
+
+import pypdfium2 as pdfium
+from fastapi import FastAPI, File, HTTPException, UploadFile
+from rapidocr import RapidOCR
+
+
+app = FastAPI(title="OpenAgent OCR Service")
+ocr_engine = RapidOCR()
+ocr_lock = Lock()
+
+
+@app.get("/health")
+def health():
+    return {"status": "ok"}
+
+
+@app.post("/ocr/pdf")
+async def ocr_pdf(file: UploadFile = File(...)):
+    content = await file.read()
+    if not content.startswith(b"%PDF"):
+        raise HTTPException(status_code=400, detail="file must be a PDF")
+
+    try:
+        text = read_pdf_text(content)
+    except Exception as err:
+        raise HTTPException(status_code=500, detail=f"failed to OCR PDF: {err}") from err
+
+    return {"text": text}
+
+
+def read_pdf_text(content: bytes) -> str:
+    temp_path = write_temp_pdf(content)
+    try:
+        pdf = pdfium.PdfDocument(temp_path)
+        try:
+            page_texts = [read_page_text(pdf[index], index + 1) for index in range(len(pdf))]
+        finally:
+            pdf.close()
+    finally:
+        os.remove(temp_path)
+
+    return "\n\n".join(text for text in page_texts if text)
+
+
+def write_temp_pdf(content: bytes) -> str:
+    with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as temp_file:
+        temp_file.write(content)
+        return temp_file.name
+
+
+def read_page_text(page, page_number: int) -> str:
+    try:
+        bitmap = page.render(scale=2.0)
+        try:
+            image = bitmap.to_pil().convert("RGB")
+        finally:
+            bitmap.close()
+    finally:
+        page.close()
+
+    with ocr_lock:
+        result = ocr_engine(image)
+
+    if result is None or result.txts is None:
+        return ""
+
+    text = "\n".join(item for item in result.txts if item)
+    if text == "":
+        return ""
+    return f"Page {page_number}\n{text}"

--- a/deploy/ocr-service/requirements.txt
+++ b/deploy/ocr-service/requirements.txt
@@ -1,0 +1,7 @@
+fastapi
+uvicorn[standard]
+python-multipart
+rapidocr
+onnxruntime
+pypdfium2
+opencv-python-headless

--- a/docker-compose.ocr.yml
+++ b/docker-compose.ocr.yml
@@ -1,0 +1,8 @@
+services:
+  openagent-ocr:
+    restart: unless-stopped
+    build:
+      context: ./deploy/ocr-service
+      dockerfile: Dockerfile
+    ports:
+      - "8001:8001"

--- a/embed.go
+++ b/embed.go
@@ -15,9 +15,9 @@
 //go:build embed
 
 // This file is only compiled when building with -tags embed.
-// It embeds conf/, web/build/ (without source-map files), and skills/ into
-// the binary, and wires them up via embedsupport.Setup so that the server
-// can run from a single executable without any on-disk assets.
+// It embeds conf/, web/build/ (without source-map files), skills/, and the
+// OCR service into the binary, and wires them up via embedsupport.Setup so
+// that the server can run from a single executable without any on-disk assets.
 // On-disk files always take priority over the embedded versions at runtime.
 
 package main
@@ -44,9 +44,13 @@ var _embeddedWeb embed.FS
 //go:embed skills
 var _embeddedSkills embed.FS
 
+//go:embed deploy/ocr-service
+var _embeddedOcrService embed.FS
+
 func init() {
 	confFS, _ := fs.Sub(_embeddedConf, "conf")
 	webFS, _ := fs.Sub(_embeddedWeb, "web/build")
 	skillsFS, _ := fs.Sub(_embeddedSkills, "skills")
-	embedsupport.Setup(confFS, webFS, skillsFS)
+	ocrServiceFS, _ := fs.Sub(_embeddedOcrService, "deploy/ocr-service")
+	embedsupport.Setup(confFS, webFS, skillsFS, ocrServiceFS)
 }

--- a/embedsupport/setup.go
+++ b/embedsupport/setup.go
@@ -13,24 +13,26 @@
 // limitations under the License.
 
 // Package embedsupport wires up the optional embedded filesystems for conf,
-// web/build, and skills. When the binary is built with -tags embed, the
-// caller (main) passes the embedded fs.FS values here via Setup. At runtime,
-// on-disk files always take priority; the embedded versions are used only when
-// the corresponding directory is absent next to the executable.
+// web/build, skills, and the OCR service. When the binary is built with
+// -tags embed, the caller (main) passes the embedded fs.FS values here via
+// Setup. At runtime, on-disk files always take priority; the embedded versions
+// are used only when the corresponding directory is absent next to the executable.
 package embedsupport
 
 import "io/fs"
 
 var (
-	webFS    fs.FS
-	skillsFS fs.FS
+	webFS        fs.FS
+	skillsFS     fs.FS
+	ocrServiceFS fs.FS
 )
 
 // Setup must be called at the very start of main(), before any config values
 // are read or HTTP requests are served.
-func Setup(conf, web, skills fs.FS) {
+func Setup(conf, web, skills, ocrService fs.FS) {
 	webFS = web
 	skillsFS = skills
+	ocrServiceFS = ocrService
 	setupConf(conf)
 }
 
@@ -39,3 +41,6 @@ func WebFS() fs.FS { return webFS }
 
 // SkillsFS returns the embedded skills filesystem, or nil if not available.
 func SkillsFS() fs.FS { return skillsFS }
+
+// OcrServiceFS returns the embedded OCR service filesystem, or nil if not available.
+func OcrServiceFS() fs.FS { return ocrServiceFS }

--- a/internal/localocr/manager.go
+++ b/internal/localocr/manager.go
@@ -1,0 +1,322 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package localocr
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/beego/beego/logs"
+	"github.com/the-open-agent/openagent/embedsupport"
+)
+
+const (
+	DefaultEndpoint = "http://127.0.0.1:8001/ocr/pdf"
+
+	defaultHealthURL      = "http://127.0.0.1:8001/health"
+	installMarkerFile     = "requirements.sha256"
+	managedServiceTimeout = 2 * time.Minute
+)
+
+type Manager struct {
+	rootDir       string
+	serviceDir    string
+	requirements  string
+	stateDir      string
+	venvDir       string
+	installMarker string
+	endpoint      string
+	healthURL     string
+	httpClient    *http.Client
+
+	mu  sync.Mutex
+	cmd *exec.Cmd
+}
+
+func NewManager(rootDir string) *Manager {
+	stateDir := filepath.Join(rootDir, "tmp", "ocr-service")
+	serviceDir := filepath.Join(rootDir, "deploy", "ocr-service")
+	return &Manager{
+		rootDir:       rootDir,
+		serviceDir:    serviceDir,
+		requirements:  filepath.Join(serviceDir, "requirements.txt"),
+		stateDir:      stateDir,
+		venvDir:       filepath.Join(stateDir, ".venv"),
+		installMarker: filepath.Join(stateDir, installMarkerFile),
+		endpoint:      DefaultEndpoint,
+		healthURL:     defaultHealthURL,
+		httpClient:    &http.Client{Timeout: 2 * time.Second},
+	}
+}
+
+func Start(ctx context.Context) (*Manager, error) {
+	rootDir, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+
+	manager := NewManager(rootDir)
+	if err = manager.Start(ctx); err != nil {
+		return manager, err
+	}
+	return manager, nil
+}
+
+func (m *Manager) Start(ctx context.Context) error {
+	if m.isHealthy() {
+		logs.Info("Local OCR service is already running at %s", m.endpoint)
+		return nil
+	}
+
+	if err := m.ensureServiceFiles(); err != nil {
+		return err
+	}
+	python, err := m.findPython()
+	if err != nil {
+		return err
+	}
+	if err = m.ensureInstalled(ctx, python); err != nil {
+		return err
+	}
+	return m.startService(ctx)
+}
+
+func (m *Manager) ensureServiceFiles() error {
+	if _, err := os.Stat(m.requirements); err == nil {
+		return nil
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+
+	embeddedService := embedsupport.OcrServiceFS()
+	if embeddedService == nil {
+		return fmt.Errorf("OCR service files not found at %s", m.serviceDir)
+	}
+
+	serviceDir := filepath.Join(m.stateDir, "service")
+	if err := copyEmbeddedService(embeddedService, serviceDir); err != nil {
+		return err
+	}
+	m.serviceDir = serviceDir
+	m.requirements = filepath.Join(serviceDir, "requirements.txt")
+	return nil
+}
+
+func (m *Manager) Stop() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.cmd == nil || m.cmd.Process == nil {
+		return
+	}
+	if err := m.cmd.Process.Kill(); err != nil {
+		logs.Warning("Failed to stop local OCR service: %v", err)
+	}
+	m.cmd = nil
+}
+
+func (m *Manager) findPython() (string, error) {
+	var candidates []string
+	if runtime.GOOS == "windows" {
+		candidates = []string{"python"}
+	} else {
+		candidates = []string{"python3", "python"}
+	}
+
+	for _, candidate := range candidates {
+		path, err := exec.LookPath(candidate)
+		if err == nil {
+			return path, nil
+		}
+	}
+	return "", fmt.Errorf("Python was not found; install Python 3.10+ to enable local OCR")
+}
+
+func (m *Manager) ensureInstalled(ctx context.Context, python string) error {
+	if m.isInstalled() {
+		return nil
+	}
+	if err := os.MkdirAll(m.stateDir, 0o755); err != nil {
+		return err
+	}
+
+	logs.Info("Preparing local OCR Python environment at %s", m.venvDir)
+	if err := m.run(ctx, m.rootDir, python, "-m", "venv", m.venvDir); err != nil {
+		return fmt.Errorf("failed to create OCR virtual environment: %w", err)
+	}
+
+	venvPython := venvPythonPath(m.venvDir)
+	if err := m.run(ctx, m.rootDir, venvPython, "-m", "pip", "install", "--upgrade", "pip"); err != nil {
+		return fmt.Errorf("failed to upgrade pip for OCR service: %w", err)
+	}
+	if err := m.run(ctx, m.rootDir, venvPython, "-m", "pip", "install", "-r", m.requirements); err != nil {
+		return fmt.Errorf("failed to install OCR dependencies: %w", err)
+	}
+
+	hash, err := m.requirementsHash()
+	if err != nil {
+		return err
+	}
+	if err = os.WriteFile(m.installMarker, []byte(hash), 0o644); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *Manager) startService(ctx context.Context) error {
+	m.mu.Lock()
+	venvPython := venvPythonPath(m.venvDir)
+	cmd := exec.CommandContext(ctx, venvPython, "-m", "uvicorn", "app:app", "--host", "127.0.0.1", "--port", "8001")
+	cmd.Dir = m.serviceDir
+	cmd.Stdout = localOcrLogWriter{}
+	cmd.Stderr = localOcrLogWriter{}
+	if err := cmd.Start(); err != nil {
+		m.mu.Unlock()
+		return fmt.Errorf("failed to start local OCR service: %w", err)
+	}
+	m.cmd = cmd
+	m.mu.Unlock()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.Wait()
+	}()
+
+	deadline := time.Now().Add(managedServiceTimeout)
+	for time.Now().Before(deadline) {
+		if m.isHealthy() {
+			logs.Info("Local OCR service is ready at %s", m.endpoint)
+			go func() {
+				if err := <-done; err != nil {
+					logs.Warning("Local OCR service stopped: %v", err)
+				}
+			}()
+			return nil
+		}
+		select {
+		case err := <-done:
+			m.mu.Lock()
+			m.cmd = nil
+			m.mu.Unlock()
+			return fmt.Errorf("local OCR service stopped before ready: %w", err)
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(time.Second):
+		}
+	}
+
+	_ = cmd.Process.Kill()
+	m.mu.Lock()
+	m.cmd = nil
+	m.mu.Unlock()
+	return fmt.Errorf("local OCR service did not become ready before timeout")
+}
+
+func (m *Manager) isInstalled() bool {
+	hash, err := m.requirementsHash()
+	if err != nil {
+		return false
+	}
+	marker, err := os.ReadFile(m.installMarker)
+	if err != nil || strings.TrimSpace(string(marker)) != hash {
+		return false
+	}
+	_, err = os.Stat(venvPythonPath(m.venvDir))
+	return err == nil
+}
+
+func (m *Manager) requirementsHash() (string, error) {
+	content, err := os.ReadFile(m.requirements)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(content)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func (m *Manager) isHealthy() bool {
+	resp, err := m.httpClient.Get(m.healthURL)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return false
+	}
+
+	var body struct {
+		Status string `json:"status"`
+	}
+	if err = json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return false
+	}
+	return body.Status == "ok"
+}
+
+func (m *Manager) run(ctx context.Context, dir string, name string, args ...string) error {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = dir
+	cmd.Stdout = localOcrLogWriter{}
+	cmd.Stderr = localOcrLogWriter{}
+	return cmd.Run()
+}
+
+func venvPythonPath(venvDir string) string {
+	if runtime.GOOS == "windows" {
+		return filepath.Join(venvDir, "Scripts", "python.exe")
+	}
+	return filepath.Join(venvDir, "bin", "python")
+}
+
+func copyEmbeddedService(source fs.FS, targetDir string) error {
+	return fs.WalkDir(source, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		targetPath := filepath.Join(targetDir, filepath.FromSlash(path))
+		if d.IsDir() {
+			return os.MkdirAll(targetPath, 0o755)
+		}
+
+		data, err := fs.ReadFile(source, path)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(targetPath, data, 0o644)
+	})
+}
+
+type localOcrLogWriter struct{}
+
+func (w localOcrLogWriter) Write(p []byte) (int, error) {
+	text := strings.TrimSpace(string(p))
+	if text != "" {
+		logs.Info("[local_ocr] %s", text)
+	}
+	return len(p), nil
+}

--- a/internal/localocr/manager.go
+++ b/internal/localocr/manager.go
@@ -21,11 +21,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/fs"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -37,9 +39,12 @@ import (
 const (
 	DefaultEndpoint = "http://127.0.0.1:8001/ocr/pdf"
 
-	defaultHealthURL      = "http://127.0.0.1:8001/health"
+	defaultHost           = "127.0.0.1"
+	defaultPort           = 8001
 	installMarkerFile     = "requirements.sha256"
-	managedServiceTimeout = 2 * time.Minute
+	installCommandTimeout = 10 * time.Minute
+	serviceReadyTimeout   = 2 * time.Minute
+	healthCheckTimeout    = 2 * time.Second
 )
 
 type Manager struct {
@@ -51,11 +56,17 @@ type Manager struct {
 	installMarker string
 	endpoint      string
 	healthURL     string
+	port          int
 	httpClient    *http.Client
 
 	mu  sync.Mutex
 	cmd *exec.Cmd
 }
+
+var (
+	managedMu sync.Mutex
+	managed   *Manager
+)
 
 func NewManager(rootDir string) *Manager {
 	stateDir := filepath.Join(rootDir, "tmp", "ocr-service")
@@ -68,9 +79,41 @@ func NewManager(rootDir string) *Manager {
 		venvDir:       filepath.Join(stateDir, ".venv"),
 		installMarker: filepath.Join(stateDir, installMarkerFile),
 		endpoint:      DefaultEndpoint,
-		healthURL:     defaultHealthURL,
-		httpClient:    &http.Client{Timeout: 2 * time.Second},
+		healthURL:     healthURL(defaultPort),
+		port:          defaultPort,
+		httpClient:    &http.Client{Timeout: healthCheckTimeout},
 	}
+}
+
+func EnsureRunning(ctx context.Context) (string, error) {
+	managedMu.Lock()
+	defer managedMu.Unlock()
+
+	if managed != nil {
+		if managed.isHealthy() {
+			return managed.endpoint, nil
+		}
+		managed.Stop()
+		managed = nil
+	}
+
+	manager, err := Start(ctx)
+	if err != nil {
+		return "", err
+	}
+	managed = manager
+	return manager.endpoint, nil
+}
+
+func StopManaged() {
+	managedMu.Lock()
+	defer managedMu.Unlock()
+
+	if managed == nil {
+		return
+	}
+	managed.Stop()
+	managed = nil
 }
 
 func Start(ctx context.Context) (*Manager, error) {
@@ -81,7 +124,8 @@ func Start(ctx context.Context) (*Manager, error) {
 
 	manager := NewManager(rootDir)
 	if err = manager.Start(ctx); err != nil {
-		return manager, err
+		manager.Stop()
+		return nil, err
 	}
 	return manager, nil
 }
@@ -102,7 +146,29 @@ func (m *Manager) Start(ctx context.Context) error {
 	if err = m.ensureInstalled(ctx, python); err != nil {
 		return err
 	}
+
+	port, err := m.resolvePort()
+	if err != nil {
+		return err
+	}
+	m.setPort(port)
 	return m.startService(ctx)
+}
+
+func (m *Manager) resolvePort() (int, error) {
+	if m.isHealthyAt(defaultPort) {
+		return defaultPort, nil
+	}
+	if isPortAvailable(defaultPort) {
+		return defaultPort, nil
+	}
+	return freePort()
+}
+
+func (m *Manager) setPort(port int) {
+	m.port = port
+	m.endpoint = endpointURL(port)
+	m.healthURL = healthURL(port)
 }
 
 func (m *Manager) ensureServiceFiles() error {
@@ -165,15 +231,15 @@ func (m *Manager) ensureInstalled(ctx context.Context, python string) error {
 	}
 
 	logs.Info("Preparing local OCR Python environment at %s", m.venvDir)
-	if err := m.run(ctx, m.rootDir, python, "-m", "venv", m.venvDir); err != nil {
+	if err := m.runInstallCommand(ctx, m.rootDir, python, "-m", "venv", m.venvDir); err != nil {
 		return fmt.Errorf("failed to create OCR virtual environment: %w", err)
 	}
 
 	venvPython := venvPythonPath(m.venvDir)
-	if err := m.run(ctx, m.rootDir, venvPython, "-m", "pip", "install", "--upgrade", "pip"); err != nil {
+	if err := m.runInstallCommand(ctx, m.rootDir, venvPython, "-m", "pip", "install", "--upgrade", "pip"); err != nil {
 		return fmt.Errorf("failed to upgrade pip for OCR service: %w", err)
 	}
-	if err := m.run(ctx, m.rootDir, venvPython, "-m", "pip", "install", "-r", m.requirements); err != nil {
+	if err := m.runInstallCommand(ctx, m.rootDir, venvPython, "-m", "pip", "install", "-r", m.requirements); err != nil {
 		return fmt.Errorf("failed to install OCR dependencies: %w", err)
 	}
 
@@ -190,7 +256,7 @@ func (m *Manager) ensureInstalled(ctx context.Context, python string) error {
 func (m *Manager) startService(ctx context.Context) error {
 	m.mu.Lock()
 	venvPython := venvPythonPath(m.venvDir)
-	cmd := exec.CommandContext(ctx, venvPython, "-m", "uvicorn", "app:app", "--host", "127.0.0.1", "--port", "8001")
+	cmd := exec.Command(venvPython, "-m", "uvicorn", "app:app", "--host", defaultHost, "--port", strconv.Itoa(m.port))
 	cmd.Dir = m.serviceDir
 	cmd.Stdout = localOcrLogWriter{}
 	cmd.Stderr = localOcrLogWriter{}
@@ -206,7 +272,7 @@ func (m *Manager) startService(ctx context.Context) error {
 		done <- cmd.Wait()
 	}()
 
-	deadline := time.Now().Add(managedServiceTimeout)
+	deadline := time.Now().Add(serviceReadyTimeout)
 	for time.Now().Before(deadline) {
 		if m.isHealthy() {
 			logs.Info("Local OCR service is ready at %s", m.endpoint)
@@ -259,7 +325,15 @@ func (m *Manager) requirementsHash() (string, error) {
 }
 
 func (m *Manager) isHealthy() bool {
-	resp, err := m.httpClient.Get(m.healthURL)
+	return m.isHealthyURL(m.healthURL)
+}
+
+func (m *Manager) isHealthyAt(port int) bool {
+	return m.isHealthyURL(healthURL(port))
+}
+
+func (m *Manager) isHealthyURL(url string) bool {
+	resp, err := m.httpClient.Get(url)
 	if err != nil {
 		return false
 	}
@@ -277,12 +351,21 @@ func (m *Manager) isHealthy() bool {
 	return body.Status == "ok"
 }
 
-func (m *Manager) run(ctx context.Context, dir string, name string, args ...string) error {
-	cmd := exec.CommandContext(ctx, name, args...)
+func (m *Manager) runInstallCommand(ctx context.Context, dir string, name string, args ...string) error {
+	commandCtx, cancel := context.WithTimeout(ctx, installCommandTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(commandCtx, name, args...)
 	cmd.Dir = dir
 	cmd.Stdout = localOcrLogWriter{}
 	cmd.Stderr = localOcrLogWriter{}
-	return cmd.Run()
+	if err := cmd.Run(); err != nil {
+		if commandCtx.Err() != nil {
+			return commandCtx.Err()
+		}
+		return err
+	}
+	return nil
 }
 
 func venvPythonPath(venvDir string) string {
@@ -309,6 +392,37 @@ func copyEmbeddedService(source fs.FS, targetDir string) error {
 		}
 		return os.WriteFile(targetPath, data, 0o644)
 	})
+}
+
+func endpointURL(port int) string {
+	return fmt.Sprintf("http://%s:%d/ocr/pdf", defaultHost, port)
+}
+
+func healthURL(port int) string {
+	return fmt.Sprintf("http://%s:%d/health", defaultHost, port)
+}
+
+func isPortAvailable(port int) bool {
+	listener, err := net.Listen("tcp", fmt.Sprintf("%s:%d", defaultHost, port))
+	if err != nil {
+		return false
+	}
+	_ = listener.Close()
+	return true
+}
+
+func freePort() (int, error) {
+	listener, err := net.Listen("tcp", fmt.Sprintf("%s:0", defaultHost))
+	if err != nil {
+		return 0, err
+	}
+	defer listener.Close()
+
+	address, ok := listener.Addr().(*net.TCPAddr)
+	if !ok {
+		return 0, fmt.Errorf("failed to resolve local OCR listener address")
+	}
+	return address.Port, nil
 }
 
 type localOcrLogWriter struct{}

--- a/main.go
+++ b/main.go
@@ -127,6 +127,7 @@ func main() {
 		}
 	}()
 
+	go warmupManagedLocalOCR(ctx)
 	go object.ClearThroughputPerSecond()
 
 	if util.IsDoubleClicked() {
@@ -134,4 +135,27 @@ func main() {
 	}
 
 	beego.Run(fmt.Sprintf(":%v", port))
+}
+
+func warmupManagedLocalOCR(ctx context.Context) {
+	shouldWarmup, err := object.ShouldWarmupManagedLocalOCR()
+	if err != nil {
+		logs.Warning("Failed to check managed local OCR warmup: %v", err)
+		return
+	}
+	if !shouldWarmup {
+		return
+	}
+
+	logs.Info("Warming up managed local OCR service in background")
+	endpoint, err := localocr.EnsureRunning(ctx)
+	if err != nil {
+		if ctx.Err() != nil {
+			logs.Info("Managed local OCR warmup canceled")
+			return
+		}
+		logs.Warning("Failed to warm up managed local OCR service: %v", err)
+		return
+	}
+	logs.Info("Managed local OCR service is ready at %s", endpoint)
 }

--- a/main.go
+++ b/main.go
@@ -15,10 +15,13 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/beego/beego"
 	"github.com/beego/beego/logs"
@@ -26,6 +29,7 @@ import (
 	"github.com/the-open-agent/openagent/authz"
 	"github.com/the-open-agent/openagent/conf"
 	"github.com/the-open-agent/openagent/internal/cli"
+	"github.com/the-open-agent/openagent/internal/localocr"
 	"github.com/the-open-agent/openagent/object"
 	"github.com/the-open-agent/openagent/proxy"
 	"github.com/the-open-agent/openagent/routers"
@@ -102,11 +106,27 @@ func main() {
 	}
 
 	port := beego.AppConfig.DefaultInt("httpport", 14000)
-
 	err = util.StopOldInstance(port)
 	if err != nil {
 		panic(err)
 	}
+
+	ctx, stopSignal := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stopSignal()
+
+	ocrManager, err := localocr.Start(ctx)
+	if err != nil {
+		logs.Warning("Local OCR service is unavailable: %v", err)
+	} else {
+		defer ocrManager.Stop()
+	}
+	go func() {
+		<-ctx.Done()
+		if ocrManager != nil {
+			ocrManager.Stop()
+		}
+		os.Exit(0)
+	}()
 
 	go object.ClearThroughputPerSecond()
 

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/beego/beego"
 	"github.com/beego/beego/logs"
@@ -113,19 +114,17 @@ func main() {
 
 	ctx, stopSignal := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stopSignal()
-
-	ocrManager, err := localocr.Start(ctx)
-	if err != nil {
-		logs.Warning("Local OCR service is unavailable: %v", err)
-	} else {
-		defer ocrManager.Stop()
-	}
+	defer localocr.StopManaged()
 	go func() {
 		<-ctx.Done()
-		if ocrManager != nil {
-			ocrManager.Stop()
+		stopSignal()
+		localocr.StopManaged()
+
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := beego.BeeApp.Server.Shutdown(shutdownCtx); err != nil {
+			logs.Warning("Failed to shut down HTTP server: %v", err)
 		}
-		os.Exit(0)
 	}()
 
 	go object.ClearThroughputPerSecond()

--- a/object/local_ocr.go
+++ b/object/local_ocr.go
@@ -1,0 +1,98 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package object
+
+import (
+	"strings"
+
+	"github.com/the-open-agent/openagent/util"
+)
+
+const (
+	activeState       = "Active"
+	allToolsSelection = "All"
+	localFileToolType = "local_file"
+)
+
+func ShouldWarmupManagedLocalOCR() (bool, error) {
+	stores, err := GetGlobalStores()
+	if err != nil {
+		return false, err
+	}
+
+	tools, err := GetGlobalTools()
+	if err != nil {
+		return false, err
+	}
+
+	managedLocalFileTools := map[string]*Tool{}
+	for _, t := range tools {
+		if isManagedLocalFileTool(t) {
+			managedLocalFileTools[t.GetId()] = t
+		}
+	}
+	if len(managedLocalFileTools) == 0 {
+		return false, nil
+	}
+
+	for _, store := range stores {
+		if store == nil || store.State != activeState {
+			continue
+		}
+		if storeEnablesManagedLocalFileTool(store, managedLocalFileTools) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func isManagedLocalFileTool(t *Tool) bool {
+	return t != nil &&
+		t.Type == localFileToolType &&
+		t.State == activeState &&
+		strings.TrimSpace(t.ProviderUrl) == ""
+}
+
+func storeEnablesManagedLocalFileTool(store *Store, managedLocalFileTools map[string]*Tool) bool {
+	if len(store.Tools) == 1 && store.Tools[0] == allToolsSelection {
+		for _, t := range managedLocalFileTools {
+			if t.Owner == store.Owner {
+				return true
+			}
+		}
+		return false
+	}
+
+	for _, toolName := range store.Tools {
+		toolName = strings.TrimSpace(toolName)
+		if toolName == "" {
+			continue
+		}
+
+		if _, ok := managedLocalFileTools[toolIdForStoreTool(store.Owner, toolName)]; ok {
+			return true
+		}
+	}
+
+	return false
+}
+
+func toolIdForStoreTool(storeOwner string, toolName string) string {
+	if owner, name, err := util.GetOwnerAndNameFromIdWithError(toolName); err == nil {
+		return util.GetIdFromOwnerAndName(owner, name)
+	}
+	return util.GetIdFromOwnerAndName(storeOwner, toolName)
+}

--- a/tool/local_file.go
+++ b/tool/local_file.go
@@ -246,12 +246,12 @@ func localFileReadText(path, ext, lang string) (string, error) {
 	return string(bs), nil
 }
 
-func localFileOcrEndpoint(endpoint string) string {
+func localFileOcrEndpoint(ctx context.Context, endpoint string) (string, error) {
 	endpoint = strings.TrimSpace(endpoint)
 	if endpoint != "" {
-		return endpoint
+		return endpoint, nil
 	}
-	return localocr.DefaultEndpoint
+	return localocr.EnsureRunning(ctx)
 }
 
 func localFilePostPdfOcr(ctx context.Context, endpoint string, path string) (string, error) {
@@ -394,8 +394,6 @@ func (b *localPdfOcrReadBuiltin) GetInputSchema() interface{} {
 }
 
 func (b *localPdfOcrReadBuiltin) Execute(ctx context.Context, arguments map[string]interface{}) (*protocol.CallToolResult, error) {
-	endpoint := localFileOcrEndpoint(b.endpoint)
-
 	path := localFileStringArg(arguments, "path")
 	if err := localFileRequireAbsolutePath(path, "path"); err != nil {
 		return localFileError(err.Error()), nil
@@ -409,6 +407,11 @@ func (b *localPdfOcrReadBuiltin) Execute(ctx context.Context, arguments map[stri
 	}
 	if strings.ToLower(filepath.Ext(path)) != ".pdf" {
 		return localFileError("path must be a PDF file"), nil
+	}
+
+	endpoint, err := localFileOcrEndpoint(ctx, b.endpoint)
+	if err != nil {
+		return localFileError(fmt.Sprintf("failed to start managed OCR service: %s", err.Error())), nil
 	}
 
 	text, err := localFilePostPdfOcr(ctx, endpoint, path)

--- a/tool/local_file.go
+++ b/tool/local_file.go
@@ -15,19 +15,25 @@
 package tool
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/fs"
+	"mime/multipart"
+	"net/http"
 	"os"
 	"os/user"
 	"path/filepath"
 	"runtime"
 	"sort"
 	"strings"
+	"time"
 	"unicode/utf8"
 
 	"github.com/ThinkInAIXYZ/go-mcp/protocol"
+	"github.com/the-open-agent/openagent/internal/localocr"
 	"github.com/the-open-agent/openagent/txt"
 )
 
@@ -36,11 +42,13 @@ const (
 	localFileMaxPreviewChars     = 20000
 	localFileDefaultReadLimit    = 12000
 	localFileMaxReadLimit        = 100000
+	localFileOcrTimeout          = 2 * time.Minute
 )
 
 // LocalFileTool is the Tool Type "local_file".
 type LocalFileTool struct {
-	lang string
+	lang        string
+	ocrEndpoint string
 }
 
 func (p *LocalFileTool) BuiltinTools() []BuiltinTool {
@@ -48,6 +56,7 @@ func (p *LocalFileTool) BuiltinTools() []BuiltinTool {
 		&localSpecialDirsBuiltin{},
 		&localFileScanBuiltin{lang: p.lang},
 		&localFileReadBuiltin{lang: p.lang},
+		&localPdfOcrReadBuiltin{endpoint: p.ocrEndpoint},
 		&localFileWriteBuiltin{},
 		&localFileMoveBuiltin{},
 	}
@@ -97,6 +106,16 @@ type localFileReadResult struct {
 	TextLength int    `json:"textLength"`
 	Text       string `json:"text"`
 	Truncated  bool   `json:"truncated"`
+}
+
+type localPdfOcrReadResult struct {
+	Path       string `json:"path"`
+	TextLength int    `json:"textLength"`
+	Text       string `json:"text"`
+}
+
+type localPdfOcrResponse struct {
+	Text *string `json:"text"`
 }
 
 type localFileWriteResult struct {
@@ -227,6 +246,61 @@ func localFileReadText(path, ext, lang string) (string, error) {
 	return string(bs), nil
 }
 
+func localFileOcrEndpoint(endpoint string) string {
+	endpoint = strings.TrimSpace(endpoint)
+	if endpoint != "" {
+		return endpoint
+	}
+	return localocr.DefaultEndpoint
+}
+
+func localFilePostPdfOcr(ctx context.Context, endpoint string, path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, err := writer.CreateFormFile("file", filepath.Base(path))
+	if err != nil {
+		return "", err
+	}
+	if _, err = io.Copy(part, file); err != nil {
+		return "", err
+	}
+	if err = writer.Close(); err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, &body)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	client := &http.Client{Timeout: localFileOcrTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return "", fmt.Errorf("ocr endpoint returned status %d", resp.StatusCode)
+	}
+
+	var result localPdfOcrResponse
+	if err = json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", err
+	}
+	if result.Text == nil {
+		return "", fmt.Errorf("ocr endpoint response missing text")
+	}
+	return *result.Text, nil
+}
+
 func localFileDirectory(path string) localSpecialDirInfo {
 	info, err := os.Stat(path)
 	return localSpecialDirInfo{
@@ -288,6 +362,63 @@ func (b *localSpecialDirsBuiltin) Execute(_ context.Context, _ map[string]interf
 			Documents: localFileDirectory(filepath.Join(home, "Documents")),
 			Downloads: localFileDirectory(filepath.Join(home, "Downloads")),
 		},
+	}), nil
+}
+
+type localPdfOcrReadBuiltin struct {
+	endpoint string
+}
+
+func (b *localPdfOcrReadBuiltin) GetName() string {
+	return "local_pdf_ocr_read"
+}
+
+func (b *localPdfOcrReadBuiltin) GetDescription() string {
+	return `Read a scanned local PDF through the configured OCR HTTP endpoint.
+- path (required): absolute PDF file path for the current operating system.
+- Sends multipart/form-data field "file" to the local_file Provider URL, or the managed local OCR service when Provider URL is empty.
+- The OCR endpoint must return JSON: {"text":"recognized text"}.`
+}
+
+func (b *localPdfOcrReadBuiltin) GetInputSchema() interface{} {
+	return map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"path": map[string]interface{}{
+				"type":        "string",
+				"description": "Absolute path to a local PDF file.",
+			},
+		},
+		"required": []string{"path"},
+	}
+}
+
+func (b *localPdfOcrReadBuiltin) Execute(ctx context.Context, arguments map[string]interface{}) (*protocol.CallToolResult, error) {
+	endpoint := localFileOcrEndpoint(b.endpoint)
+
+	path := localFileStringArg(arguments, "path")
+	if err := localFileRequireAbsolutePath(path, "path"); err != nil {
+		return localFileError(err.Error()), nil
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return localFileError(fmt.Sprintf("failed to access path: %s", err.Error())), nil
+	}
+	if info.IsDir() {
+		return localFileError("path must be a file"), nil
+	}
+	if strings.ToLower(filepath.Ext(path)) != ".pdf" {
+		return localFileError("path must be a PDF file"), nil
+	}
+
+	text, err := localFilePostPdfOcr(ctx, endpoint, path)
+	if err != nil {
+		return localFileError(fmt.Sprintf("failed to read PDF through OCR endpoint: %s", err.Error())), nil
+	}
+	return localFileJSON(localPdfOcrReadResult{
+		Path:       path,
+		TextLength: len([]rune(text)),
+		Text:       text,
 	}), nil
 }
 

--- a/tool/tool.go
+++ b/tool/tool.go
@@ -46,7 +46,7 @@ func New(config Config, lang string) (Tool, error) {
 	case "shell":
 		return &ShellTool{}, nil
 	case "local_file":
-		return &LocalFileTool{lang: lang}, nil
+		return &LocalFileTool{lang: lang, ocrEndpoint: config.ProviderUrl}, nil
 	case "office":
 		return &OfficeTool{subType: officeSubType(config.SubType)}, nil
 	case "web_fetch":

--- a/web/src/Setting.js
+++ b/web/src/Setting.js
@@ -458,6 +458,11 @@ export function getToolFunctions(tool) {
         testContent: JSON.stringify({tool: "local_file_read", arguments: {path: "/absolute/path/to/Desktop/report.pdf", offset: 0, limit: 12000}}, null, 2),
       },
       {
+        name: "local_pdf_ocr_read",
+        description: "Read a scanned local PDF through the configured or managed OCR HTTP endpoint",
+        testContent: JSON.stringify({tool: "local_pdf_ocr_read", arguments: {path: "/absolute/path/to/Desktop/scanned.pdf"}}, null, 2),
+      },
+      {
         name: "local_file_write",
         description: "Write text to an absolute local path",
         testContent: JSON.stringify({tool: "local_file_write", arguments: {path: "/absolute/path/to/Desktop/Project Summaries/summary.md", content: "# Summary\\n\\nProject notes.", overwrite: false}}, null, 2),

--- a/web/src/ToolEditPage.js
+++ b/web/src/ToolEditPage.js
@@ -223,7 +223,7 @@ class ToolEditPage extends React.Component {
                 12
               )
             ) : null}
-            {["web_search", "web_fetch", "web_browser"].includes(tool.type) ? (
+            {["web_search", "web_fetch", "web_browser", "local_file"].includes(tool.type) ? (
               this.renderToolField(
                 this.getProviderUrlLabel(tool),
                 <Input value={tool.providerUrl} onChange={e => {


### PR DESCRIPTION
## Summary

- Add a local OCR service for `local_file` scanned PDF reading.
- Start a local FastAPI/RapidOCR service from OpenAgent when no OCR endpoint is already running.

## Changes

- Add `internal/localocr` to manage the local OCR Python service lifecycle.
- Add `deploy/ocr-service` FastAPI wrapper using `pypdfium2` + `RapidOCR`.
- Make `local_pdf_ocr_read` use the managed local OCR endpoint when `Provider URL` is empty.
- Expose `Provider URL` for `local_file` as an optional external OCR override.
- Include OCR service files in GoReleaser archives.
- Keep Docker OCR deployment available via `docker-compose.ocr.yml`.