### PR TITLE
chore: disable source map generation in production build

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -72,7 +72,7 @@
   },
   "scripts": {
     "start": "cross-env PORT=13001 craco start",
-    "build": "craco build",
+    "build": "cross-env GENERATE_SOURCEMAP=false craco build",
     "postbuild": "node mv.js",
     "test": "craco test",
     "eject": "craco eject",


### PR DESCRIPTION
## Summary
Disable source map generation during production builds to reduce build output size by approximately 47 MB.

## Problem
The default Create React App configuration generates `.map` files during production builds. These source maps:
- Consume significant disk space (~47 MB)
- Are only useful for debugging in development
- Are unnecessary for production binary releases

## Solution
Add `GENERATE_SOURCEMAP=false` environment variable to the build script in `package.json`.

### Changes
```diff
- "build": "craco build",
+ "build": "cross-env GENERATE_SOURCEMAP=false craco build",
```

## Impact
| Metric | Before | After | Reduction |
|--------|--------|-------|-----------|
| Build output size | ~63.7 MB | ~16.8 MB | ~47 MB (74%) |
| File count | Includes `.map` files | No `.map` files | Cleaner output |

## Verification
- [x] `yarn build` no longer generates `.map` files
- [x] `yarn start` (development) unaffected
- [x] Uses `cross-env` for cross-platform compatibility (Windows/macOS/Linux)
- [x] Build completes successfully

## Backward Compatibility
- **Development**: No impact (`yarn start` unchanged)
- **Production**: Only affects builds using `yarn build`
- **Debugging**: Source maps can be temporarily re-enabled by removing the environment variable when needed

## Notes
- `cross-env` is already used in the project (see `start` script), ensuring cross-platform compatibility
- For volume analysis with `source-map-explorer`, temporarily remove `GENERATE_SOURCEMAP=false` if source maps are needed