### PR TITLE
fix: detach message generation from SSE clients

### DIFF
--- a/authz/authz.go
+++ b/authz/authz.go
@@ -62,6 +62,7 @@ p, anonymous, *, /api/get-video
 p, anonymous, *, /api/get-messages
 p, anonymous, *, /api/delete-welcome-message
 p, anonymous, *, /api/get-message-answer
+p, anonymous, *, /api/cancel-message-answer
 p, anonymous, *, /api/get-answer
 p, anonymous, *, /api/get-storage-providers
 p, anonymous, *, /api/get-store

--- a/controllers/message_answer.go
+++ b/controllers/message_answer.go
@@ -16,6 +16,7 @@ package controllers
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -40,17 +41,101 @@ import (
 // @router /get-message-answer [get]
 func (c *ApiController) GetMessageAnswer() {
 	id := c.Input().Get("id")
+	_, signedIn := c.CheckSignedIn()
+
+	message, err := object.GetMessage(id)
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+	if message != nil {
+		ok := c.IsCurrentUser(message.User)
+		if !ok {
+			return
+		}
+	}
 
 	c.Ctx.ResponseWriter.Header().Set("Content-Type", "text/event-stream")
 	c.Ctx.ResponseWriter.Header().Set("Cache-Control", "no-cache")
 	c.Ctx.ResponseWriter.Header().Set("Connection", "keep-alive")
 
-	c.generateMessageAnswer(id, c.Ctx.ResponseWriter, c.Ctx.Request.Host)
+	job := messageAnswerJobs.getOrStart(id, c.Ctx.Request.Host, c.GetAcceptLanguage(), signedIn)
+	streamMessageAnswerJob(c.Ctx.ResponseWriter, c.Ctx.Request, job)
+}
+
+// CancelMessageAnswer
+// @Title CancelMessageAnswer
+// @Tag Message API
+// @Description cancel a running message answer job
+// @Param id query string true "The id of message"
+// @Success 200 {object} controllers.Response The Response object
+// @router /cancel-message-answer [post]
+func (c *ApiController) CancelMessageAnswer() {
+	id := c.Input().Get("id")
+
+	message, err := object.GetMessage(id)
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+	if message == nil {
+		c.ResponseError(fmt.Sprintf("The message: %s is not found", id))
+		return
+	}
+	ok := c.IsCurrentUser(message.User)
+	if !ok {
+		return
+	}
+
+	messageAnswerJobs.cancel(id)
+	c.ResponseOk()
 }
 
 func (c *ApiController) generateMessageAnswer(id string, responseWriter http.ResponseWriter, host string) {
 	_, signedIn := c.CheckSignedIn()
 	generateMessageAnswer(id, responseWriter, host, c.GetAcceptLanguage(), signedIn, c.ResponseError)
+}
+
+func streamMessageAnswerJob(responseWriter http.ResponseWriter, request *http.Request, job *messageAnswerJob) {
+	replay, ch, unsubscribe, done := job.subscribe()
+	defer unsubscribe()
+
+	for _, chunk := range replay {
+		if _, err := responseWriter.Write(chunk); err != nil {
+			return
+		}
+		if flusher, ok := responseWriter.(http.Flusher); ok {
+			flusher.Flush()
+		}
+	}
+
+	if done {
+		return
+	}
+
+	var notify <-chan struct{}
+	if request != nil {
+		notify = request.Context().Done()
+	}
+
+	for {
+		select {
+		case chunk, ok := <-ch:
+			if !ok {
+				return
+			}
+			if _, err := responseWriter.Write(chunk); err != nil {
+				return
+			}
+			if flusher, ok := responseWriter.(http.Flusher); ok {
+				flusher.Flush()
+			}
+		case <-notify:
+			if notify != nil {
+				return
+			}
+		}
+	}
 }
 
 func generateMessageAnswer(id string, responseWriter http.ResponseWriter, host string, lang string, signedIn bool, responseError func(string, ...interface{})) {
@@ -308,6 +393,9 @@ func generateMessageAnswer(id string, responseWriter http.ResponseWriter, host s
 		}
 	}
 	if err != nil {
+		if errors.Is(err, errMessageAnswerCanceled) {
+			return
+		}
 		if strings.Contains(err.Error(), "write tcp") {
 			if responseError != nil {
 				responseError(err.Error())
@@ -336,6 +424,9 @@ func generateMessageAnswer(id string, responseWriter http.ResponseWriter, host s
 
 		_, err = writer.ResponseWriter.Write([]byte(fmt.Sprintf("event: message\ndata: %s\n\n", jsonData)))
 		if err != nil {
+			if errors.Is(err, errMessageAnswerCanceled) {
+				return
+			}
 			responseErrorStream(message, err.Error())
 			return
 		}

--- a/controllers/message_answer_job.go
+++ b/controllers/message_answer_job.go
@@ -1,0 +1,231 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/the-open-agent/openagent/object"
+)
+
+const messageAnswerJobRetention = 5 * time.Minute
+
+var errMessageAnswerCanceled = errors.New("message answer canceled")
+
+var messageAnswerJobs = newMessageAnswerJobManager()
+
+type messageAnswerJobManager struct {
+	mu   sync.Mutex
+	jobs map[string]*messageAnswerJob
+}
+
+func newMessageAnswerJobManager() *messageAnswerJobManager {
+	return &messageAnswerJobManager{
+		jobs: map[string]*messageAnswerJob{},
+	}
+}
+
+func (m *messageAnswerJobManager) getOrStart(id string, host string, lang string, signedIn bool) *messageAnswerJob {
+	m.mu.Lock()
+	if job, ok := m.jobs[id]; ok {
+		m.mu.Unlock()
+		return job
+	}
+	m.mu.Unlock()
+
+	job := newMessageAnswerJob(id)
+	if message, err := object.GetMessage(id); err != nil {
+		job.appendChunk([]byte(fmt.Sprintf("event: myerror\ndata: %s\n\n", err.Error())))
+		job.finish()
+		return job
+	} else if message != nil && message.Text != "" {
+		jsonData, err := ConvertMessageDataToJSON(message.Text)
+		if err != nil {
+			job.appendChunk([]byte(fmt.Sprintf("event: myerror\ndata: %s\n\n", err.Error())))
+		} else {
+			job.appendChunk([]byte(fmt.Sprintf("event: message\ndata: %s\n\n", jsonData)))
+			job.appendChunk([]byte("event: end\ndata: end\n\n"))
+		}
+		job.finish()
+		return job
+	}
+
+	m.mu.Lock()
+	if existing, ok := m.jobs[id]; ok {
+		m.mu.Unlock()
+		return existing
+	}
+	m.jobs[id] = job
+	m.mu.Unlock()
+
+	go func() {
+		defer job.finish()
+		generateMessageAnswer(id, job.writer, host, lang, signedIn, nil)
+	}()
+
+	return job
+}
+
+func (m *messageAnswerJobManager) cancel(id string) bool {
+	m.mu.Lock()
+	job, ok := m.jobs[id]
+	m.mu.Unlock()
+	if !ok {
+		return false
+	}
+
+	job.cancel()
+	return true
+}
+
+func (m *messageAnswerJobManager) remove(id string, job *messageAnswerJob) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if current, ok := m.jobs[id]; ok && current == job {
+		delete(m.jobs, id)
+	}
+}
+
+type messageAnswerJob struct {
+	id     string
+	writer *messageAnswerJobWriter
+
+	mu          sync.Mutex
+	chunks      [][]byte
+	subscribers map[chan []byte]struct{}
+	done        bool
+	canceled    bool
+}
+
+func newMessageAnswerJob(id string) *messageAnswerJob {
+	job := &messageAnswerJob{
+		id:          id,
+		subscribers: map[chan []byte]struct{}{},
+	}
+	job.writer = &messageAnswerJobWriter{
+		header: http.Header{},
+		job:    job,
+	}
+	return job
+}
+
+func (j *messageAnswerJob) appendChunk(p []byte) {
+	data := append([]byte(nil), p...)
+
+	j.mu.Lock()
+	defer j.mu.Unlock()
+
+	j.chunks = append(j.chunks, data)
+	for ch := range j.subscribers {
+		select {
+		case ch <- data:
+		default:
+			close(ch)
+			delete(j.subscribers, ch)
+		}
+	}
+}
+
+func (j *messageAnswerJob) subscribe() ([][]byte, <-chan []byte, func(), bool) {
+	ch := make(chan []byte, 256)
+
+	j.mu.Lock()
+	replay := make([][]byte, 0, len(j.chunks))
+	for _, chunk := range j.chunks {
+		replay = append(replay, append([]byte(nil), chunk...))
+	}
+	done := j.done
+	if !done {
+		j.subscribers[ch] = struct{}{}
+	}
+	j.mu.Unlock()
+
+	unsubscribe := func() {
+		j.mu.Lock()
+		if _, ok := j.subscribers[ch]; ok {
+			delete(j.subscribers, ch)
+			close(ch)
+		}
+		j.mu.Unlock()
+	}
+
+	return replay, ch, unsubscribe, done
+}
+
+func (j *messageAnswerJob) finish() {
+	j.mu.Lock()
+	if j.done {
+		j.mu.Unlock()
+		return
+	}
+
+	j.done = true
+	for ch := range j.subscribers {
+		close(ch)
+		delete(j.subscribers, ch)
+	}
+	j.mu.Unlock()
+
+	time.AfterFunc(messageAnswerJobRetention, func() {
+		messageAnswerJobs.remove(j.id, j)
+	})
+}
+
+func (j *messageAnswerJob) cancel() {
+	j.mu.Lock()
+	if j.done || j.canceled {
+		j.mu.Unlock()
+		return
+	}
+	j.canceled = true
+	j.mu.Unlock()
+
+	j.appendChunk([]byte("event: end\ndata: canceled\n\n"))
+	j.finish()
+}
+
+type messageAnswerJobWriter struct {
+	header http.Header
+	job    *messageAnswerJob
+	status int
+}
+
+func (w *messageAnswerJobWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *messageAnswerJobWriter) WriteHeader(statusCode int) {
+	w.status = statusCode
+}
+
+func (w *messageAnswerJobWriter) Write(p []byte) (int, error) {
+	if w.job != nil {
+		w.job.mu.Lock()
+		canceled := w.job.canceled
+		w.job.mu.Unlock()
+		if canceled {
+			return 0, errMessageAnswerCanceled
+		}
+		w.job.appendChunk(p)
+	}
+	return len(p), nil
+}
+
+func (w *messageAnswerJobWriter) Flush() {}

--- a/routers/authz_filter.go
+++ b/routers/authz_filter.go
@@ -41,7 +41,7 @@ func isAllowedInDemoMode(method string, urlPath string) bool {
 		return true
 	}
 
-	if strings.HasPrefix(urlPath, "/api/signin") || urlPath == "/api/signout" || urlPath == "/api/add-chat" || urlPath == "/api/add-message" || urlPath == "/api/update-message" || urlPath == "/api/delete-welcome-message" || urlPath == "/api/generate-text-to-speech-audio" || urlPath == "/api/add-node-tunnel" || urlPath == "/api/start-connection" || urlPath == "/api/stop-connection" || urlPath == "/api/commit-record" || urlPath == "/api/commit-record-second" || urlPath == "/api/update-chat" || urlPath == "/api/delete-chat" {
+	if strings.HasPrefix(urlPath, "/api/signin") || urlPath == "/api/signout" || urlPath == "/api/add-chat" || urlPath == "/api/add-message" || urlPath == "/api/update-message" || urlPath == "/api/delete-welcome-message" || urlPath == "/api/cancel-message-answer" || urlPath == "/api/generate-text-to-speech-audio" || urlPath == "/api/add-node-tunnel" || urlPath == "/api/start-connection" || urlPath == "/api/stop-connection" || urlPath == "/api/commit-record" || urlPath == "/api/commit-record-second" || urlPath == "/api/update-chat" || urlPath == "/api/delete-chat" {
 		return true
 	}
 

--- a/routers/router.go
+++ b/routers/router.go
@@ -145,6 +145,7 @@ func initAPI() {
 	beego.Router("/api/get-messages", &controllers.ApiController{}, "GET:GetMessages")
 	beego.Router("/api/get-message", &controllers.ApiController{}, "GET:GetMessage")
 	beego.Router("/api/get-message-answer", &controllers.ApiController{}, "GET:GetMessageAnswer")
+	beego.Router("/api/cancel-message-answer", &controllers.ApiController{}, "POST:CancelMessageAnswer")
 	beego.Router("/api/get-answer", &controllers.ApiController{}, "GET:GetAnswer")
 	beego.Router("/api/update-message", &controllers.ApiController{}, "POST:UpdateMessage")
 	beego.Router("/api/add-message", &controllers.ApiController{}, "POST:AddMessage")

--- a/web/src/ChatPage.js
+++ b/web/src/ChatPage.js
@@ -238,7 +238,7 @@ class ChatPage extends BaseListPage {
     if (this.state.messages && this.state.messages.length > 0) {
       const lastMessage = this.state.messages[this.state.messages.length - 1];
       if (lastMessage.author === "AI" && this.state.messageLoading) {
-        MessageBackend.closeMessageEventSource(lastMessage.owner, lastMessage.name);
+        MessageBackend.closeMessageEventSource(lastMessage.owner, lastMessage.name, true);
 
         MessageBackend.updateMessage(lastMessage.owner, lastMessage.name, lastMessage)
           .then((res) => {

--- a/web/src/backend/MessageBackend.js
+++ b/web/src/backend/MessageBackend.js
@@ -142,15 +142,31 @@ export function updateMessage(owner, name, message, isHitOnly = false) {
   }).then(res => Setting.handleFetchResponse(res));
 }
 
-export function closeMessageEventSource(owner, name) {
+export function closeMessageEventSource(owner, name, cancel = false) {
   const key = `${owner}/${name}`;
   if (eventSourceMap.has(key)) {
     const eventSource = eventSourceMap.get(key);
     eventSource.close();
     eventSourceMap.delete(key);
+    if (cancel) {
+      cancelMessageAnswer(owner, name).catch(() => {});
+    }
     return true;
   }
+  if (cancel) {
+    cancelMessageAnswer(owner, name).catch(() => {});
+  }
   return false;
+}
+
+export function cancelMessageAnswer(owner, name) {
+  return fetch(`${Setting.ServerUrl}/api/cancel-message-answer?id=${owner}/${encodeURIComponent(name)}`, {
+    method: "POST",
+    credentials: "include",
+    headers: {
+      "Accept-Language": Setting.getAcceptLanguage(),
+    },
+  }).then(res => Setting.handleFetchResponse(res));
 }
 
 export function addMessage(message) {

--- a/web/src/common/ChatWidget.js
+++ b/web/src/common/ChatWidget.js
@@ -369,7 +369,7 @@ class ChatWidget extends React.Component {
     if (this.state.messages && this.state.messages.length > 0) {
       const lastMessage = this.state.messages[this.state.messages.length - 1];
       if (lastMessage.author === "AI" && this.state.messageLoading) {
-        MessageBackend.closeMessageEventSource(lastMessage.owner, lastMessage.name);
+        MessageBackend.closeMessageEventSource(lastMessage.owner, lastMessage.name, true);
 
         MessageBackend.updateMessage(lastMessage.owner, lastMessage.name, lastMessage)
           .then((res) => {


### PR DESCRIPTION
## Summary

This PR decouples message answer generation from individual SSE client connections.

Previously, `/api/get-message-answer` generated the AI response directly inside the request handler, so refreshing the page or closing the SSE connection could interrupt the backend generation. This change introduces an in-memory message answer job manager so generation continues independently, while SSE clients can subscribe, reconnect, and replay buffered chunks from the same job.

## Changes

- Add an in-memory message answer job manager for active/completed message answer streams.
- Allow refreshed or reconnected SSE clients to attach to an existing generation job.
- Replay buffered SSE chunks for reconnecting clients.
- Add `/api/cancel-message-answer` for explicit user cancellation.
- Keep page refresh/client disconnect separate from cancellation.
- Add ownership checks for answer streaming and cancellation.
- Add auth/demo-mode allowlist entries for the cancel endpoint.

## Notes

- Completed jobs are retained briefly in memory to support reconnect/replay.
- Cancellation is cooperative: generation stops when the writer observes the cancel state.