### PR TITLE
feat: route pipe webhook through message answer flow

### DIFF
--- a/authz/authz.go
+++ b/authz/authz.go
@@ -94,6 +94,7 @@ p, anonymous, *, /api/analyze-task
 p, anonymous, *, /api/claim-store
 p, anonymous, *, /api/is-session-duplicated
 p, anonymous, *, /api/add-node-tunnel
+p, anonymous, *, /api/chat-webhook/*
 
 g, admin, user
 g, user, anonymous

--- a/controllers/message_answer.go
+++ b/controllers/message_answer.go
@@ -23,6 +23,7 @@ import (
 	"github.com/beego/beego/context"
 	"github.com/the-open-agent/openagent/conf"
 	"github.com/the-open-agent/openagent/embedding"
+	"github.com/the-open-agent/openagent/i18n"
 	"github.com/the-open-agent/openagent/model"
 	"github.com/the-open-agent/openagent/object"
 	"github.com/the-open-agent/openagent/util"
@@ -46,10 +47,16 @@ func (c *ApiController) GetMessageAnswer() {
 }
 
 func (c *ApiController) generateMessageAnswer(id string, responseWriter http.ResponseWriter, host string) {
-	lang := c.GetAcceptLanguage()
+	_, signedIn := c.CheckSignedIn()
+	generateMessageAnswer(id, responseWriter, host, c.GetAcceptLanguage(), signedIn, c.ResponseError)
+}
+
+func generateMessageAnswer(id string, responseWriter http.ResponseWriter, host string, lang string, signedIn bool, responseError func(string, ...interface{})) {
 	responseErrorStream := func(message *object.Message, errorText string) {
 		if err := writeMessageErrorStream(responseWriter, lang, message, errorText); err != nil {
-			c.ResponseError(err.Error())
+			if responseError != nil {
+				responseError(err.Error())
+			}
 		}
 	}
 
@@ -112,7 +119,7 @@ func (c *ApiController) generateMessageAnswer(id string, responseWriter http.Res
 				KnowledgeCount: 10,
 			}
 		} else {
-			responseErrorStream(message, fmt.Sprintf(c.T("account:The store: %s is not found"), chat.Store))
+			responseErrorStream(message, fmt.Sprintf(i18n.Translate(lang, "account:The store: %s is not found"), chat.Store))
 			return
 		}
 	}
@@ -171,8 +178,7 @@ func (c *ApiController) generateMessageAnswer(id string, responseWriter http.Res
 		return
 	}
 
-	_, ok := c.CheckSignedIn()
-	if !ok {
+	if !signedIn {
 		var count int
 		count, err = object.GetNearMessageCount(message.User, store.LimitMinutes)
 		if err != nil {
@@ -227,7 +233,7 @@ func (c *ApiController) generateMessageAnswer(id string, responseWriter http.Res
 	if chat.Tool == "" && store.KnowledgeCount != 0 {
 		knowledge, vectorScores, embeddingResult, err = object.GetNearestKnowledge(store.Name, store.VectorStores, store.SearchProvider, embeddingProvider, embeddingProviderObj, modelProvider, store.Owner, question, store.KnowledgeCount, lang)
 		if err != nil && err.Error() != "no knowledge vectors found" {
-			err = fmt.Errorf(c.T("message_answer:object.GetNearestKnowledge() error, %s"), err.Error())
+			err = fmt.Errorf(i18n.Translate(lang, "message_answer:object.GetNearestKnowledge() error, %s"), err.Error())
 			responseErrorStream(message, err.Error())
 			return
 		}
@@ -298,7 +304,9 @@ func (c *ApiController) generateMessageAnswer(id string, responseWriter http.Res
 	}
 	if err != nil {
 		if strings.Contains(err.Error(), "write tcp") {
-			c.ResponseError(err.Error())
+			if responseError != nil {
+				responseError(err.Error())
+			}
 			return
 		}
 		responseErrorStream(message, err.Error())

--- a/controllers/pipe.go
+++ b/controllers/pipe.go
@@ -121,6 +121,9 @@ func (c *ApiController) AddPipe() {
 	}
 
 	pipe.Owner = "admin"
+	if pipe.Store == "" {
+		pipe.Store = "store-built-in"
+	}
 	success, err := object.AddPipe(&pipe)
 	if err != nil {
 		c.ResponseError(err.Error())

--- a/controllers/pipe_webhook.go
+++ b/controllers/pipe_webhook.go
@@ -15,13 +15,37 @@
 package controllers
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
+	"github.com/the-open-agent/openagent/conf"
 	"github.com/the-open-agent/openagent/object"
 	pipepkg "github.com/the-open-agent/openagent/pipe"
+	"github.com/the-open-agent/openagent/util"
 )
+
+type pipeAnswerSender interface {
+	WriteMessage(text string) error
+	WriteError(text string) error
+	CloseMessage(text string) error
+}
+
+type defaultPipeAnswerSender struct {
+	provider  pipepkg.Pipe
+	chatId    string
+	text      string
+	errorText string
+}
+
+type streamPipeAnswerSender struct {
+	writer    pipepkg.PipeMessageWriter
+	text      string
+	errorText string
+}
 
 // ChatWebhookVerify handles the HTTP GET challenge that some platforms (e.g. WhatsApp
 // Cloud API) send to verify webhook ownership before they start delivering events.
@@ -77,6 +101,8 @@ func (c *ApiController) ChatWebhookVerify() {
 func (c *ApiController) ChatWebhook() {
 	pipeType := c.Ctx.Input.Param(":pipeType")
 	pipeName := c.Ctx.Input.Param(":pipeName")
+	host := c.Ctx.Request.Host
+	lang := c.GetAcceptLanguage()
 
 	pipeObj, err := object.GetPipeByName("admin", pipeName)
 	if err != nil {
@@ -88,7 +114,7 @@ func (c *ApiController) ChatWebhook() {
 		return
 	}
 
-	provider, err := pipeObj.GetProvider(c.GetAcceptLanguage())
+	provider, err := pipeObj.GetProvider(lang)
 	if err != nil {
 		c.Ctx.ResponseWriter.WriteHeader(http.StatusInternalServerError)
 		return
@@ -119,11 +145,11 @@ func (c *ApiController) ChatWebhook() {
 
 	if immediateResponse != nil {
 		writePipeWebhookResponse(c, immediateResponse)
-		go sendPipeAnswer(provider, incoming, c.GetAcceptLanguage())
+		go sendPipeAnswer(provider, pipeObj, incoming, host, lang)
 		return
 	}
 
-	sendPipeAnswer(provider, incoming, c.GetAcceptLanguage())
+	sendPipeAnswer(provider, pipeObj, incoming, host, lang)
 	c.Ctx.ResponseWriter.WriteHeader(http.StatusOK)
 }
 
@@ -155,12 +181,283 @@ func writePipeWebhookResponse(c *ApiController, response *pipepkg.WebhookRespons
 	}
 }
 
-func sendPipeAnswer(provider pipepkg.Pipe, incoming *pipepkg.IncomingMessage, lang string) {
-	answer, _, err := object.GetAnswer("", incoming.Text, lang)
+type pipeSSERecorder struct {
+	header http.Header
+	body   bytes.Buffer
+	status int
+	sender pipeAnswerSender
+}
+
+func newPipeSSERecorder(sender pipeAnswerSender) *pipeSSERecorder {
+	return &pipeSSERecorder{header: http.Header{}, status: http.StatusOK, sender: sender}
+}
+
+func (r *pipeSSERecorder) Header() http.Header {
+	return r.header
+}
+
+func (r *pipeSSERecorder) WriteHeader(statusCode int) {
+	r.status = statusCode
+}
+
+func (r *pipeSSERecorder) Write(p []byte) (int, error) {
+	n, err := r.body.Write(p)
+	if err != nil {
+		return n, err
+	}
+
+	if r.sender != nil {
+		r.consumeBody()
+	}
+
+	return n, nil
+}
+
+func (r *pipeSSERecorder) Flush() {}
+
+func (r *pipeSSERecorder) consumeBody() {
+	for {
+		body := r.body.String()
+		idx := strings.Index(body, "\n\n")
+		if idx == -1 {
+			return
+		}
+
+		chunk := body[:idx]
+		rest := body[idx+2:]
+		r.body.Reset()
+		_, _ = r.body.WriteString(rest)
+
+		r.consumeChunk(chunk)
+	}
+}
+
+func (r *pipeSSERecorder) consumeChunk(chunk string) {
+	lines := strings.Split(chunk, "\n")
+	if len(lines) == 0 {
+		return
+	}
+
+	eventType := ""
+	if strings.HasPrefix(lines[0], "event: ") {
+		eventType = strings.TrimPrefix(lines[0], "event: ")
+	}
+
+	switch eventType {
+	case "message":
+		for _, line := range lines {
+			if !strings.HasPrefix(line, "data: ") {
+				continue
+			}
+			payload := strings.TrimPrefix(line, "data: ")
+			var data map[string]string
+			if err := json.Unmarshal([]byte(payload), &data); err == nil && r.sender != nil {
+				_ = r.sender.WriteMessage(data["text"])
+			}
+		}
+	case "myerror":
+		for _, line := range lines {
+			if !strings.HasPrefix(line, "data: ") {
+				continue
+			}
+			payload := strings.TrimPrefix(line, "data: ")
+			if r.sender != nil {
+				_ = r.sender.WriteError(payload)
+			}
+		}
+	}
+}
+
+func ensurePipeChat(pipeObj *object.Pipe, incoming *pipepkg.IncomingMessage) (*object.Chat, error) {
+	chatName := fmt.Sprintf("pipe_%s_%s", pipeObj.Name, incoming.ChatId)
+	chatId := util.GetIdFromOwnerAndName("admin", chatName)
+	chat, err := object.GetChat(chatId)
+	if err != nil {
+		return nil, err
+	}
+	if chat != nil {
+		return chat, nil
+	}
+
+	casdoorOrganization := conf.GetConfigString("casdoorOrganization")
+	storeName := ""
+	if pipeObj.Store != "" {
+		storeName = pipeObj.Store
+	} else {
+		defaultStore, err := object.GetDefaultStore("admin")
+		if err != nil {
+			return nil, err
+		}
+		if defaultStore != nil {
+			storeName = defaultStore.Name
+		}
+	}
+
+	currentTime := util.GetCurrentTime()
+	chat = &object.Chat{
+		Owner:         "admin",
+		Name:          chatName,
+		CreatedTime:   currentTime,
+		UpdatedTime:   currentTime,
+		Organization:  casdoorOrganization,
+		DisplayName:   incoming.Username,
+		Store:         storeName,
+		ModelProvider: "",
+		Category:      "Pipe",
+		Type:          "AI",
+		User:          chatName,
+		User1:         "",
+		User2:         "",
+		Users:         []string{},
+		ClientIp:      "",
+		UserAgent:     fmt.Sprintf("pipe/%s", pipeObj.Type),
+		MessageCount:  0,
+		IsHidden:      true,
+	}
+	_, err = object.AddChat(chat)
+	if err != nil {
+		return nil, err
+	}
+	return chat, nil
+}
+
+func addPipeQuestionAndAnswerMessages(chat *object.Chat, incoming *pipepkg.IncomingMessage) (*object.Message, *object.Message, error) {
+	questionMessage := &object.Message{
+		Owner:        "admin",
+		Name:         fmt.Sprintf("message_%s", util.GetRandomName()),
+		CreatedTime:  util.GetCurrentTimeWithMilli(),
+		Organization: chat.Organization,
+		Store:        chat.Store,
+		User:         chat.User,
+		Chat:         chat.Name,
+		ReplyTo:      "",
+		Author:       incoming.Username,
+		Text:         incoming.Text,
+	}
+	if questionMessage.Author == "" {
+		questionMessage.Author = incoming.UserId
+	}
+	if questionMessage.Author == "" {
+		questionMessage.Author = "User"
+	}
+
+	_, err := object.AddMessage(questionMessage)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	answerMessage := &object.Message{
+		Owner:         "admin",
+		Name:          fmt.Sprintf("message_%s", util.GetRandomName()),
+		CreatedTime:   util.GetCurrentTimeEx(questionMessage.CreatedTime),
+		Organization:  chat.Organization,
+		Store:         chat.Store,
+		User:          chat.User,
+		Chat:          chat.Name,
+		ReplyTo:       questionMessage.Name,
+		Author:        "AI",
+		Text:          "",
+		ModelProvider: chat.ModelProvider,
+	}
+
+	_, err = object.AddMessage(answerMessage)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return questionMessage, answerMessage, nil
+}
+
+func sendPipeAnswer(provider pipepkg.Pipe, pipeObj *object.Pipe, incoming *pipepkg.IncomingMessage, host string, lang string) {
+	chat, err := ensurePipeChat(pipeObj, incoming)
 	if err != nil {
 		_ = provider.SendMessage(incoming.ChatId, fmt.Sprintf("Error: %v", err))
 		return
 	}
 
-	_ = provider.SendMessage(incoming.ChatId, answer)
+	_, answerMessage, err := addPipeQuestionAndAnswerMessages(chat, incoming)
+	if err != nil {
+		_ = provider.SendMessage(incoming.ChatId, fmt.Sprintf("Error: %v", err))
+		return
+	}
+
+	var sender pipeAnswerSender = newDefaultPipeAnswerSender(provider, incoming.ChatId)
+	if streamProvider, ok := provider.(pipepkg.StreamPipe); ok {
+		if writer, streamErr := streamProvider.SendStreamMessage(incoming.ChatId, ""); streamErr == nil && writer != nil {
+			sender = newStreamPipeAnswerSender(writer)
+		}
+	}
+
+	recorder := newPipeSSERecorder(sender)
+	generateMessageAnswer(answerMessage.GetId(), recorder, host, lang, false, nil)
+
+	answer, err := object.GetMessage(answerMessage.GetId())
+	if err == nil && answer != nil && answer.Text != "" {
+		_ = sender.CloseMessage(answer.Text)
+		return
+	}
+	if answer != nil && answer.ErrorText != "" {
+		_ = sender.CloseMessage(answer.ErrorText)
+		return
+	}
+	_ = sender.CloseMessage("")
+}
+
+func newDefaultPipeAnswerSender(provider pipepkg.Pipe, chatId string) *defaultPipeAnswerSender {
+	return &defaultPipeAnswerSender{provider: provider, chatId: chatId}
+}
+
+func (s *defaultPipeAnswerSender) WriteMessage(text string) error {
+	if text != "" {
+		s.text = text
+	}
+	return nil
+}
+
+func (s *defaultPipeAnswerSender) WriteError(text string) error {
+	if text != "" {
+		s.errorText = text
+	}
+	return nil
+}
+
+func (s *defaultPipeAnswerSender) CloseMessage(text string) error {
+	if text == "" {
+		return nil
+	}
+	return s.provider.SendMessage(s.chatId, text)
+}
+
+func newStreamPipeAnswerSender(writer pipepkg.PipeMessageWriter) *streamPipeAnswerSender {
+	return &streamPipeAnswerSender{writer: writer}
+}
+
+func (s *streamPipeAnswerSender) WriteMessage(text string) error {
+	if text == "" || text == s.text {
+		return nil
+	}
+	s.text = text
+	return s.writer.WriteMessage(text)
+}
+
+func (s *streamPipeAnswerSender) WriteError(text string) error {
+	if text != "" {
+		s.errorText = text
+	}
+	return nil
+}
+
+func (s *streamPipeAnswerSender) CloseMessage(text string) error {
+	finalText := text
+	if finalText == "" {
+		switch {
+		case s.text != "":
+			finalText = s.text
+		case s.errorText != "":
+			finalText = s.errorText
+		default:
+			finalText = "No response generated"
+		}
+	}
+	return s.writer.CloseMessage(finalText)
 }

--- a/object/pipe.go
+++ b/object/pipe.go
@@ -33,6 +33,7 @@ type Pipe struct {
 	Type        string `xorm:"varchar(100)" json:"type"`
 	Token       string `xorm:"varchar(2000)" json:"token"`
 	SecretKey   string `xorm:"varchar(100) 'provider_key'" json:"secretKey"`
+	Store       string `xorm:"varchar(100)" json:"store"`
 	Domain      string `xorm:"varchar(200)" json:"domain"`
 
 	IsDefault bool   `json:"isDefault"`

--- a/pipe/pipe.go
+++ b/pipe/pipe.go
@@ -37,6 +37,17 @@ type Pipe interface {
 	SetWebhook(webhookUrl string) error
 }
 
+type PipeMessageWriter interface {
+	WriteMessage(text string) error
+	CloseMessage(text string) error
+}
+
+// StreamPipe is implemented by pipes that can progressively update an
+// in-flight response (for example via send + edit message APIs).
+type StreamPipe interface {
+	SendStreamMessage(chatId string, text string) (PipeMessageWriter, error)
+}
+
 type WebhookResponse struct {
 	StatusCode  int
 	ContentType string

--- a/web/src/PipeEditPage.js
+++ b/web/src/PipeEditPage.js
@@ -17,6 +17,7 @@ import Loading from "./common/Loading";
 import {Button, Card, Col, Input, Row, Select, Switch} from "antd";
 import {LinkOutlined, SendOutlined} from "@ant-design/icons";
 import * as PipeBackend from "./backend/PipeBackend";
+import * as StoreBackend from "./backend/StoreBackend";
 import * as Setting from "./Setting";
 import i18next from "i18next";
 
@@ -30,6 +31,7 @@ class PipeEditPage extends React.Component {
       pipeName: props.match.params.pipeName,
       pipe: null,
       originalPipe: null,
+      storeNames: [],
       isNewPipe: props.location?.state?.isNewPipe || false,
       testChatId: "",
       testMessage: "",
@@ -40,7 +42,29 @@ class PipeEditPage extends React.Component {
   }
 
   UNSAFE_componentWillMount() {
+    this.getStoreNames();
     this.getPipe();
+  }
+
+  getStoreNames() {
+    StoreBackend.getStoreNames("admin")
+      .then((res) => {
+        if (res.status === "ok") {
+          this.setState({storeNames: res.data || []});
+        } else {
+          Setting.showMessage("error", `${i18next.t("general:Failed to get")}: ${res.msg}`);
+        }
+      })
+      .catch((error) => {
+        Setting.showMessage("error", `${i18next.t("general:Failed to get")}: ${error}`);
+      });
+  }
+
+  getStoreOptions() {
+    return this.state.storeNames.map((store) => {
+      const label = store.displayName ? `${store.displayName} (${store.name})` : store.name;
+      return Setting.getOption(label, store.name);
+    });
   }
 
   getPipe() {
@@ -223,6 +247,16 @@ class PipeEditPage extends React.Component {
                   </Option>
                 ))}
               </Select>
+            </Col>
+            <Col style={{marginTop: "5px"}} span={Setting.isMobile() ? 22 : 11}>
+              <div style={{marginBottom: "4px"}}>{Setting.getLabel(i18next.t("general:Store"), i18next.t("general:Store - Tooltip"))}</div>
+              <Select
+                virtual={false}
+                style={{width: "100%"}}
+                value={pipe.store || "store-built-in"}
+                onChange={(value) => this.updatePipeField("store", value)}
+                options={this.getStoreOptions()}
+              />
             </Col>
           </Row>
 

--- a/web/src/PipeListPage.js
+++ b/web/src/PipeListPage.js
@@ -37,6 +37,7 @@ class PipeListPage extends BaseListPage {
       type: "Telegram",
       token: "",
       secretKey: "",
+      store: "store-built-in",
       domain: "",
       isDefault: false,
       state: "Active",


### PR DESCRIPTION
## Summary

Route pipe webhook requests through the real message answer flow instead of the old direct `GetAnswer` path.

This change also adds store binding for pipes, keeps the existing non-streaming behavior as the default, and introduces optional streaming pipe interfaces for future provider support.

## Details

- route pipe answers through the real `chat` / `message` flow
- bind each pipe to a selected store
- keep default pipe replies non-streaming
- add optional `StreamPipe` / `PipeMessageWriter` interfaces for future streaming providers
