### PR TITLE
fix: trim release data assets

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -45,8 +45,6 @@ archives:
         dst: './web/build'
       - src: 'conf/app.conf'
         dst: './conf/app.conf'
-      - src: 'data'
-        dst: './data'
       - src: 'skills'
         dst: './skills'
 

--- a/main.go
+++ b/main.go
@@ -43,6 +43,10 @@ func main() {
 
 	object.InitDb()
 	proxy.InitHttpClient()
+	err := util.EnsureRuntimeDataFiles()
+	if err != nil {
+		panic(err)
+	}
 	util.InitMaxmindFiles()
 	util.InitIpDb()
 	util.InitParser()
@@ -81,7 +85,7 @@ func main() {
 
 	var logAdapter string
 	logConfigMap := make(map[string]interface{})
-	err := json.Unmarshal([]byte(conf.GetConfigString("logConfig")), &logConfigMap)
+	err = json.Unmarshal([]byte(conf.GetConfigString("logConfig")), &logConfigMap)
 	if err != nil {
 		panic(err)
 	}

--- a/util/file.go
+++ b/util/file.go
@@ -23,10 +23,86 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/beego/beego"
 	"github.com/beego/beego/logs"
 	"github.com/the-open-agent/openagent/conf"
 	"github.com/the-open-agent/openagent/proxy"
 )
+
+func getRuntimeDataDir() string {
+	frontendBaseDir := conf.GetConfigString("frontendBaseDir")
+	if frontendBaseDir == "" {
+		return "data"
+	}
+	return filepath.Join(frontendBaseDir, "data")
+}
+
+func ensureDataFile(filename string, urls ...string) error {
+	targetPath := filepath.Join(getRuntimeDataDir(), filename)
+	if FileExist(targetPath) {
+		return nil
+	}
+
+	EnsureFileFolderExists(targetPath)
+
+	var lastErr error
+	for _, fileURL := range urls {
+		buffer, err := DownloadFile(fileURL)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+
+		err = os.WriteFile(targetPath, buffer.Bytes(), 0o644)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+
+		return nil
+	}
+
+	if lastErr != nil {
+		return fmt.Errorf("failed to initialize %s: %w", targetPath, lastErr)
+	}
+
+	return fmt.Errorf("failed to initialize %s: no download URLs configured", targetPath)
+}
+
+func EnsureRuntimeDataFiles() error {
+	err := ensureDataFile("regexes.yaml",
+		"https://cdn.jsdelivr.net/gh/the-open-agent/openagent@master/data/regexes.yaml",
+	)
+	if err != nil {
+		return err
+	}
+
+	if beego.AppConfig.DefaultBool("isLocalIpDb", false) {
+		err = ensureDataFile("17monipdb.dat",
+			"https://cdn.jsdelivr.net/gh/the-open-agent/openagent@master/data/17monipdb.dat",
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	templateFiles := []string{
+		"code-server.yaml",
+		"kuboard.yaml",
+		"pdf2zh.yaml",
+	}
+
+	for _, templateFile := range templateFiles {
+		err = ensureDataFile(filepath.Join("template", templateFile),
+			fmt.Sprintf("https://cdn.jsdelivr.net/gh/the-open-agent/openagent@master/data/template/%s", templateFile),
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
 
 func parseJsonToFloats(s string) []float64 {
 	s = strings.TrimLeft(s, "[")


### PR DESCRIPTION
fix #2230.

## Summary

Trim release data assets and bootstrap required runtime data on startup

- remove the packaged data/ directory, including bundled template/data assets, from release archives to reduce size
- download regexes.yaml on startup after HTTP client init
- only download 17monipdb.dat when isLocalIpDb=true