### PR TITLE
fix: improve streaming pipe support for Discord, Slack and Telegram

### DIFF
--- a/controllers/pipe_webhook.go
+++ b/controllers/pipe_webhook.go
@@ -382,7 +382,7 @@ func sendPipeAnswer(provider pipepkg.Pipe, pipeObj *object.Pipe, incoming *pipep
 
 	var sender pipeAnswerSender = newDefaultPipeAnswerSender(provider, incoming.ChatId)
 	if streamProvider, ok := provider.(pipepkg.StreamPipe); ok {
-		if writer, streamErr := streamProvider.SendStreamMessage(incoming.ChatId, ""); streamErr == nil && writer != nil {
+		if writer, streamErr := streamProvider.SendStreamMessage(incoming, ""); streamErr == nil && writer != nil {
 			sender = newStreamPipeAnswerSender(writer)
 		}
 	}
@@ -440,11 +440,18 @@ func newStreamPipeAnswerSender(writer pipepkg.PipeMessageWriter) *streamPipeAnsw
 }
 
 func (s *streamPipeAnswerSender) WriteMessage(text string) error {
-	if text == "" || text == s.text {
+	if text == "" {
 		return nil
 	}
-	s.text = text
-	return s.writer.WriteMessage(text)
+	s.text += text
+	cleaned := s.text
+	if idx := strings.Index(cleaned, "|||"); idx >= 0 {
+		cleaned = strings.TrimSpace(cleaned[:idx])
+	}
+	if cleaned == "" {
+		return nil
+	}
+	return s.writer.WriteMessage(cleaned)
 }
 
 func (s *streamPipeAnswerSender) WriteError(text string) error {
@@ -465,6 +472,9 @@ func (s *streamPipeAnswerSender) CloseMessage(text string) error {
 		default:
 			finalText = "No response generated"
 		}
+	}
+	if idx := strings.Index(finalText, "|||"); idx >= 0 {
+		finalText = strings.TrimSpace(finalText[:idx])
 	}
 	return s.writer.CloseMessage(finalText)
 }

--- a/pipe/discord.go
+++ b/pipe/discord.go
@@ -63,14 +63,15 @@ type discordApplicationCommandData struct {
 }
 
 type discordInteraction struct {
-	Id        string                         `json:"id"`
-	Type      int                            `json:"type"`
-	ChannelId string                         `json:"channel_id"`
-	GuildId   string                         `json:"guild_id"`
-	Token     string                         `json:"token"`
-	Member    *discordMember                 `json:"member"`
-	User      *discordUser                   `json:"user"`
-	Data      *discordApplicationCommandData `json:"data"`
+	Id            string                         `json:"id"`
+	ApplicationId string                         `json:"application_id"`
+	Type          int                            `json:"type"`
+	ChannelId     string                         `json:"channel_id"`
+	GuildId       string                         `json:"guild_id"`
+	Token         string                         `json:"token"`
+	Member        *discordMember                 `json:"member"`
+	User          *discordUser                   `json:"user"`
+	Data          *discordApplicationCommandData `json:"data"`
 }
 
 type discordGatewayEvent struct {
@@ -169,6 +170,10 @@ func (p *DiscordPipe) parseInteraction(interaction discordInteraction) *Incoming
 		UserId:   userId,
 		Text:     text,
 		Username: username,
+		Metadata: map[string]string{
+			"interaction_token": interaction.Token,
+			"application_id":    interaction.ApplicationId,
+		},
 	}
 }
 
@@ -297,10 +302,12 @@ type discordSentMessage struct {
 }
 
 type discordMessageWriter struct {
-	pipe      *DiscordPipe
-	channelId string
-	messageId string
-	lastText  string
+	pipe             *DiscordPipe
+	channelId        string
+	messageId        string
+	applicationId    string
+	interactionToken string
+	lastText         string
 }
 
 func (w *discordMessageWriter) editText(text string) error {
@@ -310,11 +317,17 @@ func (w *discordMessageWriter) editText(text string) error {
 	payload := map[string]interface{}{
 		"content": text,
 	}
+	var url string
+	if w.interactionToken != "" {
+		url = fmt.Sprintf("%s/webhooks/%s/%s/messages/@original", discordApiBaseUrl, w.applicationId, w.interactionToken)
+	} else {
+		url = fmt.Sprintf("%s/channels/%s/messages/%s", discordApiBaseUrl, w.channelId, w.messageId)
+	}
 	_, err := doJSONRequest(
 		w.pipe.httpClient,
 		"Discord",
 		http.MethodPatch,
-		fmt.Sprintf("%s/channels/%s/messages/%s", discordApiBaseUrl, w.channelId, w.messageId),
+		url,
 		w.pipe.authorizationHeaders(),
 		payload,
 		http.StatusOK,
@@ -333,11 +346,39 @@ func (w *discordMessageWriter) CloseMessage(text string) error {
 	return w.editText(text)
 }
 
-func (p *DiscordPipe) SendStreamMessage(chatId string, text string) (PipeMessageWriter, error) {
+func (p *DiscordPipe) SendStreamMessage(incoming *IncomingMessage, text string) (PipeMessageWriter, error) {
 	initialText := text
 	if initialText == "" {
 		initialText = "..."
 	}
+
+	// Deferred interaction: edit the original response instead of creating a new message
+	if token := incoming.Metadata["interaction_token"]; token != "" {
+		appID := incoming.Metadata["application_id"]
+		payload := map[string]interface{}{
+			"content": initialText,
+		}
+		_, err := doJSONRequest(
+			p.httpClient,
+			"Discord",
+			http.MethodPatch,
+			fmt.Sprintf("%s/webhooks/%s/%s/messages/@original", discordApiBaseUrl, appID, token),
+			p.authorizationHeaders(),
+			payload,
+			http.StatusOK,
+		)
+		if err != nil {
+			return nil, err
+		}
+		return &discordMessageWriter{
+			pipe:             p,
+			applicationId:    appID,
+			interactionToken: token,
+			lastText:         initialText,
+		}, nil
+	}
+
+	// Gateway message: create a new channel message
 	payload := map[string]interface{}{
 		"content": initialText,
 	}
@@ -345,7 +386,7 @@ func (p *DiscordPipe) SendStreamMessage(chatId string, text string) (PipeMessage
 		p.httpClient,
 		"Discord",
 		http.MethodPost,
-		fmt.Sprintf("%s/channels/%s/messages", discordApiBaseUrl, chatId),
+		fmt.Sprintf("%s/channels/%s/messages", discordApiBaseUrl, incoming.ChatId),
 		p.authorizationHeaders(),
 		payload,
 		http.StatusOK,
@@ -365,7 +406,7 @@ func (p *DiscordPipe) SendStreamMessage(chatId string, text string) (PipeMessage
 
 	return &discordMessageWriter{
 		pipe:      p,
-		channelId: chatId,
+		channelId: incoming.ChatId,
 		messageId: sent.Id,
 		lastText:  initialText,
 	}, nil

--- a/pipe/pipe.go
+++ b/pipe/pipe.go
@@ -28,6 +28,7 @@ type IncomingMessage struct {
 	UserId   string
 	Text     string
 	Username string
+	Metadata map[string]string // platform-specific data (e.g. Discord interaction token)
 }
 
 // Pipe is the core interface every pipe platform must implement.
@@ -45,7 +46,7 @@ type PipeMessageWriter interface {
 // StreamPipe is implemented by pipes that can progressively update an
 // in-flight response (for example via send + edit message APIs).
 type StreamPipe interface {
-	SendStreamMessage(chatId string, text string) (PipeMessageWriter, error)
+	SendStreamMessage(incoming *IncomingMessage, text string) (PipeMessageWriter, error)
 }
 
 type WebhookResponse struct {

--- a/pipe/slack.go
+++ b/pipe/slack.go
@@ -159,13 +159,13 @@ func (w *slackMessageWriter) CloseMessage(text string) error {
 	return w.editText(text)
 }
 
-func (p *SlackPipe) SendStreamMessage(chatId string, text string) (PipeMessageWriter, error) {
+func (p *SlackPipe) SendStreamMessage(incoming *IncomingMessage, text string) (PipeMessageWriter, error) {
 	initialText := text
 	if initialText == "" {
 		initialText = "..."
 	}
 	payload := map[string]interface{}{
-		"channel": chatId,
+		"channel": incoming.ChatId,
 		"text":    initialText,
 	}
 	headers := map[string]string{
@@ -228,7 +228,9 @@ func (p *SlackPipe) GetWebhookResponse(body []byte, header http.Header) (*Webhoo
 		}, nil
 	}
 
-	return nil, nil
+	// Return an immediate 200 for regular events so Slack does not retry.
+	// The actual message processing happens asynchronously in sendPipeAnswer.
+	return &WebhookResponse{StatusCode: http.StatusOK}, nil
 }
 
 func (p *SlackPipe) verifySignature(body []byte, header http.Header) error {

--- a/pipe/telegram.go
+++ b/pipe/telegram.go
@@ -146,13 +146,13 @@ func (w *telegramMessageWriter) CloseMessage(text string) error {
 	return w.editText(text)
 }
 
-func (p *TelegramPipe) SendStreamMessage(chatId string, text string) (PipeMessageWriter, error) {
+func (p *TelegramPipe) SendStreamMessage(incoming *IncomingMessage, text string) (PipeMessageWriter, error) {
 	initialText := text
 	if initialText == "" {
 		initialText = "..."
 	}
 	payload := map[string]interface{}{
-		"chat_id": chatId,
+		"chat_id": incoming.ChatId,
 		"text":    initialText,
 	}
 	respBody, err := p.doPost("sendMessage", payload)
@@ -170,7 +170,7 @@ func (p *TelegramPipe) SendStreamMessage(chatId string, text string) (PipeMessag
 
 	return &telegramMessageWriter{
 		pipe:      p,
-		chatId:    chatId,
+		chatId:    incoming.ChatId,
 		messageId: result.Result.MessageId,
 		lastText:  initialText,
 	}, nil


### PR DESCRIPTION
## Changes

- Fix Discord deferred interaction stuck in "responding forever" state
- Fix stream delta accumulation (replace -> append)
- Strip model-generated ||| suggestion markers from stream output
- Return immediate 200 for Slack events to prevent retries
- Add IncomingMessage.Metadata for platform-specific data