### PR TITLE
feat: rename local file tools to generic file APIs

### DIFF
--- a/object/site.go
+++ b/object/site.go
@@ -51,12 +51,12 @@ type Site struct {
 
 func SyncSiteToConf(site *Site) {
 	conf.SetSiteOverrides(map[string]string{
-		"staticBaseUrl":        site.StaticBaseUrl,
-		"htmlTitle":            site.HtmlTitle,
-		"faviconUrl":           site.FaviconUrl,
-		"logoUrl":              site.LogoUrl,
-		"navbarHtml":           site.NavbarHtml,
-		"footerHtml":           site.FooterHtml,
+		"staticBaseUrl":       site.StaticBaseUrl,
+		"htmlTitle":           site.HtmlTitle,
+		"faviconUrl":          site.FaviconUrl,
+		"logoUrl":             site.LogoUrl,
+		"navbarHtml":          site.NavbarHtml,
+		"footerHtml":          site.FooterHtml,
 		"issuer":              site.Issuer,
 		"clientId":            site.ClientId,
 		"clientSecret":        site.ClientSecret,

--- a/object/store.go
+++ b/object/store.go
@@ -61,44 +61,44 @@ type Store struct {
 	CreatedTime string `xorm:"varchar(100) index(idx_store_name_created)" json:"createdTime"`
 	DisplayName string `xorm:"varchar(100)" json:"displayName"`
 
-	StorageProvider      string   `xorm:"varchar(100)" json:"storageProvider"`
-	StorageSubpath       string   `xorm:"varchar(100)" json:"storageSubpath"`
-	ImageProvider        string   `xorm:"varchar(100)" json:"imageProvider"`
-	SplitProvider        string   `xorm:"varchar(100)" json:"splitProvider"`
-	SearchProvider       string   `xorm:"varchar(100)" json:"searchProvider"`
-	ModelProvider        string   `xorm:"varchar(100)" json:"modelProvider"`
-	EmbeddingProvider    string   `xorm:"varchar(100)" json:"embeddingProvider"`
-	TextToSpeechProvider string   `xorm:"varchar(100)" json:"textToSpeechProvider"`
-	EnableTtsStreaming   bool     `xorm:"bool" json:"enableTtsStreaming"`
-	SpeechToTextProvider string   `xorm:"varchar(100)" json:"speechToTextProvider"`
-	McpServer            string   `xorm:"varchar(100)" json:"mcpServer"`
-	Skills               []string `xorm:"mediumtext" json:"skills"`
-	Tools                []string `xorm:"mediumtext" json:"tools"`
-	VectorStoreId        string   `xorm:"varchar(100)" json:"vectorStoreId"`
-	MemoryLimit         int               `json:"memoryLimit"`
-	Frequency           int               `json:"frequency"`
-	LimitMinutes        int               `json:"limitMinutes"`
-	KnowledgeCount      int               `json:"knowledgeCount"`
-	SuggestionCount     int               `json:"suggestionCount"`
-	Welcome             string            `xorm:"varchar(100)" json:"welcome"`
-	WelcomeTitle        string            `xorm:"varchar(100)" json:"welcomeTitle"`
-	WelcomeText         string            `xorm:"varchar(100)" json:"welcomeText"`
-	Prompt              string            `xorm:"mediumtext" json:"prompt"`
-	ExampleQuestions    []ExampleQuestion `xorm:"mediumtext" json:"exampleQuestions"`
-	Avatar              string            `xorm:"varchar(200)" json:"avatar"`
-	Title               string            `xorm:"varchar(100)" json:"title"`
-	VectorStores        []string          `xorm:"mediumtext" json:"vectorStores"`
-	ChildStores         []string          `xorm:"mediumtext" json:"childStores"`
-	ChildModelProviders []string          `xorm:"mediumtext" json:"childModelProviders"`
-	ForbiddenWords      []string          `xorm:"text" json:"forbiddenWords"`
-	Owners              []string          `xorm:"mediumtext" json:"owners"`
-	ShowAutoRead        bool              `json:"showAutoRead"`
-	DisableFileUpload   bool              `json:"disableFileUpload"`
-	HideThinking        bool              `json:"hideThinking"`
-	EnableExtraOptions  bool              `json:"enableExtraOptions"`
-	IsDefault           bool              `json:"isDefault"`
-	State               string            `xorm:"varchar(100)" json:"state"`
-	SharedBy            string            `xorm:"varchar(100)" json:"sharedBy"`
+	StorageProvider      string            `xorm:"varchar(100)" json:"storageProvider"`
+	StorageSubpath       string            `xorm:"varchar(100)" json:"storageSubpath"`
+	ImageProvider        string            `xorm:"varchar(100)" json:"imageProvider"`
+	SplitProvider        string            `xorm:"varchar(100)" json:"splitProvider"`
+	SearchProvider       string            `xorm:"varchar(100)" json:"searchProvider"`
+	ModelProvider        string            `xorm:"varchar(100)" json:"modelProvider"`
+	EmbeddingProvider    string            `xorm:"varchar(100)" json:"embeddingProvider"`
+	TextToSpeechProvider string            `xorm:"varchar(100)" json:"textToSpeechProvider"`
+	EnableTtsStreaming   bool              `xorm:"bool" json:"enableTtsStreaming"`
+	SpeechToTextProvider string            `xorm:"varchar(100)" json:"speechToTextProvider"`
+	McpServer            string            `xorm:"varchar(100)" json:"mcpServer"`
+	Skills               []string          `xorm:"mediumtext" json:"skills"`
+	Tools                []string          `xorm:"mediumtext" json:"tools"`
+	VectorStoreId        string            `xorm:"varchar(100)" json:"vectorStoreId"`
+	MemoryLimit          int               `json:"memoryLimit"`
+	Frequency            int               `json:"frequency"`
+	LimitMinutes         int               `json:"limitMinutes"`
+	KnowledgeCount       int               `json:"knowledgeCount"`
+	SuggestionCount      int               `json:"suggestionCount"`
+	Welcome              string            `xorm:"varchar(100)" json:"welcome"`
+	WelcomeTitle         string            `xorm:"varchar(100)" json:"welcomeTitle"`
+	WelcomeText          string            `xorm:"varchar(100)" json:"welcomeText"`
+	Prompt               string            `xorm:"mediumtext" json:"prompt"`
+	ExampleQuestions     []ExampleQuestion `xorm:"mediumtext" json:"exampleQuestions"`
+	Avatar               string            `xorm:"varchar(200)" json:"avatar"`
+	Title                string            `xorm:"varchar(100)" json:"title"`
+	VectorStores         []string          `xorm:"mediumtext" json:"vectorStores"`
+	ChildStores          []string          `xorm:"mediumtext" json:"childStores"`
+	ChildModelProviders  []string          `xorm:"mediumtext" json:"childModelProviders"`
+	ForbiddenWords       []string          `xorm:"text" json:"forbiddenWords"`
+	Owners               []string          `xorm:"mediumtext" json:"owners"`
+	ShowAutoRead         bool              `json:"showAutoRead"`
+	DisableFileUpload    bool              `json:"disableFileUpload"`
+	HideThinking         bool              `json:"hideThinking"`
+	EnableExtraOptions   bool              `json:"enableExtraOptions"`
+	IsDefault            bool              `json:"isDefault"`
+	State                string            `xorm:"varchar(100)" json:"state"`
+	SharedBy             string            `xorm:"varchar(100)" json:"sharedBy"`
 
 	ChatCount    int `xorm:"-" json:"chatCount"`
 	MessageCount int `xorm:"-" json:"messageCount"`

--- a/tool/local_file.go
+++ b/tool/local_file.go
@@ -25,6 +25,7 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/ThinkInAIXYZ/go-mcp/protocol"
 	"github.com/the-open-agent/openagent/txt"
@@ -44,8 +45,8 @@ func (p *LocalFileTool) BuiltinTools() []BuiltinTool {
 	return []BuiltinTool{
 		&localSpecialDirsBuiltin{},
 		&localFileScanBuiltin{},
-		&localDocumentReadBuiltin{lang: p.lang},
-		&localTextWriteBuiltin{},
+		&localFileReadBuiltin{lang: p.lang},
+		&localFileWriteBuiltin{},
 		&localFileMoveBuiltin{},
 	}
 }
@@ -80,7 +81,7 @@ type localFileScanResult struct {
 	Items []localFileScanItem `json:"items"`
 }
 
-type localDocumentReadResult struct {
+type localFileReadResult struct {
 	Path       string `json:"path"`
 	Extension  string `json:"extension"`
 	Offset     int    `json:"offset"`
@@ -90,7 +91,7 @@ type localDocumentReadResult struct {
 	Truncated  bool   `json:"truncated"`
 }
 
-type localTextWriteResult struct {
+type localFileWriteResult struct {
 	Path      string `json:"path"`
 	ByteSize  int    `json:"byteSize"`
 	Overwrote bool   `json:"overwrote"`
@@ -204,8 +205,18 @@ func localFileSliceText(text string, offset, limit int) (string, bool) {
 	return string(runes[offset:end]), truncated
 }
 
-func localFileReadDocument(path, ext, lang string) (string, error) {
-	return txt.GetParsedTextFromUrl(path, ext, lang)
+func localFileReadText(path, ext, lang string) (string, error) {
+	if _, ok := localFileSupportedExt(path); ok {
+		return txt.GetParsedTextFromUrl(path, ext, lang)
+	}
+	bs, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	if !utf8.Valid(bs) {
+		return "", fmt.Errorf("file content is not valid UTF-8 text")
+	}
+	return string(bs), nil
 }
 
 func localFileDirectory(path string) localSpecialDirInfo {
@@ -346,32 +357,34 @@ func (b *localFileScanBuiltin) Execute(_ context.Context, arguments map[string]i
 	}), nil
 }
 
-type localDocumentReadBuiltin struct {
+type localFileReadBuiltin struct {
 	lang string
 }
 
-func (b *localDocumentReadBuiltin) GetName() string {
-	return "local_document_read"
+func (b *localFileReadBuiltin) GetName() string {
+	return "local_file_read"
 }
 
-func (b *localDocumentReadBuiltin) GetDescription() string {
-	return `Read text from one supported local document.
+func (b *localFileReadBuiltin) GetDescription() string {
+	return `Read text from a local file.
 - path (required): absolute file path for the current operating system.
-- offset: character offset in extracted text (default 0).
+- For supported document types, extracts text with the document parser.
+- For other files, reads UTF-8 text directly.
+- offset: character offset in returned text (default 0).
 - limit: maximum characters to return (default 12000, max 100000).`
 }
 
-func (b *localDocumentReadBuiltin) GetInputSchema() interface{} {
+func (b *localFileReadBuiltin) GetInputSchema() interface{} {
 	return map[string]interface{}{
 		"type": "object",
 		"properties": map[string]interface{}{
 			"path": map[string]interface{}{
 				"type":        "string",
-				"description": "Absolute path to a supported document.",
+				"description": "Absolute path to a file.",
 			},
 			"offset": map[string]interface{}{
 				"type":        "number",
-				"description": "Character offset in extracted text (default 0).",
+				"description": "Character offset in returned text (default 0).",
 			},
 			"limit": map[string]interface{}{
 				"type":        "number",
@@ -382,7 +395,7 @@ func (b *localDocumentReadBuiltin) GetInputSchema() interface{} {
 	}
 }
 
-func (b *localDocumentReadBuiltin) Execute(_ context.Context, arguments map[string]interface{}) (*protocol.CallToolResult, error) {
+func (b *localFileReadBuiltin) Execute(_ context.Context, arguments map[string]interface{}) (*protocol.CallToolResult, error) {
 	path := localFileStringArg(arguments, "path")
 	if err := localFileRequireAbsolutePath(path, "path"); err != nil {
 		return localFileError(err.Error()), nil
@@ -394,10 +407,7 @@ func (b *localDocumentReadBuiltin) Execute(_ context.Context, arguments map[stri
 	if info.IsDir() {
 		return localFileError("path must be a file"), nil
 	}
-	ext, ok := localFileSupportedExt(path)
-	if !ok {
-		return localFileError(fmt.Sprintf("unsupported file type: %s", ext)), nil
-	}
+	ext := strings.ToLower(filepath.Ext(path))
 
 	offset := localFileIntArg(arguments, "offset", 0)
 	if offset < 0 {
@@ -406,13 +416,13 @@ func (b *localDocumentReadBuiltin) Execute(_ context.Context, arguments map[stri
 	limit := localFileIntArg(arguments, "limit", localFileDefaultReadLimit)
 	limit = localFileClamp(limit, 0, localFileMaxReadLimit)
 
-	text, err := localFileReadDocument(path, ext, b.lang)
+	text, err := localFileReadText(path, ext, b.lang)
 	if err != nil {
-		return localFileError(fmt.Sprintf("failed to read document: %s", err.Error())), nil
+		return localFileError(fmt.Sprintf("failed to read file: %s", err.Error())), nil
 	}
 	section, truncated := localFileSliceText(text, offset, limit)
 
-	return localFileJSON(localDocumentReadResult{
+	return localFileJSON(localFileReadResult{
 		Path:       path,
 		Extension:  ext,
 		Offset:     offset,
@@ -423,20 +433,20 @@ func (b *localDocumentReadBuiltin) Execute(_ context.Context, arguments map[stri
 	}), nil
 }
 
-type localTextWriteBuiltin struct{}
+type localFileWriteBuiltin struct{}
 
-func (b *localTextWriteBuiltin) GetName() string {
-	return "local_text_write"
+func (b *localFileWriteBuiltin) GetName() string {
+	return "local_file_write"
 }
 
-func (b *localTextWriteBuiltin) GetDescription() string {
-	return `Write Markdown or plain text content to a local file.
+func (b *localFileWriteBuiltin) GetDescription() string {
+	return `Write text content to a local file.
 - path (required): absolute output file path for the current operating system.
 - content (required): text content to write.
 - overwrite: set true to replace an existing file (default false).`
 }
 
-func (b *localTextWriteBuiltin) GetInputSchema() interface{} {
+func (b *localFileWriteBuiltin) GetInputSchema() interface{} {
 	return map[string]interface{}{
 		"type": "object",
 		"properties": map[string]interface{}{
@@ -446,7 +456,7 @@ func (b *localTextWriteBuiltin) GetInputSchema() interface{} {
 			},
 			"content": map[string]interface{}{
 				"type":        "string",
-				"description": "Markdown or plain text content to write.",
+				"description": "Text content to write.",
 			},
 			"overwrite": map[string]interface{}{
 				"type":        "boolean",
@@ -457,7 +467,7 @@ func (b *localTextWriteBuiltin) GetInputSchema() interface{} {
 	}
 }
 
-func (b *localTextWriteBuiltin) Execute(_ context.Context, arguments map[string]interface{}) (*protocol.CallToolResult, error) {
+func (b *localFileWriteBuiltin) Execute(_ context.Context, arguments map[string]interface{}) (*protocol.CallToolResult, error) {
 	path := localFileStringArg(arguments, "path")
 	if err := localFileRequireAbsolutePath(path, "path"); err != nil {
 		return localFileError(err.Error()), nil
@@ -501,7 +511,7 @@ func (b *localTextWriteBuiltin) Execute(_ context.Context, arguments map[string]
 		}
 	}
 
-	return localFileJSON(localTextWriteResult{
+	return localFileJSON(localFileWriteResult{
 		Path:      path,
 		ByteSize:  len([]byte(content)),
 		Overwrote: overwrote,

--- a/tool/local_file.go
+++ b/tool/local_file.go
@@ -31,10 +31,8 @@ import (
 )
 
 const (
-	localFileDefaultPreviewChars = 1200
-	localFileMaxPreviewChars     = 20000
-	localFileDefaultReadLimit    = 12000
-	localFileMaxReadLimit        = 100000
+	localFileDefaultReadLimit = 12000
+	localFileMaxReadLimit     = 100000
 )
 
 // LocalFileTool is the Tool Type "local_file".
@@ -45,23 +43,17 @@ type LocalFileTool struct {
 func (p *LocalFileTool) BuiltinTools() []BuiltinTool {
 	return []BuiltinTool{
 		&localSpecialDirsBuiltin{},
-		&localDocumentsScanBuiltin{lang: p.lang},
+		&localFileScanBuiltin{},
 		&localDocumentReadBuiltin{lang: p.lang},
 		&localTextWriteBuiltin{},
 		&localFileMoveBuiltin{},
 	}
 }
 
-type localDocumentInfo struct {
-	Path         string `json:"path"`
-	Name         string `json:"name"`
-	Extension    string `json:"extension"`
-	Size         int64  `json:"size"`
-	ModifiedTime string `json:"modifiedTime"`
-	TextLength   int    `json:"textLength,omitempty"`
-	Preview      string `json:"preview,omitempty"`
-	Truncated    bool   `json:"truncated,omitempty"`
-	Error        string `json:"error,omitempty"`
+type localFileScanItem struct {
+	Type string `json:"type"`
+	Name string `json:"name"`
+	Path string `json:"path"`
 }
 
 type localSpecialDirInfo struct {
@@ -82,10 +74,10 @@ type localSpecialDirsResult struct {
 	Directories localSpecialDirs `json:"directories"`
 }
 
-type localDocumentsScanResult struct {
+type localFileScanResult struct {
 	Root  string              `json:"root"`
 	Count int                 `json:"count"`
-	Files []localDocumentInfo `json:"files"`
+	Items []localFileScanItem `json:"items"`
 }
 
 type localDocumentReadResult struct {
@@ -280,22 +272,19 @@ func (b *localSpecialDirsBuiltin) Execute(_ context.Context, _ map[string]interf
 	}), nil
 }
 
-type localDocumentsScanBuiltin struct {
-	lang string
+type localFileScanBuiltin struct{}
+
+func (b *localFileScanBuiltin) GetName() string {
+	return "local_file_scan"
 }
 
-func (b *localDocumentsScanBuiltin) GetName() string {
-	return "local_documents_scan"
-}
-
-func (b *localDocumentsScanBuiltin) GetDescription() string {
-	return `Scan a local directory for supported documents and return a JSON manifest with metadata, text previews, and parse errors.
+func (b *localFileScanBuiltin) GetDescription() string {
+	return `Scan a local directory recursively and return a JSON manifest of all descendant files and directories.
 - root (required): absolute directory path for the current operating system.
-- preview_chars: maximum text preview characters per file (default 1200, max 20000).
-- max_files: optional maximum number of supported files to return.`
+- Returns items with type, name, and path.`
 }
 
-func (b *localDocumentsScanBuiltin) GetInputSchema() interface{} {
+func (b *localFileScanBuiltin) GetInputSchema() interface{} {
 	return map[string]interface{}{
 		"type": "object",
 		"properties": map[string]interface{}{
@@ -303,20 +292,12 @@ func (b *localDocumentsScanBuiltin) GetInputSchema() interface{} {
 				"type":        "string",
 				"description": "Absolute directory path to scan.",
 			},
-			"preview_chars": map[string]interface{}{
-				"type":        "number",
-				"description": "Maximum text preview characters per file (default 1200, max 20000).",
-			},
-			"max_files": map[string]interface{}{
-				"type":        "number",
-				"description": "Optional maximum number of supported files to return.",
-			},
 		},
 		"required": []string{"root"},
 	}
 }
 
-func (b *localDocumentsScanBuiltin) Execute(_ context.Context, arguments map[string]interface{}) (*protocol.CallToolResult, error) {
+func (b *localFileScanBuiltin) Execute(_ context.Context, arguments map[string]interface{}) (*protocol.CallToolResult, error) {
 	root := localFileStringArg(arguments, "root")
 	if err := localFileRequireAbsolutePath(root, "root"); err != nil {
 		return localFileError(err.Error()), nil
@@ -330,58 +311,38 @@ func (b *localDocumentsScanBuiltin) Execute(_ context.Context, arguments map[str
 		return localFileError("root must be a directory"), nil
 	}
 
-	previewChars := localFileIntArg(arguments, "preview_chars", localFileDefaultPreviewChars)
-	previewChars = localFileClamp(previewChars, 0, localFileMaxPreviewChars)
-	maxFiles := localFileIntArg(arguments, "max_files", 0)
-
-	var files []localDocumentInfo
+	var items []localFileScanItem
 	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return nil
 		}
+		if path == root {
+			return nil
+		}
+
+		itemType := "file"
 		if d.IsDir() {
-			return nil
+			itemType = "directory"
 		}
-		ext, ok := localFileSupportedExt(path)
-		if !ok {
-			return nil
-		}
-		if maxFiles > 0 && len(files) >= maxFiles {
-			return filepath.SkipAll
-		}
-
-		item := localDocumentInfo{
-			Path:      path,
-			Name:      d.Name(),
-			Extension: ext,
-		}
-		if fileInfo, statErr := d.Info(); statErr == nil {
-			item.Size = fileInfo.Size()
-			item.ModifiedTime = fileInfo.ModTime().Format("2006-01-02 15:04:05")
-		}
-
-		text, readErr := localFileReadDocument(path, ext, b.lang)
-		if readErr != nil {
-			item.Error = readErr.Error()
-		} else {
-			item.TextLength = len([]rune(text))
-			item.Preview, item.Truncated = localFileSliceText(text, 0, previewChars)
-		}
-		files = append(files, item)
+		items = append(items, localFileScanItem{
+			Type: itemType,
+			Name: d.Name(),
+			Path: path,
+		})
 		return nil
 	})
 	if walkErr != nil {
 		return localFileError(fmt.Sprintf("failed to scan root: %s", walkErr.Error())), nil
 	}
 
-	sort.Slice(files, func(i, j int) bool {
-		return files[i].Path < files[j].Path
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].Path < items[j].Path
 	})
 
-	return localFileJSON(localDocumentsScanResult{
+	return localFileJSON(localFileScanResult{
 		Root:  root,
-		Count: len(files),
-		Files: files,
+		Count: len(items),
+		Items: items,
 	}), nil
 }
 

--- a/web/src/Setting.js
+++ b/web/src/Setting.js
@@ -457,14 +457,14 @@ export function getToolFunctions(tool) {
         testContent: JSON.stringify({tool: "local_file_scan", arguments: {root: "/absolute/path/to/Desktop"}}, null, 2),
       },
       {
-        name: "local_document_read",
-        description: "Read text from one supported local document",
-        testContent: JSON.stringify({tool: "local_document_read", arguments: {path: "/absolute/path/to/Desktop/report.pdf", offset: 0, limit: 12000}}, null, 2),
+        name: "local_file_read",
+        description: "Read text from a local file",
+        testContent: JSON.stringify({tool: "local_file_read", arguments: {path: "/absolute/path/to/Desktop/report.pdf", offset: 0, limit: 12000}}, null, 2),
       },
       {
-        name: "local_text_write",
-        description: "Write Markdown or plain text to an absolute local path",
-        testContent: JSON.stringify({tool: "local_text_write", arguments: {path: "/absolute/path/to/Desktop/Project Summaries/summary.md", content: "# Summary\\n\\nProject notes.", overwrite: false}}, null, 2),
+        name: "local_file_write",
+        description: "Write text to an absolute local path",
+        testContent: JSON.stringify({tool: "local_file_write", arguments: {path: "/absolute/path/to/Desktop/Project Summaries/summary.md", content: "# Summary\\n\\nProject notes.", overwrite: false}}, null, 2),
       },
       {
         name: "local_file_move",

--- a/web/src/Setting.js
+++ b/web/src/Setting.js
@@ -452,9 +452,9 @@ export function getToolFunctions(tool) {
         testContent: JSON.stringify({tool: "local_special_dirs", arguments: {}}, null, 2),
       },
       {
-        name: "local_documents_scan",
-        description: "Scan an absolute local directory for supported documents",
-        testContent: JSON.stringify({tool: "local_documents_scan", arguments: {root: "/absolute/path/to/Desktop", preview_chars: 1200}}, null, 2),
+        name: "local_file_scan",
+        description: "Scan an absolute local directory for all files and subdirectories",
+        testContent: JSON.stringify({tool: "local_file_scan", arguments: {root: "/absolute/path/to/Desktop"}}, null, 2),
       },
       {
         name: "local_document_read",


### PR DESCRIPTION
## Summary

Refactors local file tools to use generic `local_file_*` names and broader file-oriented behavior.

## Replacements

- `local_documents_scan` -> `local_file_scan`
  - Before: only scanned supported documents and returned text previews.
  - After: scans all files/directories and returns only `type`, `name`, `path`.

- `local_document_read` -> `local_file_read`
  - Before: only read supported document types.
  - After: still parses supported documents, and reads other UTF-8 text files directly.

- `local_text_write` -> `local_file_write`
  - Behavior unchanged.
  - Renamed for consistent `local_file_*` API naming.