### PR TITLE
fix: fix bugs in frontend i18n code

### DIFF
--- a/web2/app/context/AccountContext.tsx
+++ b/web2/app/context/AccountContext.tsx
@@ -3,6 +3,7 @@
 import * as React from "react"
 import { useNavigate } from "react-router"
 import { type Account, getAccount, signout } from "~/backend/AccountBackend"
+import { setLanguage } from "~/i18n"
 
 type AccountState = {
   /** undefined = still loading; null = not signed in; Account = signed in */
@@ -23,7 +24,7 @@ export function AccountProvider({ children }: { children: React.ReactNode }) {
         setAccount(res.data ?? null)
         // Sync language preference from account
         if (res.data?.language) {
-          localStorage.setItem("language", res.data.language)
+          setLanguage(res.data.language)
         }
       } else {
         setAccount(null)

--- a/web2/app/i18n.ts
+++ b/web2/app/i18n.ts
@@ -4,10 +4,9 @@ import { initReactI18next } from "react-i18next"
 import en from "./locales/en/data.json"
 import zh from "./locales/zh/data.json"
 
-export const supportedLanguages = ["en", "zh"] as const
-export type SupportedLanguage = (typeof supportedLanguages)[number]
-
 const LANGUAGE_KEY = "language"
+const supportedLanguages = ["en", "zh"] as const
+type SupportedLanguage = (typeof supportedLanguages)[number]
 
 function toSupportedLanguage(language: string | null | undefined): SupportedLanguage | null {
   if (!language) return null
@@ -17,51 +16,20 @@ function toSupportedLanguage(language: string | null | undefined): SupportedLang
   return null
 }
 
-export function normalizeLanguage(language: string | null | undefined): SupportedLanguage {
-  return toSupportedLanguage(language) ?? "en"
-}
-
-function getStoredLanguage(): SupportedLanguage | null {
-  if (typeof window === "undefined") return null
-  return toSupportedLanguage(window.localStorage.getItem(LANGUAGE_KEY))
-}
-
-function getBrowserLanguage(): SupportedLanguage | null {
-  if (typeof navigator === "undefined") return null
-  const languages = navigator.languages?.length ? navigator.languages : [navigator.language]
-  for (const language of languages) {
-    const supportedLanguage = toSupportedLanguage(language)
-    if (supportedLanguage) return supportedLanguage
-  }
-  return null
-}
-
 function getInitialLanguage(): SupportedLanguage {
-  return getStoredLanguage() ?? getBrowserLanguage() ?? "en"
-}
-
-function persistLanguage(language: SupportedLanguage) {
-  if (typeof window !== "undefined") {
-    window.localStorage.setItem(LANGUAGE_KEY, language)
-  }
+  return "en"
 }
 
 export function getLanguage(): SupportedLanguage {
-  return (
-    toSupportedLanguage(i18n.resolvedLanguage) ??
-    toSupportedLanguage(i18n.language) ??
-    getStoredLanguage() ??
-    "en"
-  )
+  return toSupportedLanguage(i18n.resolvedLanguage) ?? toSupportedLanguage(i18n.language) ?? "en"
 }
 
 export function setLanguage(language: string | null | undefined): SupportedLanguage {
-  const nextLanguage = normalizeLanguage(language)
-  const currentLanguage = toSupportedLanguage(i18n.resolvedLanguage) ?? toSupportedLanguage(i18n.language)
-  persistLanguage(nextLanguage)
-  if (currentLanguage !== nextLanguage) {
-    void i18n.changeLanguage(nextLanguage)
+  const nextLanguage = toSupportedLanguage(language) ?? "en"
+  if (typeof window !== "undefined") {
+    window.localStorage.setItem(LANGUAGE_KEY, nextLanguage)
   }
+  void i18n.changeLanguage(nextLanguage)
   return nextLanguage
 }
 

--- a/web2/app/i18n.ts
+++ b/web2/app/i18n.ts
@@ -17,7 +17,12 @@ function toSupportedLanguage(language: string | null | undefined): SupportedLang
 }
 
 function getInitialLanguage(): SupportedLanguage {
-  return "en"
+  if (typeof window === "undefined") return "en"
+
+  const storedLanguage = toSupportedLanguage(window.localStorage.getItem(LANGUAGE_KEY))
+  if (storedLanguage) return storedLanguage
+
+  return toSupportedLanguage(window.navigator.language) ?? "en"
 }
 
 export function getLanguage(): SupportedLanguage {

--- a/web2/app/i18n.ts
+++ b/web2/app/i18n.ts
@@ -1,23 +1,75 @@
 import i18n from "i18next"
 import { initReactI18next } from "react-i18next"
 
-// Locales are loaded once at module initialisation time (client bundle only).
-// SSR falls back to "en" since localStorage is unavailable server-side.
-let initialLanguage = "en"
-if (typeof localStorage !== "undefined") {
-  const stored = localStorage.getItem("language")
-  if (stored === "zh") initialLanguage = "zh"
-}
-
-// Lazily imported so the JSON does not bloat the SSR bundle
 import en from "./locales/en/data.json"
 import zh from "./locales/zh/data.json"
 
+export const supportedLanguages = ["en", "zh"] as const
+export type SupportedLanguage = (typeof supportedLanguages)[number]
+
+const LANGUAGE_KEY = "language"
+
+function toSupportedLanguage(language: string | null | undefined): SupportedLanguage | null {
+  if (!language) return null
+  const normalized = language.toLowerCase()
+  if (normalized === "zh" || normalized.startsWith("zh-")) return "zh"
+  if (normalized === "en" || normalized.startsWith("en-")) return "en"
+  return null
+}
+
+export function normalizeLanguage(language: string | null | undefined): SupportedLanguage {
+  return toSupportedLanguage(language) ?? "en"
+}
+
+function getStoredLanguage(): SupportedLanguage | null {
+  if (typeof window === "undefined") return null
+  return toSupportedLanguage(window.localStorage.getItem(LANGUAGE_KEY))
+}
+
+function getBrowserLanguage(): SupportedLanguage | null {
+  if (typeof navigator === "undefined") return null
+  const languages = navigator.languages?.length ? navigator.languages : [navigator.language]
+  for (const language of languages) {
+    const supportedLanguage = toSupportedLanguage(language)
+    if (supportedLanguage) return supportedLanguage
+  }
+  return null
+}
+
+function getInitialLanguage(): SupportedLanguage {
+  return getStoredLanguage() ?? getBrowserLanguage() ?? "en"
+}
+
+function persistLanguage(language: SupportedLanguage) {
+  if (typeof window !== "undefined") {
+    window.localStorage.setItem(LANGUAGE_KEY, language)
+  }
+}
+
+export function getLanguage(): SupportedLanguage {
+  return (
+    toSupportedLanguage(i18n.resolvedLanguage) ??
+    toSupportedLanguage(i18n.language) ??
+    getStoredLanguage() ??
+    "en"
+  )
+}
+
+export function setLanguage(language: string | null | undefined): SupportedLanguage {
+  const nextLanguage = normalizeLanguage(language)
+  const currentLanguage = toSupportedLanguage(i18n.resolvedLanguage) ?? toSupportedLanguage(i18n.language)
+  persistLanguage(nextLanguage)
+  if (currentLanguage !== nextLanguage) {
+    void i18n.changeLanguage(nextLanguage)
+  }
+  return nextLanguage
+}
+
 i18n.use(initReactI18next).init({
-  lng: initialLanguage,
+  lng: getInitialLanguage(),
   resources: { en, zh },
   fallbackLng: "en",
-  supportedLngs: ["en", "zh"],
+  supportedLngs: supportedLanguages,
   keySeparator: false,
   interpolation: { escapeValue: false },
   saveMissing: false,

--- a/web2/app/lib/api.ts
+++ b/web2/app/lib/api.ts
@@ -1,14 +1,10 @@
-import { getLanguage as getI18nLanguage } from "~/i18n"
+import { getLanguage } from "~/i18n"
 
 // Server URL — empty string means same-origin (production); localhost gets the backend port
 export const ServerUrl =
   typeof window !== "undefined" && window.location.hostname === "localhost"
     ? `http://${window.location.hostname}:14000`
     : ""
-
-export function getLanguage(): string {
-  return getI18nLanguage()
-}
 
 export function getAcceptLanguage(): string {
   const lang = getLanguage()
@@ -49,11 +45,11 @@ export async function handleFetchResponse(res: Response): Promise<any> {
 export function apiFetch(path: string, init?: RequestInit): Promise<any> {
   return fetch(`${ServerUrl}${path}`, {
     credentials: "include",
+    ...init,
     headers: {
       "Accept-Language": getAcceptLanguage(),
       ...init?.headers,
     },
-    ...init,
   }).then(handleFetchResponse)
 }
 

--- a/web2/app/lib/api.ts
+++ b/web2/app/lib/api.ts
@@ -1,3 +1,5 @@
+import { getLanguage as getI18nLanguage } from "~/i18n"
+
 // Server URL — empty string means same-origin (production); localhost gets the backend port
 export const ServerUrl =
   typeof window !== "undefined" && window.location.hostname === "localhost"
@@ -5,8 +7,7 @@ export const ServerUrl =
     : ""
 
 export function getLanguage(): string {
-  if (typeof localStorage === "undefined") return "en"
-  return localStorage.getItem("language") ?? "en"
+  return getI18nLanguage()
 }
 
 export function getAcceptLanguage(): string {


### PR DESCRIPTION
## Summary
- Add shared `getLanguage()` and `setLanguage()` helpers for web2 i18n runtime state
- Keep initial language behavior aligned with the existing web UI: localStorage first, then browser language, then English
- Sync account language through the shared i18n setter
- Make API `Accept-Language` use the current i18n language
- Fix `apiFetch()` header merging so caller headers do not drop `Accept-Language`