### PR TITLE
fix: add SSE heartbeat during tool execution to prevent connection drops

### DIFF
--- a/controllers/message_writer.go
+++ b/controllers/message_writer.go
@@ -39,6 +39,14 @@ func newRefinedWriter(w context.Response) *RefinedWriter {
 }
 
 func (w *RefinedWriter) Write(p []byte) (n int, err error) {
+	if len(p) > 0 && p[0] == ':' {
+		n, err = w.ResponseWriter.Write(p)
+		if flusher, ok := w.ResponseWriter.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		return n, err
+	}
+
 	var eventType string
 	var data string
 

--- a/model/mcp.go
+++ b/model/mcp.go
@@ -19,7 +19,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"strings"
+	"time"
 
 	"github.com/ThinkInAIXYZ/go-mcp/protocol"
 	"github.com/openai/openai-go/v2/responses"
@@ -202,6 +204,26 @@ func createToolMessage(toolCall openai.ToolCall, text string) *RawMessage {
 	}
 }
 
+func startHeartbeat(writer io.Writer) chan<- struct{} {
+	stop := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(5 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				if flusher, ok := writer.(http.Flusher); ok {
+					_, _ = fmt.Fprint(writer, ":keepalive\n\n")
+					flusher.Flush()
+				}
+			case <-stop:
+				return
+			}
+		}
+	}()
+	return stop
+}
+
 func callMcpTool(toolCall openai.ToolCall, serverName, toolName string, mcpToolSet *mcp.ToolSet, messages []*RawMessage, writer io.Writer, lang string) ([]*RawMessage, error) {
 	var arguments map[string]interface{}
 	ctx := context.Background()
@@ -222,6 +244,9 @@ func callMcpTool(toolCall openai.ToolCall, serverName, toolName string, mcpToolS
 	}
 
 	var result *protocol.CallToolResult
+
+	heartbeat := startHeartbeat(writer)
+	defer close(heartbeat)
 
 	if serverName == "" {
 		// builtin tools

--- a/model/mcp.go
+++ b/model/mcp.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/ThinkInAIXYZ/go-mcp/protocol"
@@ -204,7 +205,7 @@ func createToolMessage(toolCall openai.ToolCall, text string) *RawMessage {
 	}
 }
 
-func startHeartbeat(writer io.Writer) chan<- struct{} {
+func startHeartbeat(writer io.Writer, mu *sync.Mutex) chan<- struct{} {
 	stop := make(chan struct{})
 	go func() {
 		ticker := time.NewTicker(5 * time.Second)
@@ -212,10 +213,12 @@ func startHeartbeat(writer io.Writer) chan<- struct{} {
 		for {
 			select {
 			case <-ticker.C:
+				mu.Lock()
 				if flusher, ok := writer.(http.Flusher); ok {
 					_, _ = fmt.Fprint(writer, ":keepalive\n\n")
 					flusher.Flush()
 				}
+				mu.Unlock()
 			case <-stop:
 				return
 			}
@@ -243,9 +246,10 @@ func callMcpTool(toolCall openai.ToolCall, serverName, toolName string, mcpToolS
 		_ = flushDataThink(string(toolStartJSON), "tool-start", writer, lang)
 	}
 
+	var mu sync.Mutex
 	var result *protocol.CallToolResult
 
-	heartbeat := startHeartbeat(writer)
+	heartbeat := startHeartbeat(writer, &mu)
 	defer close(heartbeat)
 
 	if serverName == "" {
@@ -313,8 +317,10 @@ func callMcpTool(toolCall openai.ToolCall, serverName, toolName string, mcpToolS
 	}
 	toolJSON, err := json.Marshal(toolData)
 	if err == nil {
+		mu.Lock()
 		if err := flushDataThink(string(toolJSON), "tool", writer, lang); err == nil {
 		}
+		mu.Unlock()
 	}
 
 	messages = append(messages, createToolMessage(toolCall, string(responseJson)))


### PR DESCRIPTION
## Summary

- Add SSE heartbeat during long-running tool calls to prevent proxy/server connection drops
- Add mutex to serialize writes between heartbeat goroutine and main streaming path