### PR TITLE
fix(ui): migrate antd Card to shadcn Card/SectionCard across all pages

### DIFF
--- a/web/src/AccountPage.js
+++ b/web/src/AccountPage.js
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 import React from "react";
-import {Avatar, Button, Card, Col, Form, Input, Modal, Row, Space, message} from "antd";
+import {Avatar, Button, Col, Form, Input, Modal, Row, Space, message} from "antd";
+import SectionCard from "./components/ui/section-card";
 import i18next from "i18next";
 import * as AccountBackend from "./backend/AccountBackend";
 import * as Setting from "./Setting";
@@ -114,28 +115,6 @@ class AccountPage extends React.Component {
       padding: "6px 10px",
     };
 
-    const cardHeadStyle = {
-      background: "transparent",
-      borderBottom: "none",
-      fontWeight: 600,
-      fontSize: "15px",
-      fontFamily: "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
-    };
-
-    const sectionCardStyle = {
-      marginBottom: "16px",
-      borderRadius: "14px",
-      boxShadow: "0 1px 3px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04)",
-      padding: "18px",
-    };
-
-    const renderCardTitle = (title, desc) => (
-      <div>
-        <div style={{fontWeight: 600, fontSize: "15px"}}>{title}</div>
-        <div style={{fontSize: "13px", color: "var(--ant-color-text-tertiary)", fontWeight: 400, marginTop: "2px"}}>{desc}</div>
-      </div>
-    );
-
     return (
       <div style={{background: "var(--ant-color-bg-layout)", padding: "16px 20px 32px", minHeight: "100vh"}}>
         <div style={{marginBottom: "16px", display: "flex", justifyContent: "space-between", alignItems: "center"}}>
@@ -157,12 +136,7 @@ class AccountPage extends React.Component {
           onFinish={(values) => this.onFinish(values)}
           onValuesChange={(_, values) => this.setState({avatar: values.avatar ?? ""})}
         >
-          <Card
-            size="small"
-            title={renderCardTitle(i18next.t("account:Profile"), i18next.t("account:Profile desc"))}
-            style={sectionCardStyle}
-            headStyle={cardHeadStyle}
-          >
+          <SectionCard title={i18next.t("account:Profile")} desc={i18next.t("account:Profile desc")}>
             <Row gutter={[16, 8]}>
               {this.renderField(
                 Setting.getLabel(i18next.t("general:Name"), i18next.t("general:Name - Tooltip")),
@@ -193,14 +167,9 @@ class AccountPage extends React.Component {
                 24
               )}
             </Row>
-          </Card>
+          </SectionCard>
 
-          <Card
-            size="small"
-            title={renderCardTitle(i18next.t("general:Password"), i18next.t("account:Password desc"))}
-            style={sectionCardStyle}
-            headStyle={cardHeadStyle}
-          >
+          <SectionCard title={i18next.t("general:Password")} desc={i18next.t("account:Password desc")}>
             <Row gutter={[16, 8]}>
               {this.renderField(
                 Setting.getLabel(i18next.t("general:Password"), i18next.t("general:Password - Tooltip")),
@@ -210,7 +179,7 @@ class AccountPage extends React.Component {
                 12
               )}
             </Row>
-          </Card>
+          </SectionCard>
         </Form>
 
         <Modal

--- a/web/src/ChatBox.js
+++ b/web/src/ChatBox.js
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 import React from "react";
-import {Card, Layout} from "antd";
+import {Layout} from "antd";
+import {Card, CardContent} from "./components/ui/card";
 import * as Setting from "./Setting";
 import i18next from "i18next";
 import copy from "copy-to-clipboard";
@@ -390,50 +391,52 @@ class ChatBox extends React.Component {
     return (
       <Layout style={{display: "flex", width: "100%", height: "100%", borderRadius: "6px", ...this.props.styles?.layout}}>
         <Card variant="borderless" style={{display: "flex", width: "100%", height: "100%", flexDirection: "column", position: "relative", padding: "0", boxShadow: "none", ...this.props.styles?.card}}>
-          {messages.length === 0 && !hasUrlMessage && <WelcomeHeader store={this.props.store} />}
+          <CardContent>
+            {messages.length === 0 && !hasUrlMessage && <WelcomeHeader store={this.props.store} />}
 
-          <MessageList
-            ref={this.messageListRef}
-            messages={messages}
-            account={this.props.account}
-            store={this.props.store}
-            onRegenerate={this.handleRegenerate}
-            onMessageLike={this.handleMessageLike}
-            onCopyMessage={this.copyMessageFromHTML}
-            onToggleRead={this.toggleMessageReadState}
-            onEditMessage={this.handleEditMessage}
-            hideInput={this.props.hideInput}
-            disableInput={this.props.disableInput}
-            isReading={this.state.isReading}
-            isLoadingTTS={this.state.isLoadingTTS}
-            readingMessage={this.state.readingMessage}
-            sendMessage={(text, fileName = "") => this.props.sendMessage(text, fileName, false, false, this.state.webSearchEnabled)}
-            files={this.state.files}
-            hideThinking={this.props.store?.hideThinking === true}
-          />
-
-          {!this.props.disableInput && (
-            <ChatInput
-              ref={this.inputRef}
-              value={this.state.value}
+            <MessageList
+              ref={this.messageListRef}
+              messages={messages}
+              account={this.props.account}
               store={this.props.store}
-              chat={this.props.chat}
-              files={this.state.files}
-              onFileChange={(files) => this.setState({files})}
-              onChange={(value) => this.setState({value})}
-              onSend={this.handleSend}
-              loading={this.props.loading}
+              onRegenerate={this.handleRegenerate}
+              onMessageLike={this.handleMessageLike}
+              onCopyMessage={this.copyMessageFromHTML}
+              onToggleRead={this.toggleMessageReadState}
+              onEditMessage={this.handleEditMessage}
+              hideInput={this.props.hideInput}
               disableInput={this.props.disableInput}
-              disableFocusHighlight={this.props.disableFocusHighlight}
-              messageError={this.props.messageError}
-              onCancelMessage={this.props.onCancelMessage}
-              onVoiceInputStart={this.startVoiceInput}
-              onVoiceInputEnd={this.stopVoiceInput}
-              isVoiceInput={this.state.isVoiceInput}
-              webSearchEnabled={this.state.webSearchEnabled}
-              onWebSearchChange={this.setWebSearchEnabled}
+              isReading={this.state.isReading}
+              isLoadingTTS={this.state.isLoadingTTS}
+              readingMessage={this.state.readingMessage}
+              sendMessage={(text, fileName = "") => this.props.sendMessage(text, fileName, false, false, this.state.webSearchEnabled)}
+              files={this.state.files}
+              hideThinking={this.props.store?.hideThinking === true}
             />
-          )}
+
+            {!this.props.disableInput && (
+              <ChatInput
+                ref={this.inputRef}
+                value={this.state.value}
+                store={this.props.store}
+                chat={this.props.chat}
+                files={this.state.files}
+                onFileChange={(files) => this.setState({files})}
+                onChange={(value) => this.setState({value})}
+                onSend={this.handleSend}
+                loading={this.props.loading}
+                disableInput={this.props.disableInput}
+                disableFocusHighlight={this.props.disableFocusHighlight}
+                messageError={this.props.messageError}
+                onCancelMessage={this.props.onCancelMessage}
+                onVoiceInputStart={this.startVoiceInput}
+                onVoiceInputEnd={this.stopVoiceInput}
+                isVoiceInput={this.state.isVoiceInput}
+                webSearchEnabled={this.state.webSearchEnabled}
+                onWebSearchChange={this.setWebSearchEnabled}
+              />
+            )}
+          </CardContent>
         </Card>
 
         {messages.length === 0 ? (

--- a/web/src/ChatEditPage.js
+++ b/web/src/ChatEditPage.js
@@ -14,7 +14,8 @@
 
 import React from "react";
 import Loading from "./common/Loading";
-import {Button, Card, Col, Input, Row, Select, Space, Switch} from "antd";
+import {Button, Col, Input, Row, Select, Space, Switch} from "antd";
+import SectionCard from "./components/ui/section-card";
 import * as ChatBackend from "./backend/ChatBackend";
 import * as ProviderBackend from "./backend/ProviderBackend";
 import * as Setting from "./Setting";
@@ -147,21 +148,6 @@ class ChatEditPage extends React.Component {
   renderChat() {
     const chat = this.state.chat;
     const rowGutter = [16, 8];
-    const cardHeadStyle = {background: "transparent", borderBottom: "none", fontWeight: 600, fontSize: "15px", fontFamily: "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"};
-    const sectionCardStyle = {
-      marginBottom: "16px",
-      borderRadius: "14px",
-      boxShadow: "0 1px 3px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04)",
-      padding: "18px",
-    };
-
-    const renderCardTitle = (title, desc) => (
-      <div>
-        <div style={{fontWeight: 600, fontSize: "15px"}}>{title}</div>
-        <div style={{fontSize: "13px", color: "var(--ant-color-text-tertiary)", fontWeight: 400, marginTop: "2px"}}>{desc}</div>
-      </div>
-    );
-
     return (
       <div>
         <div style={{marginBottom: "16px", display: "flex", justifyContent: "space-between", alignItems: "center"}}>
@@ -171,7 +157,7 @@ class ChatEditPage extends React.Component {
           </div>
         </div>
 
-        <Card size="small" title={renderCardTitle(i18next.t("general:General Settings"), i18next.t("general:General Settings desc"))} style={sectionCardStyle} headStyle={cardHeadStyle}>
+        <SectionCard title={i18next.t("general:General Settings")} desc={i18next.t("general:General Settings desc")}>
           <Row gutter={rowGutter}>
             {this.renderChatField(
               Setting.getLabel(i18next.t("general:Name"), i18next.t("general:Name - Tooltip")),
@@ -228,9 +214,9 @@ class ChatEditPage extends React.Component {
               8
             )}
           </Row>
-        </Card>
+        </SectionCard>
 
-        <Card size="small" title={renderCardTitle(i18next.t("general:User"), i18next.t("chat:User desc"))} style={sectionCardStyle} headStyle={cardHeadStyle}>
+        <SectionCard title={i18next.t("general:Users")} desc={i18next.t("general:Users desc")}>
           <Row gutter={rowGutter}>
             {this.renderChatField(
               Setting.getLabel(i18next.t("general:User"), i18next.t("general:User - Tooltip")),
@@ -248,13 +234,13 @@ class ChatEditPage extends React.Component {
               6
             )}
           </Row>
-        </Card>
+        </SectionCard>
 
-        <Card size="small" title={renderCardTitle(i18next.t("general:Messages"), i18next.t("general:Messages desc"))} style={sectionCardStyle} headStyle={cardHeadStyle}>
+        <SectionCard title={i18next.t("general:Messages")} desc={i18next.t("general:Messages desc")}>
           <div style={{width: "100%", height: "800px"}}>
             <ChatBox disableInput={true} hideInput={true} messages={this.state.messages} sendMessage={null} account={this.props.account} />
           </div>
-        </Card>
+        </SectionCard>
       </div>
     );
   }

--- a/web/src/FileTree.js
+++ b/web/src/FileTree.js
@@ -14,7 +14,8 @@
 
 import React from "react";
 import {withRouter} from "react-router-dom";
-import {Button, Card, Col, Descriptions, Empty, Input, Modal, Popconfirm, Radio, Result, Row, Spin, Tooltip, Tree, Upload} from "antd";
+import {Button, Col, Descriptions, Empty, Input, Modal, Popconfirm, Radio, Result, Row, Spin, Tooltip, Tree, Upload} from "antd";
+import {Card} from "./components/ui/card";
 import {CloudUploadOutlined, DeleteOutlined, DownloadOutlined, FileDoneOutlined, FolderAddOutlined, InfoCircleTwoTone, UploadOutlined, createFromIconfontCN} from "@ant-design/icons";
 import moment from "moment";
 import * as Setting from "./Setting";
@@ -977,7 +978,7 @@ class FileTree extends React.Component {
         <Row>
           <Col span={8}>
             <Card className="content-warp-card-filetreeleft" style={{marginRight: "10px"}}>
-              <div style={{margin: "-25px"}}>
+              <div>
                 {
                   this.renderSearch(this.props.store)
                 }
@@ -989,7 +990,7 @@ class FileTree extends React.Component {
           </Col>
           <Col span={16}>
             <Card className="content-warp-card-filetreeright">
-              <div style={{margin: "-25px"}}>
+              <div>
                 <div style={{height: this.getEditorHeightCss(), border: "1px solid rgb(242,242,242)", borderRadius: "6px"}}>
                   {
                     this.renderFileViewer(this.props.store)

--- a/web/src/FormEditPage.js
+++ b/web/src/FormEditPage.js
@@ -14,7 +14,8 @@
 
 import React from "react";
 import Loading from "./common/Loading";
-import {Button, Card, Col, Input, Row, Select, Space} from "antd";
+import {Button, Col, Input, Row, Select, Space} from "antd";
+import SectionCard from "./components/ui/section-card";
 import {LinkOutlined} from "@ant-design/icons";
 import * as FormBackend from "./backend/FormBackend";
 import * as Setting from "./Setting";
@@ -204,20 +205,6 @@ class FormEditPage extends React.Component {
   renderForm() {
     const form = this.state.form;
     const rowGutter = [16, 8];
-    const cardHeadStyle = {background: "transparent", borderBottom: "none", fontWeight: 600, fontSize: "15px", fontFamily: "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"};
-    const sectionCardStyle = {
-      marginBottom: "16px",
-      borderRadius: "14px",
-      boxShadow: "0 1px 3px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04)",
-      padding: "18px",
-    };
-    const renderCardTitle = (title, desc) => (
-      <div>
-        <div style={{fontWeight: 600, fontSize: "15px"}}>{title}</div>
-        {desc && <div style={{fontSize: "13px", color: "var(--ant-color-text-tertiary)", fontWeight: 400, marginTop: "2px"}}>{desc}</div>}
-      </div>
-    );
-
     return (
       <div>
         <div style={{marginBottom: "16px", display: "flex", justifyContent: "space-between", alignItems: "center"}}>
@@ -227,7 +214,7 @@ class FormEditPage extends React.Component {
           </div>
         </div>
 
-        <Card size="small" title={renderCardTitle(i18next.t("general:General Settings"), i18next.t("general:General Settings desc"))} style={sectionCardStyle} headStyle={cardHeadStyle}>
+        <SectionCard title={i18next.t("general:General Settings")} desc={i18next.t("general:General Settings desc")}>
           <Row gutter={rowGutter}>
             {this.renderFormField(
               Setting.getLabel(i18next.t("general:Name"), i18next.t("general:Name - Tooltip")),
@@ -256,15 +243,15 @@ class FormEditPage extends React.Component {
               8
             )}
           </Row>
-        </Card>
+        </SectionCard>
 
         {form.category && (
-          <Card size="small" title={renderCardTitle(i18next.t("general:Content"), "")} style={sectionCardStyle} headStyle={cardHeadStyle}>
+          <SectionCard title={i18next.t("general:Content")}>
             {this.renderFormConfigContent()}
-          </Card>
+          </SectionCard>
         )}
 
-        <Card size="small" title={renderCardTitle(i18next.t("general:Preview"), "")} style={sectionCardStyle} headStyle={cardHeadStyle}>
+        <SectionCard title={i18next.t("general:Preview")}>
           <Row gutter={rowGutter}>
             {this.renderFormField(
               "",
@@ -276,7 +263,7 @@ class FormEditPage extends React.Component {
               24
             )}
           </Row>
-        </Card>
+        </SectionCard>
       </div>
     );
   }

--- a/web/src/ManagementPage.js
+++ b/web/src/ManagementPage.js
@@ -14,7 +14,8 @@
 
 import React, {useEffect, useRef, useState} from "react";
 import {Link, Redirect, Route, Switch, withRouter} from "react-router-dom";
-import {Avatar, Button, Card, Drawer, Dropdown, Layout, Menu, Result} from "antd";
+import {Avatar, Button, Drawer, Dropdown, Layout, Menu, Result} from "antd";
+import {Card, CardContent} from "./components/ui/card";
 import {
   ApartmentOutlined,
   ApiOutlined,
@@ -768,8 +769,10 @@ function ManagementPage(props) {
         <Content style={{display: "flex", flexDirection: "column"}}>
           {isWithoutCard() ?
             renderRouter() :
-            <Card className="content-warp-card" styles={{body: {padding: 0, margin: 0}}}>
-              {renderRouter()}
+            <Card variant="inner" className="content-warp-card">
+              <CardContent className="p-0 m-0">
+                {renderRouter()}
+              </CardContent>
             </Card>
           }
         </Content>

--- a/web/src/MessageEditPage.js
+++ b/web/src/MessageEditPage.js
@@ -14,7 +14,8 @@
 
 import React from "react";
 import Loading from "./common/Loading";
-import {Button, Card, Col, Input, Row, Select, Space, Switch} from "antd";
+import {Button, Col, Input, Row, Select, Space, Switch} from "antd";
+import SectionCard from "./components/ui/section-card";
 import i18next from "i18next";
 import * as Setting from "./Setting";
 import * as MessageBackend from "./backend/MessageBackend";
@@ -175,19 +176,6 @@ class MessageEditPage extends React.Component {
   renderMessage() {
     const message = this.state.message;
     const rowGutter = [16, 8];
-    const cardHeadStyle = {background: "transparent", borderBottom: "none", fontWeight: 600, fontSize: "15px", fontFamily: "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"};
-    const sectionCardStyle = {
-      marginBottom: "16px",
-      borderRadius: "14px",
-      boxShadow: "0 1px 3px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04)",
-      padding: "18px",
-    };
-    const renderCardTitle = (title, desc) => (
-      <div>
-        <div style={{fontWeight: 600, fontSize: "15px"}}>{title}</div>
-        {desc && <div style={{fontSize: "13px", color: "var(--ant-color-text-tertiary)", fontWeight: 400, marginTop: "2px"}}>{desc}</div>}
-      </div>
-    );
 
     return (
       <div>
@@ -198,7 +186,7 @@ class MessageEditPage extends React.Component {
           </div>
         </div>
 
-        <Card size="small" title={renderCardTitle(i18next.t("general:General Settings"), i18next.t("general:General Settings desc"))} style={sectionCardStyle} headStyle={cardHeadStyle}>
+        <SectionCard title={i18next.t("general:General Settings")} desc={i18next.t("general:General Settings desc")}>
           <Row gutter={rowGutter}>
             {this.renderMessageField(
               Setting.getLabel(i18next.t("general:Name"), i18next.t("general:Name - Tooltip")),
@@ -270,9 +258,9 @@ class MessageEditPage extends React.Component {
               12
             )}
           </Row>
-        </Card>
+        </SectionCard>
 
-        <Card size="small" title={renderCardTitle(i18next.t("general:Content"), "")} style={sectionCardStyle} headStyle={cardHeadStyle}>
+        <SectionCard title={i18next.t("general:Content")}>
           <Row gutter={rowGutter}>
             {this.renderMessageField(
               Setting.getLabel(i18next.t("general:Reasoning text"), i18next.t("general:Reasoning text - Tooltip")),
@@ -302,9 +290,9 @@ class MessageEditPage extends React.Component {
               24
             )}
           </Row>
-        </Card>
+        </SectionCard>
 
-        <Card size="small" title={renderCardTitle(i18next.t("general:Options"), "")} style={sectionCardStyle} headStyle={cardHeadStyle}>
+        <SectionCard title={i18next.t("general:Options")}>
           <Row gutter={rowGutter}>
             {this.renderMessageSwitch(
               Setting.getLabel(i18next.t("message:Need notify"), i18next.t("message:Need notify - Tooltip")),
@@ -325,7 +313,7 @@ class MessageEditPage extends React.Component {
               6
             )}
           </Row>
-        </Card>
+        </SectionCard>
       </div>
     );
   }

--- a/web/src/PipeEditPage.js
+++ b/web/src/PipeEditPage.js
@@ -14,7 +14,8 @@
 
 import React from "react";
 import Loading from "./common/Loading";
-import {Button, Card, Col, Input, Row, Select, Switch} from "antd";
+import {Button, Col, Input, Row, Select, Switch} from "antd";
+import SectionCard from "./components/ui/section-card";
 import {LinkOutlined, SendOutlined} from "@ant-design/icons";
 import * as PipeBackend from "./backend/PipeBackend";
 import * as StoreBackend from "./backend/StoreBackend";
@@ -209,15 +210,6 @@ class PipeEditPage extends React.Component {
   renderPipe() {
     const pipe = this.state.pipe;
 
-    const sectionCardStyle = {
-      marginBottom: "16px",
-      borderRadius: "14px",
-      boxShadow: "0 1px 3px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04)",
-      padding: "18px",
-    };
-
-    const cardHeadStyle = {background: "transparent", borderBottom: "none", fontWeight: 600, fontSize: "15px"};
-
     const btnStyle = {
       backgroundColor: "var(--ant-color-bg-container)",
       borderColor: "var(--ant-color-border)",
@@ -240,7 +232,7 @@ class PipeEditPage extends React.Component {
         </div>
 
         {/* Card 1: General Settings */}
-        <Card size="small" title={i18next.t("general:General Settings")} style={sectionCardStyle} headStyle={cardHeadStyle}>
+        <SectionCard title={i18next.t("general:General Settings")}>
           <Row style={{marginTop: "10px"}} gutter={16}>
             <Col style={{marginTop: "5px"}} span={Setting.isMobile() ? 22 : 11}>
               <div style={{marginBottom: "4px"}}>{Setting.getLabel(i18next.t("general:ID"), i18next.t("general:Name - Tooltip"))}</div>
@@ -436,10 +428,10 @@ class PipeEditPage extends React.Component {
               />
             </Col>
           </Row>
-        </Card>
+        </SectionCard>
 
         {/* Card 2: Pipe Test */}
-        <Card size="small" title={i18next.t("pipe:Pipe Test")} style={sectionCardStyle} headStyle={cardHeadStyle}>
+        <SectionCard title={i18next.t("pipe:Pipe Test")}>
           <Row style={{marginTop: "10px"}}>
             <Col span={24}>
               <Button
@@ -454,10 +446,10 @@ class PipeEditPage extends React.Component {
               </span>
             </Col>
           </Row>
-        </Card>
+        </SectionCard>
 
         {/* Card 3: Chat Test */}
-        <Card size="small" title={i18next.t("pipe:Chat Test")} style={sectionCardStyle} headStyle={cardHeadStyle}>
+        <SectionCard title={i18next.t("pipe:Chat Test")}>
           <Row style={{marginTop: "10px"}} gutter={16}>
             <Col span={Setting.isMobile() ? 22 : 8}>
               <div style={{marginBottom: "4px"}}>{i18next.t("pipe:Chat ID")}</div>
@@ -498,7 +490,7 @@ class PipeEditPage extends React.Component {
               </Col>
             </Row>
           )}
-        </Card>
+        </SectionCard>
       </div>
     );
   }

--- a/web/src/ProviderEditPage.js
+++ b/web/src/ProviderEditPage.js
@@ -14,7 +14,8 @@
 
 import React from "react";
 import Loading from "./common/Loading";
-import {AutoComplete, Button, Card, Col, Input, InputNumber, Row, Select, Slider, Switch} from "antd";
+import {AutoComplete, Button, Col, Input, InputNumber, Row, Select, Slider, Switch} from "antd";
+import SectionCard from "./components/ui/section-card";
 import {LinkOutlined} from "@ant-design/icons";
 import * as ProviderBackend from "./backend/ProviderBackend";
 import * as Setting from "./Setting";
@@ -269,15 +270,6 @@ class ProviderEditPage extends React.Component {
 
     const colSpan = Setting.isMobile() ? 22 : 22;
 
-    const sectionCardStyle = {
-      marginBottom: "16px",
-      borderRadius: "14px",
-      boxShadow: "0 1px 3px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04)",
-      padding: "18px",
-    };
-
-    const cardHeadStyle = {background: "transparent", borderBottom: "none", fontWeight: 600, fontSize: "15px"};
-
     const btnStyle = {
       backgroundColor: "var(--ant-color-bg-container)",
       borderColor: "var(--ant-color-border)",
@@ -302,7 +294,7 @@ class ProviderEditPage extends React.Component {
         </div>
 
         {/* Card 1: General Settings */}
-        <Card size="small" title={i18next.t("general:General Settings")} style={sectionCardStyle} headStyle={cardHeadStyle}>
+        <SectionCard title={i18next.t("general:General Settings")}>
           <Row style={{marginTop: "10px"}} gutter={16}>
             <Col style={{marginTop: "5px"}} span={Setting.isMobile() ? 22 : 11}>
               <div style={{marginBottom: "4px"}}>{Setting.getLabel(i18next.t("general:ID"), i18next.t("general:Name - Tooltip"))}</div>
@@ -1029,11 +1021,11 @@ class ProviderEditPage extends React.Component {
               </Row>
             ) : null
           }
-        </Card>
+        </SectionCard>
 
         {/* Card 2: Advanced Model Parameters */}
         {isModelProvider && (this.isTemperatureEnabled(provider) || this.isTopPEnabled(provider) || (provider.type === "Gemini")) && (
-          <Card size="small" title={i18next.t("provider:Advanced Model Parameters")} style={sectionCardStyle} headStyle={cardHeadStyle}>
+          <SectionCard title={i18next.t("provider:Advanced Model Parameters")}>
             {this.isTemperatureEnabled(provider) ? (
               <Row style={{marginTop: "10px"}} gutter={16}>
                 <Col span={Setting.isMobile() ? 22 : 14}>
@@ -1171,10 +1163,10 @@ class ProviderEditPage extends React.Component {
                 </Col>
               </Row>
             ) : null}
-          </Card>
+          </SectionCard>
         )}
         {/* Card 3: Provider Test */}
-        <Card size="small" title={i18next.t("provider:Provider Test")} style={sectionCardStyle} headStyle={cardHeadStyle}>
+        <SectionCard title={i18next.t("provider:Provider Test")}>
           <ModelTestWidget
             provider={this.state.provider}
             originalProvider={this.state.originalProvider}
@@ -1197,7 +1189,7 @@ class ProviderEditPage extends React.Component {
             originalProvider={this.state.originalProvider}
             onUpdateProvider={this.updateProviderField.bind(this)}
           />
-        </Card>
+        </SectionCard>
       </div>
     );
   }

--- a/web/src/RecordEditPage.js
+++ b/web/src/RecordEditPage.js
@@ -14,7 +14,8 @@
 
 import React from "react";
 import Loading from "./common/Loading";
-import {Button, Card, Col, Input, Row, Select, Space, Switch} from "antd";
+import {Button, Col, Input, Row, Select, Space, Switch} from "antd";
+import SectionCard from "./components/ui/section-card";
 import * as RecordBackend from "./backend/RecordBackend";
 import * as ProviderBackend from "./backend/ProviderBackend";
 import * as Setting from "./Setting";
@@ -124,19 +125,6 @@ class RecordEditPage extends React.Component {
   renderRecord() {
     const record = this.state.record;
     const rowGutter = [16, 8];
-    const cardHeadStyle = {background: "transparent", borderBottom: "none", fontWeight: 600, fontSize: "15px", fontFamily: "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"};
-    const sectionCardStyle = {
-      marginBottom: "16px",
-      borderRadius: "14px",
-      boxShadow: "0 1px 3px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04)",
-      padding: "18px",
-    };
-    const renderCardTitle = (title, desc) => (
-      <div>
-        <div style={{fontWeight: 600, fontSize: "15px"}}>{title}</div>
-        {desc && <div style={{fontSize: "13px", color: "var(--ant-color-text-tertiary)", fontWeight: 400, marginTop: "2px"}}>{desc}</div>}
-      </div>
-    );
 
     const pageTitle = this.state.mode === "add"
       ? i18next.t("record:New Record")
@@ -151,7 +139,7 @@ class RecordEditPage extends React.Component {
           </div>
         </div>
 
-        <Card size="small" title={renderCardTitle(i18next.t("general:General Settings"), i18next.t("general:General Settings desc"))} style={sectionCardStyle} headStyle={cardHeadStyle}>
+        <SectionCard title={i18next.t("general:General Settings")} desc={i18next.t("general:General Settings desc")}>
           <Row gutter={rowGutter}>
             {this.renderRecordField(
               Setting.getLabel(i18next.t("general:Organization"), i18next.t("general:Organization - Tooltip")),
@@ -231,9 +219,9 @@ class RecordEditPage extends React.Component {
               8
             )}
           </Row>
-        </Card>
+        </SectionCard>
 
-        <Card size="small" title={renderCardTitle(i18next.t("general:Providers"), i18next.t("general:Providers desc"))} style={sectionCardStyle} headStyle={cardHeadStyle}>
+        <SectionCard title={i18next.t("general:Providers")} desc={i18next.t("general:Providers desc")}>
           <Row gutter={rowGutter}>
             {this.renderRecordField(
               Setting.getLabel(i18next.t("general:Provider"), i18next.t("general:Provider - Tooltip")),
@@ -264,9 +252,9 @@ class RecordEditPage extends React.Component {
               8
             )}
           </Row>
-        </Card>
+        </SectionCard>
 
-        <Card size="small" title={renderCardTitle(i18next.t("general:Content"), "")} style={sectionCardStyle} headStyle={cardHeadStyle}>
+        <SectionCard title={i18next.t("general:Content")}>
           <Row gutter={rowGutter}>
             {this.renderRecordField(
               Setting.getLabel(i18next.t("general:Object"), i18next.t("general:Object - Tooltip")),
@@ -301,7 +289,7 @@ class RecordEditPage extends React.Component {
               6
             )}
           </Row>
-        </Card>
+        </SectionCard>
       </div>
     );
   }

--- a/web/src/ScaleEditPage.js
+++ b/web/src/ScaleEditPage.js
@@ -5,7 +5,8 @@
 
 import React from "react";
 import Loading from "./common/Loading";
-import {Button, Card, Col, Input, Row, Select, Space} from "antd";
+import {Button, Col, Input, Row, Select, Space} from "antd";
+import SectionCard from "./components/ui/section-card";
 import * as ScaleBackend from "./backend/ScaleBackend";
 import * as Setting from "./Setting";
 import i18next from "i18next";
@@ -72,20 +73,6 @@ class ScaleEditPage extends React.Component {
   renderScale() {
     const s = this.state.scale;
     const rowGutter = [16, 8];
-    const cardHeadStyle = {background: "transparent", borderBottom: "none", fontWeight: 600, fontSize: "15px", fontFamily: "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"};
-    const sectionCardStyle = {
-      marginBottom: "16px",
-      borderRadius: "14px",
-      boxShadow: "0 1px 3px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04)",
-      padding: "18px",
-    };
-    const renderCardTitle = (title, desc) => (
-      <div>
-        <div style={{fontWeight: 600, fontSize: "15px"}}>{title}</div>
-        {desc && <div style={{fontSize: "13px", color: "var(--ant-color-text-tertiary)", fontWeight: 400, marginTop: "2px"}}>{desc}</div>}
-      </div>
-    );
-
     return (
       <div>
         <div style={{marginBottom: "16px", display: "flex", justifyContent: "space-between", alignItems: "center"}}>
@@ -95,7 +82,7 @@ class ScaleEditPage extends React.Component {
           </div>
         </div>
 
-        <Card size="small" title={renderCardTitle(i18next.t("general:General Settings"), i18next.t("general:General Settings desc"))} style={sectionCardStyle} headStyle={cardHeadStyle}>
+        <SectionCard title={i18next.t("general:General Settings")} desc={i18next.t("general:General Settings desc")}>
           <Row gutter={rowGutter}>
             {this.renderScaleField(
               Setting.getLabel(i18next.t("general:Name"), i18next.t("general:Name - Tooltip")),
@@ -122,9 +109,9 @@ class ScaleEditPage extends React.Component {
               8
             ) : null}
           </Row>
-        </Card>
+        </SectionCard>
 
-        <Card size="small" title={renderCardTitle(i18next.t("general:Content"), "")} style={sectionCardStyle} headStyle={cardHeadStyle}>
+        <SectionCard title={i18next.t("general:Content")}>
           <Row gutter={rowGutter}>
             {this.renderScaleField(
               Setting.getLabel(i18next.t("general:Text"), i18next.t("task:Scale - Tooltip")),
@@ -132,7 +119,7 @@ class ScaleEditPage extends React.Component {
               24
             )}
           </Row>
-        </Card>
+        </SectionCard>
       </div>
     );
   }

--- a/web/src/ServerEditPage.js
+++ b/web/src/ServerEditPage.js
@@ -14,7 +14,8 @@
 
 import React from "react";
 import Loading from "./common/Loading";
-import {Button, Card, Col, Input, Row, Space} from "antd";
+import {Button, Col, Input, Row, Space} from "antd";
+import SectionCard from "./components/ui/section-card";
 import {LinkOutlined} from "@ant-design/icons";
 import * as ServerBackend from "./backend/ServerBackend";
 import * as Setting from "./Setting";
@@ -105,15 +106,6 @@ class ServerEditPage extends React.Component {
       });
   }
 
-  renderCardTitle(title, desc) {
-    return (
-      <div>
-        <div style={{fontWeight: 600, fontSize: "15px"}}>{title}</div>
-        <div style={{fontSize: "13px", color: "var(--ant-color-text-tertiary)", fontWeight: 400, marginTop: "2px"}}>{desc}</div>
-      </div>
-    );
-  }
-
   renderServerField(label, control, span = 8, style = {}) {
     return (
       <Col style={{marginTop: "12px", ...style}} span={Setting.isMobile() ? 22 : span}>
@@ -126,13 +118,6 @@ class ServerEditPage extends React.Component {
   renderServer() {
     const server = this.state.server;
     const rowGutter = [16, 8];
-    const cardHeadStyle = {background: "transparent", borderBottom: "none", fontWeight: 600, fontSize: "15px", fontFamily: "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"};
-    const sectionCardStyle = {
-      marginBottom: "16px",
-      borderRadius: "14px",
-      boxShadow: "0 1px 3px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04)",
-      padding: "18px",
-    };
     const btnStyle = {
       backgroundColor: "var(--ant-color-bg-container)",
       borderColor: "var(--ant-color-border)",
@@ -154,7 +139,7 @@ class ServerEditPage extends React.Component {
           </div>
         </div>
 
-        <Card size="small" title={this.renderCardTitle(i18next.t("general:General Settings"), i18next.t("general:General Settings desc"))} style={sectionCardStyle} headStyle={cardHeadStyle}>
+        <SectionCard title={i18next.t("general:General Settings")} desc={i18next.t("general:General Settings desc")}>
           <Row gutter={rowGutter}>
             {this.renderServerField(
               Setting.getLabel(i18next.t("general:Name"), i18next.t("general:Name - Tooltip")),
@@ -177,9 +162,9 @@ class ServerEditPage extends React.Component {
               16
             )}
           </Row>
-        </Card>
+        </SectionCard>
 
-        <Card size="small" title={this.renderCardTitle(i18next.t("general:Tools"), i18next.t("general:Tools desc"))} style={sectionCardStyle} headStyle={cardHeadStyle}>
+        <SectionCard title={i18next.t("general:Tools")} desc={i18next.t("general:Tools desc")}>
           {!this.state.isNewServer && (
             <div style={{marginBottom: "8px"}}>
               <Button type="primary" loading={this.state.syncButtonLoading} onClick={() => this.syncMcpTool(false)}>{i18next.t("general:Sync")}</Button>
@@ -190,9 +175,9 @@ class ServerEditPage extends React.Component {
             tools={server.tools || []}
             onUpdateTable={(value) => this.updateServerField("tools", value)}
           />
-        </Card>
+        </SectionCard>
 
-        <Card size="small" title={this.renderCardTitle(i18next.t("general:Test"), i18next.t("general:Test desc"))} style={sectionCardStyle} headStyle={cardHeadStyle}>
+        <SectionCard title={i18next.t("general:Test")} desc={i18next.t("general:Test desc")}>
           <TestMcpWidget server={server} />
           <Row gutter={rowGutter}>
             {this.renderServerField(
@@ -201,7 +186,7 @@ class ServerEditPage extends React.Component {
               24
             )}
           </Row>
-        </Card>
+        </SectionCard>
       </div>
     );
   }

--- a/web/src/ServerStorePage.js
+++ b/web/src/ServerStorePage.js
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 import React from "react";
-import {Button, Card, Col, Empty, Input, Row, Select, Tag, Typography} from "antd";
+import {Button, Col, Empty, Input, Row, Select, Tag, Typography} from "antd";
+import {Card, CardContent, CardHeader, CardTitle} from "./components/ui/card";
 import Loading from "./common/Loading";
 import moment from "moment";
 import * as Setting from "./Setting";
@@ -143,11 +144,9 @@ class ServerStorePage extends React.Component {
 
   renderServerCard = (server) => (
     <Col xs={24} sm={12} md={8} lg={6} key={server.id} style={{marginBottom: "16px"}}>
-      <Card
-        title={server.name || "-"}
-        hoverable
-        style={{height: "100%"}}
-        extra={
+      <Card hoverable style={{height: "100%"}}>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <CardTitle>{server.name || "-"}</CardTitle>
           <Button
             type="primary"
             size="small"
@@ -159,30 +158,31 @@ class ServerStorePage extends React.Component {
           >
             {i18next.t("general:Add")}
           </Button>
-        }
-      >
-        <div style={{minHeight: "48px", marginBottom: "8px"}}>
-          <Text type="secondary">{server.description || "-"}</Text>
-        </div>
-        <div style={{marginBottom: "8px"}}>
-          <Text strong>{i18next.t("general:URL")}: </Text>
-          {server.endpoint ? (
-            <a target="_blank" rel="noreferrer" href={server.endpoint}>{Setting.getShortText(server.endpoint, 40)}</a>
-          ) : (
-            <Text>-</Text>
-          )}
-        </div>
-        <div style={{marginBottom: "8px"}}>
-          <Text strong>{i18next.t("general:Website")}: </Text>
-          {server.website ? (
-            <a target="_blank" rel="noreferrer" href={this.getWebsiteUrl(server.website)}>{server.website}</a>
-          ) : (
-            <Text>-</Text>
-          )}
-        </div>
-        <div>
-          {(server.categoriesRaw || []).map((c) => <Tag key={`${server.id}-${c}`}>{c}</Tag>)}
-        </div>
+        </CardHeader>
+        <CardContent>
+          <div style={{minHeight: "48px", marginBottom: "8px"}}>
+            <Text type="secondary">{server.description || "-"}</Text>
+          </div>
+          <div style={{marginBottom: "8px"}}>
+            <Text strong>{i18next.t("general:URL")}: </Text>
+            {server.endpoint ? (
+              <a target="_blank" rel="noreferrer" href={server.endpoint}>{Setting.getShortText(server.endpoint, 40)}</a>
+            ) : (
+              <Text>-</Text>
+            )}
+          </div>
+          <div style={{marginBottom: "8px"}}>
+            <Text strong>{i18next.t("general:Website")}: </Text>
+            {server.website ? (
+              <a target="_blank" rel="noreferrer" href={this.getWebsiteUrl(server.website)}>{server.website}</a>
+            ) : (
+              <Text>-</Text>
+            )}
+          </div>
+          <div>
+            {(server.categoriesRaw || []).map((c) => <Tag key={`${server.id}-${c}`}>{c}</Tag>)}
+          </div>
+        </CardContent>
       </Card>
     </Col>
   );

--- a/web/src/SiteEditPage.js
+++ b/web/src/SiteEditPage.js
@@ -14,7 +14,8 @@
 
 import React from "react";
 import Loading from "./common/Loading";
-import {Button, Card, Col, Image, Input, Modal, Popover, Row, Space, Switch, Upload} from "antd";
+import SectionCard from "./components/ui/section-card";
+import {Button, Col, Image, Input, Modal, Popover, Row, Space, Switch, Upload} from "antd";
 import {EyeInvisibleOutlined, EyeTwoTone} from "@ant-design/icons";
 import * as SiteBackend from "./backend/SiteBackend";
 import * as ResourceBackend from "./backend/ResourceBackend";
@@ -135,21 +136,6 @@ class SiteEditPage extends React.Component {
   renderSite() {
     const site = this.state.site;
     const rowGutter = [16, 8];
-    const cardHeadStyle = {background: "transparent", borderBottom: "none", fontWeight: 600, fontSize: "15px", fontFamily: "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"};
-    const sectionCardStyle = {
-      marginBottom: "16px",
-      borderRadius: "14px",
-      boxShadow: "0 1px 3px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04)",
-      padding: "18px",
-    };
-
-    const renderCardTitle = (title, desc) => (
-      <div>
-        <div style={{fontWeight: 600, fontSize: "15px"}}>{title}</div>
-        <div style={{fontSize: "13px", color: "var(--ant-color-text-tertiary)", fontWeight: 400, marginTop: "2px"}}>{desc}</div>
-      </div>
-    );
-
     return (
       <div>
         <div style={{marginBottom: "16px", display: "flex", justifyContent: "space-between", alignItems: "center"}}>
@@ -159,7 +145,7 @@ class SiteEditPage extends React.Component {
           </div>
         </div>
 
-        <Card size="small" title={renderCardTitle(i18next.t("general:General Settings"), i18next.t("general:General Settings desc"))} style={sectionCardStyle} headStyle={cardHeadStyle}>
+        <SectionCard title={i18next.t("general:General Settings")} desc={i18next.t("general:General Settings desc")}>
           <Row gutter={rowGutter}>
             {this.renderSiteField(
               Setting.getLabel(i18next.t("general:Name"), i18next.t("general:Name - Tooltip")),
@@ -190,9 +176,9 @@ class SiteEditPage extends React.Component {
               8
             )}
           </Row>
-        </Card>
+        </SectionCard>
 
-        <Card size="small" title={renderCardTitle(i18next.t("general:Branding"), i18next.t("general:Branding desc"))} style={sectionCardStyle} headStyle={cardHeadStyle}>
+        <SectionCard title={i18next.t("general:Branding")} desc={i18next.t("general:Branding desc")}>
           <Row gutter={rowGutter}>
             {this.renderSiteField(
               Setting.getLabel(i18next.t("general:Favicon URL"), i18next.t("general:Favicon URL - Tooltip")),
@@ -244,9 +230,9 @@ class SiteEditPage extends React.Component {
               12
             )}
           </Row>
-        </Card>
+        </SectionCard>
 
-        <Card size="small" title={renderCardTitle(i18next.t("general:Content"), i18next.t("general:Content desc"))} style={sectionCardStyle} headStyle={cardHeadStyle}>
+        <SectionCard title={i18next.t("general:Content")} desc={i18next.t("general:Content desc")}>
           <Row gutter={rowGutter}>
             {this.renderSiteField(
               Setting.getLabel(i18next.t("general:Navbar HTML"), i18next.t("general:Navbar HTML - Tooltip")),
@@ -318,9 +304,9 @@ class SiteEditPage extends React.Component {
               24
             )}
           </Row>
-        </Card>
+        </SectionCard>
 
-        <Card size="small" title={renderCardTitle(i18next.t("site:Authentication"), i18next.t("site:Authentication desc"))} style={sectionCardStyle} headStyle={cardHeadStyle}>
+        <SectionCard title={i18next.t("site:Authentication")} desc={i18next.t("site:Authentication desc")}>
           <Row gutter={rowGutter}>
             {this.renderSiteField(
               Setting.getLabel(i18next.t("site:OIDC issuer"), i18next.t("site:OIDC issuer - Tooltip")),
@@ -356,9 +342,9 @@ class SiteEditPage extends React.Component {
               6
             )}
           </Row>
-        </Card>
+        </SectionCard>
 
-        <Card size="small" title={renderCardTitle(i18next.t("site:Advanced"), i18next.t("site:Advanced desc"))} style={sectionCardStyle} headStyle={cardHeadStyle}>
+        <SectionCard title={i18next.t("site:Advanced")} desc={i18next.t("site:Advanced desc")}>
           <Row gutter={rowGutter}>
             {this.renderSiteField(
               Setting.getLabel(i18next.t("site:IP parsing mode"), i18next.t("site:IP parsing mode - Tooltip")),
@@ -389,7 +375,7 @@ class SiteEditPage extends React.Component {
               24
             )}
           </Row>
-        </Card>
+        </SectionCard>
       </div>
     );
   }

--- a/web/src/SkillEditPage.js
+++ b/web/src/SkillEditPage.js
@@ -14,7 +14,8 @@
 
 import React from "react";
 import Loading from "./common/Loading";
-import {Button, Card, Col, Collapse, Input, Row, Select, Space, Tag, Typography} from "antd";
+import {Button, Col, Collapse, Input, Row, Select, Space, Tag, Typography} from "antd";
+import SectionCard from "./components/ui/section-card";
 import * as SkillBackend from "./backend/SkillBackend";
 import * as Setting from "./Setting";
 import i18next from "i18next";
@@ -80,13 +81,6 @@ class SkillEditPage extends React.Component {
   renderSkill() {
     const {skill} = this.state;
     const rowGutter = [16, 8];
-    const cardHeadStyle = {background: "transparent", borderBottom: "none", fontWeight: 600, fontSize: "15px", fontFamily: "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"};
-    const sectionCardStyle = {
-      marginBottom: "16px",
-      borderRadius: "14px",
-      boxShadow: "0 1px 3px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04)",
-      padding: "18px",
-    };
 
     const btnStyle = {
       backgroundColor: "var(--ant-color-bg-container)",
@@ -95,13 +89,6 @@ class SkillEditPage extends React.Component {
       borderRadius: "10px",
       padding: "6px 10px",
     };
-
-    const renderCardTitle = (title, desc) => (
-      <div>
-        <div style={{fontWeight: 600, fontSize: "15px"}}>{title}</div>
-        <div style={{fontSize: "13px", color: "var(--ant-color-text-tertiary)", fontWeight: 400, marginTop: "2px"}}>{desc}</div>
-      </div>
-    );
 
     return (
       <div>
@@ -116,7 +103,7 @@ class SkillEditPage extends React.Component {
           </div>
         </div>
 
-        <Card size="small" title={renderCardTitle(i18next.t("general:General Settings"), i18next.t("general:General Settings desc"))} style={sectionCardStyle} headStyle={cardHeadStyle}>
+        <SectionCard title={i18next.t("general:General Settings")} desc={i18next.t("general:General Settings desc")}>
           <Row gutter={rowGutter}>
             {this.renderSkillField(
               Setting.getLabel(i18next.t("general:Name"), i18next.t("general:Name - Tooltip")),
@@ -161,9 +148,9 @@ class SkillEditPage extends React.Component {
               8
             )}
           </Row>
-        </Card>
+        </SectionCard>
 
-        <Card size="small" title={renderCardTitle(i18next.t("general:Content"), i18next.t("general:Content desc"))} style={sectionCardStyle} headStyle={cardHeadStyle}>
+        <SectionCard title={i18next.t("general:Content")} desc={i18next.t("general:Content desc")}>
           <Row gutter={rowGutter}>
             {this.renderSkillField(
               Setting.getLabel(i18next.t("general:Description"), i18next.t("general:Description - Tooltip")),
@@ -252,7 +239,7 @@ class SkillEditPage extends React.Component {
               )
             )}
           </Row>
-        </Card>
+        </SectionCard>
       </div>
     );
   }

--- a/web/src/StoreEditPage.js
+++ b/web/src/StoreEditPage.js
@@ -14,7 +14,8 @@
 
 import React from "react";
 import Loading from "./common/Loading";
-import {Avatar, Button, Card, Cascader, Col, Input, InputNumber, Modal, Row, Select, Space, Spin, Switch} from "antd";
+import {Avatar, Button, Cascader, Col, Input, InputNumber, Modal, Row, Select, Space, Spin, Switch} from "antd";
+import SectionCard from "./components/ui/section-card";
 import * as StoreBackend from "./backend/StoreBackend";
 import * as StorageProviderBackend from "./backend/StorageProviderBackend";
 import * as ProviderBackend from "./backend/ProviderBackend";
@@ -317,20 +318,6 @@ class StoreEditPage extends React.Component {
     const store = this.state.store;
     const rowGutter = [16, 8];
     const providerOptions = this.state.storageProviders.concat(this.state.casdoorStorageProviders);
-    const cardHeadStyle = {background: "transparent", borderBottom: "none", fontWeight: 600, fontSize: "15px", fontFamily: "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"};
-    const sectionCardStyle = {
-      marginBottom: "16px",
-      borderRadius: "14px",
-      boxShadow: "0 1px 3px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04)",
-      padding: "18px",
-    };
-
-    const renderCardTitle = (title, desc) => (
-      <div>
-        <div style={{fontWeight: 600, fontSize: "15px"}}>{title}</div>
-        <div style={{fontSize: "13px", color: "var(--ant-color-text-tertiary)", fontWeight: 400, marginTop: "2px"}}>{desc}</div>
-      </div>
-    );
 
     return (
       <div>
@@ -341,7 +328,7 @@ class StoreEditPage extends React.Component {
           </div>
         </div>
 
-        <Card size="small" title={renderCardTitle(i18next.t("general:General Settings"), i18next.t("general:General Settings desc"))} style={sectionCardStyle} headStyle={cardHeadStyle}>
+        <SectionCard title={i18next.t("general:General Settings")} desc={i18next.t("general:General Settings desc")}>
           <Row gutter={rowGutter}>
             {this.renderStoreField(
               Setting.getLabel(i18next.t("general:Owner"), i18next.t("general:Owner - Tooltip")),
@@ -457,9 +444,9 @@ class StoreEditPage extends React.Component {
               6
             )}
           </Row>
-        </Card>
+        </SectionCard>
 
-        <Card size="small" title={renderCardTitle(i18next.t("general:Providers"), i18next.t("general:Providers desc"))} style={sectionCardStyle} headStyle={cardHeadStyle}>
+        <SectionCard title={i18next.t("general:Providers")} desc={i18next.t("general:Providers desc")}>
           <Row gutter={rowGutter}>
             {store.enableExtraOptions ? (
               <>
@@ -635,9 +622,9 @@ class StoreEditPage extends React.Component {
               8
             )}
           </Row>
-        </Card>
+        </SectionCard>
 
-        <Card size="small" title={renderCardTitle(i18next.t("general:Chat"), i18next.t("general:Chat desc"))} style={sectionCardStyle} headStyle={cardHeadStyle}>
+        <SectionCard title={i18next.t("general:Chat")} desc={i18next.t("general:Chat desc")}>
           <Row gutter={rowGutter}>
             {this.renderStoreField(
               Setting.getLabel(i18next.t("store:Welcome"), i18next.t("store:Welcome - Tooltip")),
@@ -679,9 +666,9 @@ class StoreEditPage extends React.Component {
               24
             )}
           </Row>
-        </Card>
+        </SectionCard>
 
-        <Card size="small" title={renderCardTitle(i18next.t("general:Options"), i18next.t("general:Options desc"))} style={sectionCardStyle} headStyle={cardHeadStyle}>
+        <SectionCard title={i18next.t("general:Options")} desc={i18next.t("general:Options desc")}>
           <Row gutter={rowGutter}>
             {this.renderStoreField(
               Setting.getLabel(i18next.t("store:Knowledge count"), i18next.t("store:Knowledge count - Tooltip")),
@@ -774,16 +761,16 @@ class StoreEditPage extends React.Component {
               8
             )}
           </Row>
-        </Card>
+        </SectionCard>
 
-        <Card size="small" title={renderCardTitle(Setting.getLabel(i18next.t("store:File tree"), i18next.t("store:File tree - Tooltip")), i18next.t("store:File tree desc"))} style={sectionCardStyle} headStyle={cardHeadStyle}>
+        <SectionCard title={Setting.getLabel(i18next.t("store:File tree"), i18next.t("store:File tree - Tooltip"))} desc={i18next.t("store:File tree desc")}>
           <FileTree account={this.props.account} store={store} onUpdateStore={(store) => {
             this.setState({
               store: store,
             });
             this.submitStoreEdit(undefined, store);
           }} onRefresh={() => this.getStore()} />
-        </Card>
+        </SectionCard>
       </div>
     );
   }

--- a/web/src/SystemInfo.js
+++ b/web/src/SystemInfo.js
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 import React from "react";
-import {Card, Col, Progress, Row, Tag, Tooltip} from "antd";
+import {Col, Progress, Row, Tag, Tooltip} from "antd";
+import SectionCard from "./components/ui/section-card";
 import {
   ArrowDownOutlined,
   ArrowUpOutlined,
@@ -40,7 +41,7 @@ function getUsageColor(percent) {
   return "#52c41a";
 }
 
-function CardTitle({icon, text, live}) {
+function StatTitle({icon, text, live}) {
   return (
     <span style={{display: "flex", alignItems: "center", gap: 8}}>
       {icon}
@@ -136,30 +137,9 @@ class SystemInfo extends React.Component {
     const isDark = Setting.getIsDark();
     const isMobile = Setting.isMobile();
 
-    const cardBg = isDark ? "#1e1f22" : "#ffffff";
-    const cardBorder = isDark ? "1px solid rgba(255,255,255,0.08)" : "1px solid #f0f0f0";
     const labelColor = isDark ? "#8b8fa8" : "#8c8c8c";
     const valueColor = isDark ? "#e8eaf0" : "#1a1a2e";
     const dividerColor = isDark ? "rgba(255,255,255,0.07)" : "#f5f5f5";
-
-    const cardStyle = {
-      background: cardBg,
-      border: cardBorder,
-      borderRadius: 12,
-      boxShadow: isDark
-        ? "0 2px 12px rgba(0,0,0,0.35)"
-        : "0 2px 12px rgba(0,0,0,0.06)",
-      height: "100%",
-    };
-
-    const cardHeadStyle = {
-      borderBottom: `1px solid ${dividerColor}`,
-      padding: "14px 20px",
-    };
-
-    const cardBodyStyle = {
-      padding: "20px",
-    };
 
     const {systemInfo, prometheusInfo, versionInfo, loading} = this.state;
 
@@ -395,83 +375,69 @@ class SystemInfo extends React.Component {
           <style>{pulseStyle}</style>
           <Row gutter={[16, 16]}>
             <Col span={8}>
-              <Card
+              <SectionCard
+                variant="bordered"
                 id="cpu-card"
-                title={<CardTitle icon={<DashboardOutlined style={{color: iconColor}} />} text={i18next.t("system:CPU Usage")} live />}
-                style={cardStyle}
-                headStyle={cardHeadStyle}
-                bodyStyle={cardBodyStyle}
+                title={<StatTitle icon={<DashboardOutlined style={{color: iconColor}} />} text={i18next.t("system:CPU Usage")} live />}
               >
                 {loading ? <Loading /> : cpuUi}
-              </Card>
+              </SectionCard>
             </Col>
             <Col span={8}>
-              <Card
+              <SectionCard
+                variant="bordered"
                 id="memory-card"
-                title={<CardTitle icon={<DatabaseOutlined style={{color: iconColor}} />} text={i18next.t("system:Memory Usage")} live />}
-                style={cardStyle}
-                headStyle={cardHeadStyle}
-                bodyStyle={cardBodyStyle}
+                title={<StatTitle icon={<DatabaseOutlined style={{color: iconColor}} />} text={i18next.t("system:Memory Usage")} live />}
               >
                 {loading ? <Loading /> : memUi}
-              </Card>
+              </SectionCard>
             </Col>
             <Col span={8}>
-              <Card
+              <SectionCard
+                variant="bordered"
                 id="disk-card"
-                title={<CardTitle icon={<HddOutlined style={{color: iconColor}} />} text={i18next.t("system:Disk Usage")} live />}
-                style={cardStyle}
-                headStyle={cardHeadStyle}
-                bodyStyle={cardBodyStyle}
+                title={<StatTitle icon={<HddOutlined style={{color: iconColor}} />} text={i18next.t("system:Disk Usage")} live />}
               >
                 {loading ? <Loading /> : diskUi}
-              </Card>
+              </SectionCard>
             </Col>
             <Col span={8}>
-              <Card
+              <SectionCard
+                variant="bordered"
                 id="network-card"
-                title={<CardTitle icon={<WifiOutlined style={{color: iconColor}} />} text={i18next.t("system:Network Usage")} live />}
-                style={cardStyle}
-                headStyle={cardHeadStyle}
-                bodyStyle={cardBodyStyle}
+                title={<StatTitle icon={<WifiOutlined style={{color: iconColor}} />} text={i18next.t("system:Network Usage")} live />}
               >
                 {loading ? <Loading /> : networkUi}
-              </Card>
+              </SectionCard>
             </Col>
             <Col span={8}>
-              <Card
+              <SectionCard
+                variant="bordered"
                 id="latency-card"
-                title={<CardTitle icon={<ThunderboltOutlined style={{color: iconColor}} />} text={i18next.t("system:API Latency")} />}
-                style={cardStyle}
-                headStyle={cardHeadStyle}
-                bodyStyle={cardBodyStyle}
+                title={<StatTitle icon={<ThunderboltOutlined style={{color: iconColor}} />} text={i18next.t("system:API Latency")} />}
               >
                 {loading ? <Loading /> : latencyUi}
-              </Card>
+              </SectionCard>
             </Col>
             <Col span={8}>
-              <Card
+              <SectionCard
+                variant="bordered"
                 id="throughput-card"
-                title={<CardTitle icon={<SwapOutlined style={{color: iconColor}} />} text={i18next.t("system:API Throughput")} />}
-                style={cardStyle}
-                headStyle={cardHeadStyle}
-                bodyStyle={cardBodyStyle}
+                title={<StatTitle icon={<SwapOutlined style={{color: iconColor}} />} text={i18next.t("system:API Throughput")} />}
               >
                 {loading ? <Loading /> : throughputUi}
-              </Card>
+              </SectionCard>
             </Col>
             <Col span={24}>
-              <Card
+              <SectionCard
+                variant="bordered"
                 id="about-card"
                 style={{
-                  ...cardStyle,
                   background: isDark
                     ? "linear-gradient(135deg, #1e1f22 0%, #1a1c2a 100%)"
                     : "linear-gradient(135deg, #ffffff 0%, #f8f9ff 100%)",
                 }}
-                headStyle={cardHeadStyle}
-                bodyStyle={{padding: "24px 28px"}}
-                title={<CardTitle icon={<CodeOutlined style={{color: iconColor}} />} text={i18next.t("system:About OpenAgent")} />}
+                title={<StatTitle icon={<CodeOutlined style={{color: iconColor}} />} text={i18next.t("system:About OpenAgent")} />}
               >
                 <div style={{display: "flex", alignItems: "flex-start", gap: 24, flexWrap: "wrap"}}>
                   <div style={{flex: 1, minWidth: 260}}>
@@ -491,7 +457,7 @@ class SystemInfo extends React.Component {
                           style={{
                             cursor: "pointer", borderRadius: 6, padding: "2px 10px",
                             background: isDark ? "rgba(255,255,255,0.07)" : "#f5f5f5",
-                            border: cardBorder, color: valueColor,
+                            color: valueColor,
                           }}>
                           GitHub
                         </Tag>
@@ -513,7 +479,7 @@ class SystemInfo extends React.Component {
                     </div>
                   </div>
                 </div>
-              </Card>
+              </SectionCard>
             </Col>
           </Row>
         </>
@@ -530,24 +496,20 @@ class SystemInfo extends React.Component {
               {id: "network-card", icon: <WifiOutlined style={{color: iconColor}} />, title: i18next.t("system:Network Usage"), ui: networkUi, live: true},
             ].map(({id, icon, title, ui, live}) => (
               <Col key={id} span={24}>
-                <Card
+                <SectionCard
+                  variant="bordered"
                   id={id}
-                  title={<CardTitle icon={icon} text={title} live={live} />}
-                  style={cardStyle}
-                  headStyle={cardHeadStyle}
-                  bodyStyle={cardBodyStyle}
+                  title={<StatTitle icon={icon} text={title} live={live} />}
                 >
                   {loading ? <Loading /> : ui}
-                </Card>
+                </SectionCard>
               </Col>
             ))}
             <Col span={24}>
-              <Card
+              <SectionCard
+                variant="bordered"
                 id="about-card"
-                title={<CardTitle icon={<CodeOutlined style={{color: iconColor}} />} text={i18next.t("system:About OpenAgent")} />}
-                style={cardStyle}
-                headStyle={cardHeadStyle}
-                bodyStyle={{padding: "20px"}}
+                title={<StatTitle icon={<CodeOutlined style={{color: iconColor}} />} text={i18next.t("system:About OpenAgent")} />}
               >
                 <div style={{fontSize: 13, color: isDark ? "#a0a8bf" : "#595959", lineHeight: 1.7, marginBottom: 14}}>
                   {i18next.t("system:🚀⚡️Next-generation personal AI assistant powered by LLM, RAG and agent loops,\nsupporting computer-use, browser-use and coding agent")}
@@ -563,7 +525,7 @@ class SystemInfo extends React.Component {
                     <Tag icon={<GlobalOutlined />} color="green" style={{cursor: "pointer", borderRadius: 6}}>{i18next.t("system:Official website")}</Tag>
                   </a>
                 </div>
-              </Card>
+              </SectionCard>
             </Col>
           </Row>
         </>

--- a/web/src/TaskEditPage.js
+++ b/web/src/TaskEditPage.js
@@ -14,7 +14,9 @@
 
 import React from "react";
 import Loading from "./common/Loading";
-import {Button, Card, Col, Input, Progress, Row, Select, Space, Spin, Typography, Upload} from "antd";
+import {Button, Col, Input, Progress, Row, Select, Space, Spin, Typography, Upload} from "antd";
+import SectionCard from "./components/ui/section-card";
+import {Card} from "./components/ui/card";
 
 const ANALYZE_PROGRESS_DURATION_SEC = 300;
 const ANALYZE_PROGRESS_TICK_MS = 500;
@@ -299,20 +301,6 @@ class TaskEditPage extends React.Component {
   renderTask() {
     const task = this.state.task;
     const rowGutter = [16, 8];
-    const cardHeadStyle = {background: "transparent", borderBottom: "none", fontWeight: 600, fontSize: "15px", fontFamily: "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"};
-    const sectionCardStyle = {
-      marginBottom: "16px",
-      borderRadius: "14px",
-      boxShadow: "0 1px 3px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04)",
-      padding: "18px",
-    };
-    const renderCardTitle = (title, desc) => (
-      <div>
-        <div style={{fontWeight: 600, fontSize: "15px"}}>{title}</div>
-        {desc && <div style={{fontSize: "13px", color: "var(--ant-color-text-tertiary)", fontWeight: 400, marginTop: "2px"}}>{desc}</div>}
-      </div>
-    );
-
     return (
       <div>
         <div style={{marginBottom: "16px", display: "flex", justifyContent: "space-between", alignItems: "center"}}>
@@ -322,7 +310,7 @@ class TaskEditPage extends React.Component {
           </div>
         </div>
 
-        <Card size="small" title={renderCardTitle(i18next.t("general:General Settings"), i18next.t("general:General Settings desc"))} style={sectionCardStyle} headStyle={cardHeadStyle}>
+        <SectionCard title={i18next.t("general:General Settings")} desc={i18next.t("general:General Settings desc")}>
           <Row gutter={rowGutter}>
             {this.renderTaskField(
               Setting.getLabel(i18next.t("general:Name"), i18next.t("general:Name - Tooltip")),
@@ -364,9 +352,9 @@ class TaskEditPage extends React.Component {
               8
             )}
           </Row>
-        </Card>
+        </SectionCard>
 
-        <Card size="small" title={renderCardTitle(i18next.t("general:Options"), "")} style={sectionCardStyle} headStyle={cardHeadStyle}>
+        <SectionCard title={i18next.t("general:Options")}>
           <Row gutter={rowGutter}>
             {this.renderTaskField(
               Setting.getLabel(i18next.t("task:Scale"), i18next.t("task:Scale - Tooltip")),
@@ -392,10 +380,7 @@ class TaskEditPage extends React.Component {
             {this.renderTaskField(
               Setting.getLabel(i18next.t("store:File"), i18next.t("store:File - Tooltip")),
               task.documentUrl ? (
-                <Card
-                  size="small"
-                  style={{display: "inline-block", width: "auto", maxWidth: "100%", verticalAlign: "top"}}
-                >
+                <Card style={{display: "inline-block", width: "auto", maxWidth: "100%", verticalAlign: "top"}}>
                   <div style={{display: "flex", alignItems: "center", gap: 12, flexWrap: "nowrap", minWidth: 0}}>
                     <span style={{fontSize: 28, flexShrink: 0, color: task.documentUrl.endsWith(".pdf") ? "#cf1322" : "#1890ff"}}>
                       {task.documentUrl.endsWith(".pdf") ? <FilePdfOutlined /> : <FileWordOutlined />}
@@ -487,7 +472,7 @@ class TaskEditPage extends React.Component {
               24
             ) : null}
           </Row>
-        </Card>
+        </SectionCard>
       </div>
     );
   }

--- a/web/src/ToolEditPage.js
+++ b/web/src/ToolEditPage.js
@@ -14,7 +14,8 @@
 
 import React from "react";
 import Loading from "./common/Loading";
-import {Alert, Button, Card, Col, Input, Row, Select, Space, Switch, Table, Tag} from "antd";
+import {Alert, Button, Col, Input, Row, Select, Space, Switch, Table, Tag} from "antd";
+import SectionCard from "./components/ui/section-card";
 import * as ToolBackend from "./backend/ToolBackend";
 import * as Setting from "./Setting";
 import i18next from "i18next";
@@ -100,13 +101,6 @@ class ToolEditPage extends React.Component {
   renderTool() {
     const tool = this.state.tool;
     const rowGutter = [16, 8];
-    const cardHeadStyle = {background: "transparent", borderBottom: "none", fontWeight: 600, fontSize: "15px", fontFamily: "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"};
-    const sectionCardStyle = {
-      marginBottom: "16px",
-      borderRadius: "14px",
-      boxShadow: "0 1px 3px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04)",
-      padding: "18px",
-    };
     const btnStyle = {
       backgroundColor: "var(--ant-color-bg-container)",
       borderColor: "var(--ant-color-border)",
@@ -114,13 +108,6 @@ class ToolEditPage extends React.Component {
       borderRadius: "10px",
       padding: "6px 10px",
     };
-
-    const renderCardTitle = (title, desc) => (
-      <div>
-        <div style={{fontWeight: 600, fontSize: "15px"}}>{title}</div>
-        <div style={{fontSize: "13px", color: "var(--ant-color-text-tertiary)", fontWeight: 400, marginTop: "2px"}}>{desc}</div>
-      </div>
-    );
 
     return (
       <div>
@@ -135,7 +122,7 @@ class ToolEditPage extends React.Component {
           </div>
         </div>
 
-        <Card size="small" title={renderCardTitle(i18next.t("general:General Settings"), i18next.t("general:General Settings desc"))} style={sectionCardStyle} headStyle={cardHeadStyle}>
+        <SectionCard title={i18next.t("general:General Settings")} desc={i18next.t("general:General Settings desc")}>
           <Row gutter={rowGutter}>
             {this.renderToolField(
               Setting.getLabel(i18next.t("general:Name"), i18next.t("general:Name - Tooltip")),
@@ -289,10 +276,10 @@ class ToolEditPage extends React.Component {
               8
             )}
           </Row>
-        </Card>
+        </SectionCard>
 
         {Setting.getToolFunctions(tool).length > 0 && (
-          <Card size="small" title={renderCardTitle(i18next.t("tool:Functions"), i18next.t("tool:Functions desc"))} style={sectionCardStyle} headStyle={cardHeadStyle}>
+          <SectionCard title={i18next.t("tool:Functions")} desc={i18next.t("tool:Functions desc")}>
             <Table
               size="small"
               pagination={false}
@@ -312,17 +299,17 @@ class ToolEditPage extends React.Component {
               ]}
               dataSource={Setting.getToolFunctions(tool).map((f, i) => ({...f, key: i}))}
             />
-          </Card>
+          </SectionCard>
         )}
 
-        <Card size="small" title={renderCardTitle(i18next.t("general:Test"), i18next.t("general:Test desc"))} style={sectionCardStyle} headStyle={cardHeadStyle}>
+        <SectionCard title={i18next.t("general:Test")} desc={i18next.t("general:Test desc")}>
           <TestToolWidget
             tool={tool}
             originalTool={this.state.originalTool}
             onUpdateTool={this.updateToolField.bind(this)}
             account={this.props.account}
           />
-        </Card>
+        </SectionCard>
       </div>
     );
   }

--- a/web/src/VectorEditPage.js
+++ b/web/src/VectorEditPage.js
@@ -14,7 +14,8 @@
 
 import React from "react";
 import Loading from "./common/Loading";
-import {Button, Card, Col, Input, InputNumber, Row, Space} from "antd";
+import {Button, Col, Input, InputNumber, Row, Space} from "antd";
+import SectionCard from "./components/ui/section-card";
 import i18next from "i18next";
 import * as Setting from "./Setting";
 import * as VectorBackend from "./backend/VectorBackend";
@@ -111,19 +112,6 @@ class VectorEditPage extends React.Component {
     const vector = this.state.vector;
     const isViewMode = this.state.mode === "view";
     const rowGutter = [16, 8];
-    const cardHeadStyle = {background: "transparent", borderBottom: "none", fontWeight: 600, fontSize: "15px", fontFamily: "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"};
-    const sectionCardStyle = {
-      marginBottom: "16px",
-      borderRadius: "14px",
-      boxShadow: "0 1px 3px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04)",
-      padding: "18px",
-    };
-    const renderCardTitle = (title, desc) => (
-      <div>
-        <div style={{fontWeight: 600, fontSize: "15px"}}>{title}</div>
-        {desc && <div style={{fontSize: "13px", color: "var(--ant-color-text-tertiary)", fontWeight: 400, marginTop: "2px"}}>{desc}</div>}
-      </div>
-    );
 
     return (
       <div>
@@ -136,7 +124,7 @@ class VectorEditPage extends React.Component {
           </div>
         </div>
 
-        <Card size="small" title={renderCardTitle(i18next.t("general:General Settings"), i18next.t("general:General Settings desc"))} style={sectionCardStyle} headStyle={cardHeadStyle}>
+        <SectionCard title={i18next.t("general:General Settings")} desc={i18next.t("general:General Settings desc")}>
           <Row gutter={rowGutter}>
             {this.renderVectorField(
               Setting.getLabel(i18next.t("general:Name"), i18next.t("general:Name - Tooltip")),
@@ -174,9 +162,9 @@ class VectorEditPage extends React.Component {
               4
             )}
           </Row>
-        </Card>
+        </SectionCard>
 
-        <Card size="small" title={renderCardTitle(i18next.t("general:Content"), "")} style={sectionCardStyle} headStyle={cardHeadStyle}>
+        <SectionCard title={i18next.t("general:Content")}>
           <Row gutter={rowGutter}>
             {this.renderVectorField(
               Setting.getLabel(i18next.t("general:Text"), i18next.t("general:Text - Tooltip")),
@@ -201,7 +189,7 @@ class VectorEditPage extends React.Component {
               24
             )}
           </Row>
-        </Card>
+        </SectionCard>
       </div>
     );
   }

--- a/web/src/basic/GridCards.js
+++ b/web/src/basic/GridCards.js
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Card, Row, Spin} from "antd";
+import {Row, Spin} from "antd";
+import {Card, CardContent} from "../components/ui/card";
 import i18next from "i18next";
 import React from "react";
 import * as Setting from "../Setting";
@@ -31,8 +32,10 @@ const GridCards = (props) => {
 
   return (
     Setting.isMobile() ? (
-      <Card bodyStyle={{padding: 0}}>
-        {items.map(item => <SingleCard key={item.link} logo={item.logo} link={item.link} title={item.name} desc={item.description} time={item.createdTime} isSingle={items.length === 1} />)}
+      <Card>
+        <CardContent className="p-0">
+          {items.map(item => <SingleCard key={item.link} logo={item.logo} link={item.link} title={item.name} desc={item.description} time={item.createdTime} isSingle={items.length === 1} />)}
+        </CardContent>
       </Card>
     ) : (
       <div style={{margin: "0 15px"}}>

--- a/web/src/basic/SingleCard.js
+++ b/web/src/basic/SingleCard.js
@@ -13,12 +13,11 @@
 // limitations under the License.
 
 import React from "react";
-import {Card, Col} from "antd";
+import {Col} from "antd";
+import {Card, CardContent, CardDescription, CardHeader, CardTitle} from "../components/ui/card";
 import * as Setting from "../Setting";
 import {withRouter} from "react-router-dom";
 import i18next from "i18next";
-
-const {Meta} = Card;
 
 class SingleCard extends React.Component {
   constructor(props) {
@@ -45,18 +44,20 @@ class SingleCard extends React.Component {
     const silentSigninLink = this.wrappedAsSilentSigninLink(link);
 
     return (
-      <Card.Grid style={gridStyle} onClick={() => Setting.goToLinkSoft(this, silentSigninLink)}>
-        <img src={logo} alt="logo" width={"100%"} style={{marginBottom: "20px"}} />
-        <Meta
-          title={title}
-          description={desc}
-          style={{justifyContent: "center"}}
-        />
-        <br />
-        {i18next.t("message:Comment")}
-        <br />
-        {time}
-      </Card.Grid>
+      <div style={gridStyle} onClick={() => Setting.goToLinkSoft(this, silentSigninLink)}>
+        <Card hoverable>
+          <img src={logo} alt="logo" width={"100%"} style={{marginBottom: "20px"}} />
+          <CardHeader style={{justifyContent: "center"}}>
+            <CardTitle>{title}</CardTitle>
+            <CardDescription>{desc}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            {i18next.t("message:Comment")}
+            <br />
+            {time}
+          </CardContent>
+        </Card>
+      </div>
     );
   }
 
@@ -67,17 +68,19 @@ class SingleCard extends React.Component {
       <Col style={{paddingLeft: "20px", paddingRight: "20px", paddingBottom: "20px", marginTop: "50px", marginBottom: "20px"}} span={6}>
         <Card
           hoverable
-          cover={
-            <img alt="logo" src={logo} style={{width: "100%", height: "200px", objectFit: "scale-down"}} />
-          }
           onClick={() => Setting.goToLinkSoft(this, silentSigninLink)}
           style={isSingle ? {width: "320px", height: "100%"} : {width: "100%", height: "100%"}}
         >
-          <Meta title={title} description={desc} />
-          <br />
-          {i18next.t("message:Comment")}
-          <br />
-          {time}
+          <img alt="logo" src={logo} style={{width: "100%", height: "200px", objectFit: "scale-down"}} />
+          <CardHeader>
+            <CardTitle>{title}</CardTitle>
+            <CardDescription>{desc}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            {i18next.t("message:Comment")}
+            <br />
+            {time}
+          </CardContent>
         </Card>
       </Col>
     );

--- a/web/src/components/ui/card.jsx
+++ b/web/src/components/ui/card.jsx
@@ -1,10 +1,18 @@
 import React from "react";
 import {cn} from "../../lib/utils";
 
-const Card = React.forwardRef(({className, ...props}, ref) => (
+const Card = React.forwardRef(({className, variant, hoverable, ...props}, ref) => (
   <div
     ref={ref}
-    className={cn("rounded-xl border bg-card text-card-foreground shadow-sm", className)}
+    className={cn(
+      "rounded-xl bg-card text-card-foreground",
+      variant === "bordered" && "border border-solid border-gray-200 shadow-md dark:border-gray-800",
+      variant === "inner" && "border-0 shadow-none",
+      variant === "borderless" && "border-0 shadow-none bg-transparent",
+      variant !== "bordered" && variant !== "inner" && variant !== "borderless" && "border border-solid border-gray-200 shadow-md dark:border-gray-800",
+      hoverable && "transition-shadow duration-200 hover:shadow-md cursor-pointer",
+      className
+    )}
     {...props}
   />
 ));
@@ -22,7 +30,7 @@ CardHeader.displayName = "CardHeader";
 const CardTitle = React.forwardRef(({className, ...props}, ref) => (
   <div
     ref={ref}
-    className={cn("text-2xl font-semibold leading-none tracking-tight", className)}
+    className={cn("text-lg font-semibold leading-none tracking-tight", className)}
     {...props}
   />
 ));

--- a/web/src/components/ui/section-card.jsx
+++ b/web/src/components/ui/section-card.jsx
@@ -1,0 +1,19 @@
+import React from "react";
+import {cn} from "../../lib/utils";
+import {Card, CardContent, CardDescription, CardHeader, CardTitle} from "./card";
+
+function SectionCard({title, desc, children, className, headerClassName, contentClassName, ...props}) {
+  return (
+    <Card className={cn("mb-4", className)} {...props}>
+      {(title || desc) && (
+        <CardHeader className={headerClassName}>
+          {title && <CardTitle className="text-[15px] font-semibold">{title}</CardTitle>}
+          {desc && <CardDescription className="text-[13px]">{desc}</CardDescription>}
+        </CardHeader>
+      )}
+      <CardContent className={contentClassName}>{children}</CardContent>
+    </Card>
+  );
+}
+
+export default SectionCard;


### PR DESCRIPTION
## Summary

Complete migration of antd Card to shadcn/ui Card + new `SectionCard` shared component. Based cleanly on upstream/master with zero merge conflicts.

### New components

| Component | Location | Purpose |
|-----------|----------|---------|
| `Card` (enhanced) | `components/ui/card.jsx` | `variant` (bordered/inner/borderless), `hoverable`, `shadow-md` |
| `SectionCard` | `components/ui/section-card.jsx` | `title` + `desc` API, default `mb-4` spacing |

### What changed

- **EditPages** — Deleted duplicated `renderCardTitle`/`sectionCardStyle`/`cardHeadStyle` code. All use `<SectionCard title="..." desc="...">`.
- **SystemInfo** — 12 dashboard cards use `variant="bordered"`. Local `CardTitle` function renamed to `StatTitle` to avoid import conflict.
- **ServerStorePage** — `title` + `extra` Button migrated to `CardHeader` flex layout with `hoverable`.
- **ManagementPage** — Outer `content-warp-card` set to `variant="inner"` (borderless), inner SectionCards keep borders.
- **SingleCard/GridCards** — `Card.Meta` → `CardTitle`/`CardDescription`. `Card.Grid` → flex div.
- **ChatBox** — `variant="borderless"` transparent card.
- **FileTree** — Removed `margin: "-25px"` hacks (shadcn Card has no default padding).
- **AccountPage** — Profile/Password sections migrated to SectionCard.

<img width="1220" height="781" alt="image" src="https://github.com/user-attachments/assets/4461afc9-836f-4e27-ae14-7f509cbbecb5" />


### Visual fixes

- **Visible borders** — Added `border-solid` to fix invisible borders caused by `preflight: false` in tailwind config. Light: `border-gray-200`, Dark: `dark:border-gray-800`.
- **Deeper shadows** — `shadow-md` replaces `shadow-sm`.
- **Consistent rounding** — All cards use `rounded-xl` via Tailwind tokens.
- **Outer card borderless** — ManagementPage wrapper card has `variant="inner"`, creates clear hierarchy with bordered SectionCards inside.

### Files changed

24 files, +321 / -511 (net -190 lines)

## Test plan

- [x] ESLint: all files pass
- [x] Husky pre-commit: passed
- [x] Rebased on upstream/master, zero conflicts
- [ ] Visual QA: verify borders/shadows in light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)