### PR TITLE
feat: support on-demand skill loading.

### DIFF
--- a/controllers/message_answer.go
+++ b/controllers/message_answer.go
@@ -137,7 +137,7 @@ func generateMessageAnswer(id string, responseWriter http.ResponseWriter, host s
 	}
 
 	if len(store.Skills) > 0 {
-		skillsContent, skillErr := object.GetSkillsContent(store.Owner, store.Skills)
+		skillsContent, skillErr := object.GetSkillsCatalog(store.Owner, store.Skills)
 		if skillErr != nil {
 			responseErrorStream(message, skillErr.Error())
 			return

--- a/object/merge_agent_tools.go
+++ b/object/merge_agent_tools.go
@@ -27,6 +27,12 @@ func buildMergedBuiltinRegistry(store *Store, lang string) *tool.ToolRegistry {
 		return reg
 	}
 
+	if len(store.Skills) > 0 {
+		if bt := tool.NewLoadSkillBuiltin(store.Owner, store.Skills, skillLoader{}); bt != nil {
+			reg.RegisterTool(bt)
+		}
+	}
+
 	toolNames := store.Tools
 	if len(toolNames) == 1 && toolNames[0] == "All" {
 		allTools, err := GetTools(store.Owner)

--- a/object/skill.go
+++ b/object/skill.go
@@ -339,6 +339,7 @@ func resolveEnabledSkills(owner string, skillNames []string) ([]*Skill, error) {
 		return nil, nil
 	}
 
+	hasAll := false
 	var names []string
 	for _, name := range skillNames {
 		name = strings.TrimSpace(name)
@@ -346,9 +347,13 @@ func resolveEnabledSkills(owner string, skillNames []string) ([]*Skill, error) {
 			continue
 		}
 		if name == "All" {
-			return GetSkills(owner)
+			hasAll = true
+			continue
 		}
 		names = append(names, name)
+	}
+	if hasAll {
+		return GetSkills(owner)
 	}
 
 	var skills []*Skill
@@ -542,7 +547,14 @@ func GetSkillsContent(owner string, skillNames []string) (string, error) {
 		if s == nil || s.State != "Active" || strings.TrimSpace(s.Content) == "" {
 			continue
 		}
-		parts = append(parts, strings.TrimSpace(s.Content))
+		buf := strings.TrimSpace(s.Content)
+		for _, ref := range s.References {
+			if strings.TrimSpace(ref.Content) == "" {
+				continue
+			}
+			buf += "\n\n## Reference: " + ref.Name + "\n\n" + strings.TrimSpace(ref.Content)
+		}
+		parts = append(parts, buf)
 	}
 
 	return strings.Join(parts, "\n\n"), nil

--- a/object/skill.go
+++ b/object/skill.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/the-open-agent/openagent/util"
@@ -333,6 +334,186 @@ func DeleteSkill(s *Skill) (bool, error) {
 	return affected != 0, nil
 }
 
+func resolveEnabledSkills(owner string, skillNames []string) ([]*Skill, error) {
+	if len(skillNames) == 0 {
+		return nil, nil
+	}
+
+	var names []string
+	for _, name := range skillNames {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		if name == "All" {
+			return GetSkills(owner)
+		}
+		names = append(names, name)
+	}
+
+	var skills []*Skill
+	seen := map[string]bool{}
+	for _, name := range names {
+		s, err := GetSkillByOwnerAndName(owner, name)
+		if err != nil {
+			return nil, err
+		}
+		if s == nil {
+			continue
+		}
+
+		id := s.GetId()
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		skills = append(skills, s)
+	}
+
+	return skills, nil
+}
+
+func skillNameMatches(s *Skill, skillName string) bool {
+	if s == nil {
+		return false
+	}
+
+	skillName = strings.TrimSpace(skillName)
+	if skillName == "" {
+		return false
+	}
+
+	if skillName == s.Name || skillName == s.GetId() {
+		return true
+	}
+
+	owner, name, err := util.GetOwnerAndNameFromIdWithError(skillName)
+	return err == nil && owner == s.Owner && name == s.Name
+}
+
+func GetSkillsCatalog(owner string, skillNames []string) (string, error) {
+	if len(skillNames) == 0 {
+		return "", nil
+	}
+
+	skills, err := resolveEnabledSkills(owner, skillNames)
+	if err != nil {
+		return "", err
+	}
+
+	var items []string
+	for _, s := range skills {
+		if s == nil || s.State != "Active" {
+			continue
+		}
+
+		parts := []string{fmt.Sprintf("- %s", s.Name)}
+		if strings.TrimSpace(s.Description) != "" {
+			parts = append(parts, fmt.Sprintf("description: %s", strings.TrimSpace(s.Description)))
+		}
+		if strings.TrimSpace(s.Type) != "" {
+			parts = append(parts, fmt.Sprintf("type: %s", strings.TrimSpace(s.Type)))
+		}
+
+		refNames := make([]string, 0, len(s.References))
+		for _, ref := range s.References {
+			if strings.TrimSpace(ref.Name) != "" {
+				refNames = append(refNames, ref.Name)
+			}
+		}
+		sort.Strings(refNames)
+		if len(refNames) > 0 {
+			parts = append(parts, fmt.Sprintf("references: %s", strings.Join(refNames, ", ")))
+		}
+
+		items = append(items, strings.Join(parts, " | "))
+	}
+
+	if len(items) == 0 {
+		return "", nil
+	}
+
+	return "## Skills Usage Rules\n" +
+		"- If the user explicitly mentions a skill by name, you MUST call load_skill for that skill before answering.\n" +
+		"- If the user's request is clearly about a listed skill's domain, you MUST load that skill before giving procedural, policy, workflow, or step-by-step guidance.\n" +
+		"- Do not answer from general memory when a relevant listed skill exists but has not been loaded.\n" +
+		"- If the user asks what skills are available, answer from the catalog below instead of giving a generic summary of your broad abilities.\n\n" +
+		"## Skills Catalog\n" +
+		"You have access to the following skills. Do not assume all details are already loaded. If a skill looks relevant, call the load_skill tool to load its full instructions before relying on it.\n\n" +
+		strings.Join(items, "\n"), nil
+}
+
+func LoadSkillPromptContent(owner string, skillName string, referenceName string) (string, error) {
+	s, err := GetSkillByOwnerAndName(owner, skillName)
+	if err != nil {
+		return "", err
+	}
+	if s == nil {
+		return "", fmt.Errorf("skill not found: %s", skillName)
+	}
+	if s.State != "Active" {
+		return "", fmt.Errorf("skill is not active: %s", skillName)
+	}
+
+	buf := strings.TrimSpace(s.Content)
+	if referenceName == "" {
+		if len(s.References) > 0 {
+			refNames := make([]string, 0, len(s.References))
+			for _, ref := range s.References {
+				if strings.TrimSpace(ref.Name) != "" {
+					refNames = append(refNames, ref.Name)
+				}
+			}
+			sort.Strings(refNames)
+			if len(refNames) > 0 {
+				buf += "\n\n## Available References\n"
+				for _, name := range refNames {
+					buf += "- " + name + "\n"
+				}
+			}
+		}
+		return strings.TrimSpace(buf), nil
+	}
+
+	for _, ref := range s.References {
+		if ref.Name == referenceName {
+			if strings.TrimSpace(ref.Content) == "" {
+				return "", fmt.Errorf("reference is empty: %s", referenceName)
+			}
+			if buf != "" {
+				buf += "\n\n"
+			}
+			buf += "## Reference: " + ref.Name + "\n\n" + strings.TrimSpace(ref.Content)
+			return strings.TrimSpace(buf), nil
+		}
+	}
+
+	return "", fmt.Errorf("reference not found: %s", referenceName)
+}
+
+type skillLoader struct{}
+
+func (skillLoader) Load(owner string, allowedSkillNames []string, skillName string, referenceName string) (string, error) {
+	if len(allowedSkillNames) > 0 {
+		skills, err := resolveEnabledSkills(owner, allowedSkillNames)
+		if err != nil {
+			return "", err
+		}
+
+		allowed := false
+		for _, s := range skills {
+			if skillNameMatches(s, skillName) {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			return "", fmt.Errorf("skill is not enabled for this store: %s", skillName)
+		}
+	}
+	return LoadSkillPromptContent(owner, skillName, referenceName)
+}
+
 // GetSkillsContent loads all named skills for a store and concatenates their
 // content (body of SKILL.md, or custom content) into a single string that
 // is appended to the agent's system prompt.
@@ -361,15 +542,7 @@ func GetSkillsContent(owner string, skillNames []string) (string, error) {
 		if s == nil || s.State != "Active" || strings.TrimSpace(s.Content) == "" {
 			continue
 		}
-		// Build effective skill content: the content body, plus any references
-		buf := strings.TrimSpace(s.Content)
-		for _, ref := range s.References {
-			if strings.TrimSpace(ref.Content) == "" {
-				continue
-			}
-			buf += "\n\n## Reference: " + ref.Name + "\n\n" + strings.TrimSpace(ref.Content)
-		}
-		parts = append(parts, buf)
+		parts = append(parts, strings.TrimSpace(s.Content))
 	}
 
 	return strings.Join(parts, "\n\n"), nil

--- a/tool/skill.go
+++ b/tool/skill.go
@@ -1,0 +1,114 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tool
+
+import (
+	"context"
+
+	"github.com/ThinkInAIXYZ/go-mcp/protocol"
+	"github.com/the-open-agent/openagent/tool/builtin_tool"
+)
+
+// SkillLoader loads prompt-ready skill content for one skill and optional reference.
+type SkillLoader interface {
+	Load(owner string, allowedSkillNames []string, skillName string, referenceName string) (string, error)
+}
+
+// SkillTool exposes builtin skill-loading tools. It is configured per-store by
+// directly registering builtins with a bound loader and allowed skill list.
+type SkillTool struct{}
+
+func (t *SkillTool) BuiltinTools() []BuiltinTool {
+	return nil
+}
+
+func NewLoadSkillBuiltin(owner string, allowedSkillNames []string, loader SkillLoader) builtin_tool.BuiltinTool {
+	if owner == "" || loader == nil {
+		return nil
+	}
+	return &loadSkillBuiltin{
+		owner:             owner,
+		allowedSkillNames: allowedSkillNames,
+		loader:            loader,
+	}
+}
+
+type loadSkillBuiltin struct {
+	owner             string
+	allowedSkillNames []string
+	loader            SkillLoader
+}
+
+func (t *loadSkillBuiltin) GetName() string {
+	return "load_skill"
+}
+
+func (t *loadSkillBuiltin) GetDescription() string {
+	return "Load the full instructions for one available skill, and optionally one specific reference file from that skill. Use this after consulting the skills catalog when a skill appears relevant."
+}
+
+func (t *loadSkillBuiltin) GetInputSchema() interface{} {
+	return map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"skill": map[string]interface{}{
+				"type":        "string",
+				"description": "The skill name to load from the current store's available skills catalog.",
+			},
+			"reference": map[string]interface{}{
+				"type":        "string",
+				"description": "Optional reference file name inside the skill to load together with the skill content.",
+			},
+		},
+		"required": []string{"skill"},
+	}
+}
+
+func (t *loadSkillBuiltin) Execute(_ context.Context, arguments map[string]interface{}) (*protocol.CallToolResult, error) {
+	if t.loader == nil || t.owner == "" {
+		return skillToolError("skill loader context is missing"), nil
+	}
+
+	skillName, _ := arguments["skill"].(string)
+	referenceName, _ := arguments["reference"].(string)
+	if skillName == "" {
+		return skillToolError("missing required parameter: skill"), nil
+	}
+
+	content, err := t.loader.Load(t.owner, t.allowedSkillNames, skillName, referenceName)
+	if err != nil {
+		return skillToolError(err.Error()), nil
+	}
+
+	return skillToolText(content), nil
+}
+
+func skillToolText(text string) *protocol.CallToolResult {
+	return &protocol.CallToolResult{
+		IsError: false,
+		Content: []protocol.Content{
+			&protocol.TextContent{Type: "text", Text: text},
+		},
+	}
+}
+
+func skillToolError(text string) *protocol.CallToolResult {
+	return &protocol.CallToolResult{
+		IsError: true,
+		Content: []protocol.Content{
+			&protocol.TextContent{Type: "text", Text: text},
+		},
+	}
+}


### PR DESCRIPTION
## Summary

This PR changes skill injection from full upfront prompt injection to a metadata catalog plus on-demand loading.

Instead of appending full skill content and references to every message prompt, stores now inject a compact skills catalog into the system prompt. The model can then call the new `load_skill` builtin tool to load full skill instructions, and optionally a specific reference file, only when a skill is relevant.

## Changes

- Add a `load_skill` builtin tool for loading enabled skill content on demand
- Inject a compact skill catalog via `GetSkillsCatalog` instead of full skill content
- Register `load_skill` automatically when a store has skills enabled
- Support `All` skill selection consistently for both catalog generation and tool access
- Support both bare skill names and `owner/name` ids in skill access checks
- Keep references out of the initial prompt; expose reference names and load specific references on request

## Notes

Previously, OpenAgent injected all selected skill bodies and all references into the system prompt on every request. This could waste context on irrelevant skills and made large skill sets expensive.

This PR introduces a progressive disclosure model:

1. Always show the model a compact list of available skills
2. Let the model load full instructions only when needed
3. Let references be loaded explicitly rather than injected upfront

<img width="1814" height="1012" alt="image" src="https://github.com/user-attachments/assets/993062a0-9477-4490-b6e8-31edcb02b614" />
<img width="1798" height="1492" alt="image" src="https://github.com/user-attachments/assets/b67e3721-d7db-4c7e-9502-8624ef8ca7a1" />
