### PR TITLE
feat: add store memory builtin tool

### DIFF
--- a/controllers/message_answer.go
+++ b/controllers/message_answer.go
@@ -220,6 +220,9 @@ func generateMessageAnswer(id string, responseWriter http.ResponseWriter, host s
 			"- Mutable facts need live checks: use tools rather than memory.\n" +
 			"- Longer work: brief progress update, then keep going."
 	}
+	if store.EmbeddingProvider != "" {
+		store.Prompt += "\nWhen the user shares a durable preference, personal convention, or standing instruction that should be remembered in future conversations for this store, call `store_memory` to save it."
+	}
 
 	if len(store.Skills) > 0 {
 		skillsContent, skillErr := object.GetSkillsCatalog(store.Owner, store.Skills)

--- a/object/merge_agent_tools.go
+++ b/object/merge_agent_tools.go
@@ -33,6 +33,10 @@ func buildMergedBuiltinRegistry(store *Store, lang string) *tool.ToolRegistry {
 		}
 	}
 
+	if bt := NewStoreMemoryBuiltin(store, lang); bt != nil {
+		reg.RegisterTool(bt)
+	}
+
 	toolNames := store.Tools
 	if len(toolNames) == 1 && toolNames[0] == "All" {
 		allTools, err := GetTools(store.Owner)

--- a/object/store_memory.go
+++ b/object/store_memory.go
@@ -1,0 +1,201 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package object
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/ThinkInAIXYZ/go-mcp/protocol"
+	"github.com/the-open-agent/openagent/i18n"
+	"github.com/the-open-agent/openagent/tool"
+	"github.com/the-open-agent/openagent/util"
+)
+
+const storeMemoryPrefix = "Store memory: "
+
+func normalizeStoreMemoryText(content string) string {
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return ""
+	}
+	if strings.HasPrefix(content, storeMemoryPrefix) {
+		return content
+	}
+	return storeMemoryPrefix + content
+}
+
+func AddStoreMemory(store *Store, content string, lang string) (*Vector, error) {
+	if store == nil {
+		return nil, fmt.Errorf(i18n.Translate(lang, "object:The store should not be empty"))
+	}
+
+	text := normalizeStoreMemoryText(content)
+	if text == "" {
+		return nil, fmt.Errorf(i18n.Translate(lang, "object:The memory content should not be empty"))
+	}
+
+	embeddingProviderName := store.EmbeddingProvider
+	if embeddingProviderName == "" {
+		embeddingProvider, _, err := GetEmbeddingProviderFromContext(store.Owner, "", lang)
+		if err != nil {
+			return nil, err
+		}
+		if embeddingProvider == nil {
+			return nil, fmt.Errorf(i18n.Translate(lang, "object:Please add an embedding provider first"))
+		}
+		embeddingProviderName = embeddingProvider.Name
+	}
+
+	embeddingProvider, embeddingProviderObj, err := getEmbeddingProviderFromName(store.Owner, embeddingProviderName, lang)
+	if err != nil {
+		return nil, err
+	}
+
+	data, embeddingResult, err := queryVectorSafe(embeddingProviderObj, text, embeddingProvider.Name, lang)
+	if err != nil {
+		return nil, err
+	}
+
+	existingMemories, err := getMemoryVectors(store.Owner, store.Name)
+	if err == nil {
+		dataNorm := norm(data)
+		for _, v := range existingMemories {
+			if len(v.Data) != len(data) {
+				continue
+			}
+			if cosineSimilarity(data, v.Data, dataNorm) > 0.95 {
+				if _, delErr := DeleteVector(v); delErr != nil {
+					return nil, delErr
+				}
+			}
+		}
+	}
+
+	displayName := text
+	if len([]rune(displayName)) > 40 {
+		displayName = string([]rune(displayName)[:40])
+	}
+
+	tokenCount := 0
+	price := 0.0
+	currency := ""
+	if embeddingResult != nil {
+		tokenCount = embeddingResult.TokenCount
+		price = embeddingResult.Price
+		currency = embeddingResult.Currency
+	}
+
+	vector := &Vector{
+		Owner:       store.Owner,
+		Name:        fmt.Sprintf("vector_memory_%s", util.GetRandomName()),
+		CreatedTime: util.GetCurrentTime(),
+		DisplayName: displayName,
+		Store:       store.Name,
+		Provider:    embeddingProvider.Name,
+		File:        "__store_memory__",
+		Index:       0,
+		Text:        text,
+		TokenCount:  tokenCount,
+		Price:       price,
+		Currency:    currency,
+		Data:        data,
+		Dimension:   len(data),
+	}
+
+	_, err = AddVector(vector)
+	if err != nil {
+		return nil, err
+	}
+
+	return vector, nil
+}
+
+func NewStoreMemoryBuiltin(store *Store, lang string) tool.BuiltinTool {
+	if store == nil {
+		return nil
+	}
+	if store.EmbeddingProvider == "" {
+		embeddingProvider, _, err := GetEmbeddingProviderFromContext(store.Owner, "", lang)
+		if err != nil || embeddingProvider == nil {
+			return nil
+		}
+	}
+	return &storeMemoryBuiltin{store: store, lang: lang}
+}
+
+type storeMemoryBuiltin struct {
+	store *Store
+	lang  string
+}
+
+func (t *storeMemoryBuiltin) GetName() string {
+	return "store_memory"
+}
+
+func (t *storeMemoryBuiltin) GetDescription() string {
+	return "Save an important long-term memory for the current store so it can be retrieved later through the store's existing RAG knowledge retrieval. Use this for stable preferences, conventions, or facts worth remembering for future conversations in this store."
+}
+
+func (t *storeMemoryBuiltin) GetInputSchema() interface{} {
+	return map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"content": map[string]interface{}{
+				"type":        "string",
+				"description": "The memory to save for this store. Write it as a clear enduring fact or preference.",
+			},
+		},
+		"required": []string{"content"},
+	}
+}
+
+func (t *storeMemoryBuiltin) Execute(_ context.Context, arguments map[string]interface{}) (*protocol.CallToolResult, error) {
+	if t.store == nil {
+		return storeMemoryToolError("store context is missing"), nil
+	}
+
+	content, _ := arguments["content"].(string)
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return storeMemoryToolError("missing required parameter: content"), nil
+	}
+
+	vector, err := AddStoreMemory(t.store, content, t.lang)
+	if err != nil {
+		return storeMemoryToolError(err.Error()), nil
+	}
+
+	return storeMemoryToolText(fmt.Sprintf("saved store memory for %s: %s", t.store.Name, vector.Text)), nil
+}
+
+func storeMemoryToolText(text string) *protocol.CallToolResult {
+	return &protocol.CallToolResult{
+		IsError: false,
+		Content: []protocol.Content{
+			&protocol.TextContent{Type: "text", Text: text},
+		},
+	}
+}
+
+func storeMemoryToolError(text string) *protocol.CallToolResult {
+	return &protocol.CallToolResult{
+		IsError: true,
+		Content: []protocol.Content{
+			&protocol.TextContent{Type: "text", Text: text},
+		},
+	}
+}

--- a/object/vector.go
+++ b/object/vector.go
@@ -71,6 +71,15 @@ func getVectorsByProvider(relatedStores []string, provider string) ([]*Vector, e
 	return vectors, nil
 }
 
+func getMemoryVectors(owner string, storeName string) ([]*Vector, error) {
+	vectors := []*Vector{}
+	err := adapter.engine.Where("owner = ? and store = ? and file = ?", owner, storeName, "__store_memory__").Find(&vectors)
+	if err != nil {
+		return nil, err
+	}
+	return vectors, nil
+}
+
 func getVector(owner string, name string) (*Vector, error) {
 	vector := Vector{Owner: owner, Name: name}
 	existed, err := adapter.engine.Get(&vector)


### PR DESCRIPTION
## Summary

Add a built-in store_memory tool that lets the model save durable store-scoped memories as vectors with a Store memory: prefix. Retrieval stays on the existing RAG path via GetNearestKnowledge(...), and the prompt now nudges the model to use the tool for long-term user preferences and standing instructions.