### PR TITLE
fix: translate web2 layout shell

### DIFF
--- a/web2/app/components/layout/AppHeader.tsx
+++ b/web2/app/components/layout/AppHeader.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import { Link, useLocation, useNavigate } from "react-router"
+import { useTranslation } from "react-i18next"
 import { GlobeIcon, LogOutIcon, MoonIcon, SettingsIcon, SunIcon } from "lucide-react"
 import { type Account } from "~/backend/AccountBackend"
 import { getLanguage, setLanguage } from "~/i18n"
@@ -63,9 +64,14 @@ function useBreadcrumbs(pathname: string) {
   }
 
   const last = segments[segments.length - 1]
-  const detailLabel = RESOURCE_LABELS[last] ?? last
+  const detailLabel = RESOURCE_LABELS[last]
 
-  return { listLabel: label, listUrl: `/${root}`, detail: detailLabel }
+  return {
+    listLabel: label,
+    listUrl: `/${root}`,
+    detail: detailLabel ?? last,
+    detailIsResource: Boolean(detailLabel),
+  }
 }
 
 type AppHeaderProps = {
@@ -96,9 +102,10 @@ function useHoverDropdown() {
 export function AppHeader({ account, onSignOut }: AppHeaderProps) {
   const location = useLocation()
   const navigate = useNavigate()
+  const { t } = useTranslation()
   const { theme, toggleTheme } = useTheme()
   const breadcrumbs = useBreadcrumbs(location.pathname)
-  const [lang, setLang] = React.useState(() => getLanguage())
+  const language = getLanguage()
   const langDropdown = useHoverDropdown()
   const accountDropdown = useHoverDropdown()
 
@@ -121,24 +128,26 @@ export function AppHeader({ account, onSignOut }: AppHeaderProps) {
         <Breadcrumb>
           <BreadcrumbList>
             <BreadcrumbItem>
-              <BreadcrumbLink render={<Link to="/" />}>Home</BreadcrumbLink>
+              <BreadcrumbLink render={<Link to="/" />}>{t("general:Home")}</BreadcrumbLink>
             </BreadcrumbItem>
             <BreadcrumbSeparator />
             {breadcrumbs.detail ? (
               <>
                 <BreadcrumbItem>
                   <BreadcrumbLink render={<Link to={breadcrumbs.listUrl} />}>
-                    {breadcrumbs.listLabel}
+                    {t(`general:${breadcrumbs.listLabel}`)}
                   </BreadcrumbLink>
                 </BreadcrumbItem>
                 <BreadcrumbSeparator />
                 <BreadcrumbItem>
-                  <BreadcrumbPage>{breadcrumbs.detail}</BreadcrumbPage>
+                  <BreadcrumbPage>
+                    {breadcrumbs.detailIsResource ? t(`general:${breadcrumbs.detail}`) : breadcrumbs.detail}
+                  </BreadcrumbPage>
                 </BreadcrumbItem>
               </>
             ) : (
               <BreadcrumbItem>
-                <BreadcrumbPage>{breadcrumbs.listLabel}</BreadcrumbPage>
+                <BreadcrumbPage>{t(`general:${breadcrumbs.listLabel}`)}</BreadcrumbPage>
               </BreadcrumbItem>
             )}
           </BreadcrumbList>
@@ -162,10 +171,9 @@ export function AppHeader({ account, onSignOut }: AppHeaderProps) {
                   key={key}
                   onClick={() => {
                     setLanguage(key)
-                    setLang(key as "en" | "zh")
                     langDropdown.setOpen(false)
                   }}
-                  className={lang === key ? "font-medium text-primary" : ""}
+                  className={language === key ? "font-medium text-primary" : ""}
                 >
                   {label}
                 </DropdownMenuItem>
@@ -203,12 +211,12 @@ export function AppHeader({ account, onSignOut }: AppHeaderProps) {
               <DropdownMenuContent align="end" className="w-48">
                 <DropdownMenuItem onClick={() => navigate("/account")}>
                   <SettingsIcon />
-                  My Account
+                  {t("account:My Account")}
                 </DropdownMenuItem>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem onClick={onSignOut} variant="destructive">
                   <LogOutIcon />
-                  Sign Out
+                  {t("account:Sign Out")}
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
@@ -218,7 +226,7 @@ export function AppHeader({ account, onSignOut }: AppHeaderProps) {
             to="/signin"
             className="rounded-md px-3 py-1.5 text-sm font-medium transition-colors hover:bg-accent"
           >
-            Sign In
+            {t("account:Sign In")}
           </Link>
         ) : null}
       </div>

--- a/web2/app/components/layout/AppSidebar.tsx
+++ b/web2/app/components/layout/AppSidebar.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import { NavLink, useLocation } from "react-router"
+import { useTranslation } from "react-i18next"
 import { type Account, isAdminUser, isChatAdminUser } from "~/backend/AccountBackend"
 import {
   BarChart2Icon,
@@ -166,17 +167,19 @@ function getActiveGroupKey(pathname: string): string | null {
 
 function NavGroupItem({ group, defaultOpen }: { group: NavGroup; defaultOpen: boolean }) {
   const location = useLocation()
+  const { t } = useTranslation("general")
   const Icon = group.icon
+  const title = t(group.title)
 
   return (
     <Collapsible defaultOpen={defaultOpen} className="group/collapsible">
       <SidebarMenuItem>
         <SidebarMenuButton
           render={<CollapsibleTrigger className="w-full" />}
-          tooltip={group.title}
+          tooltip={title}
         >
           <Icon className="shrink-0" />
-          <span>{group.title}</span>
+          <span>{title}</span>
           <ChevronRightIcon className="ml-auto shrink-0 transition-transform duration-200 group-data-open/collapsible:rotate-90" />
         </SidebarMenuButton>
         <CollapsibleContent>
@@ -189,7 +192,7 @@ function NavGroupItem({ group, defaultOpen }: { group: NavGroup; defaultOpen: bo
                     render={item.external ? <a href={item.url} target="_blank" rel="noreferrer" /> : <NavLink to={item.url} />}
                     isActive={isActive}
                   >
-                    <span>{item.title}</span>
+                    <span>{t(item.title)}</span>
                   </SidebarMenuSubButton>
                 </SidebarMenuSubItem>
               )
@@ -206,6 +209,7 @@ export function AppSidebar({
   ...props
 }: React.ComponentProps<typeof Sidebar> & { account?: Account }) {
   const location = useLocation()
+  const { t } = useTranslation("general")
   const { theme } = useTheme()
   const { getLogoUrl } = useSite()
   const activeGroupKey = getActiveGroupKey(location.pathname)
@@ -244,11 +248,11 @@ export function AppSidebar({
                 <SidebarMenuItem key={item.url}>
                   <SidebarMenuButton
                     render={<NavLink to={item.url} />}
-                    tooltip={item.title}
+                    tooltip={t(item.title)}
                     isActive={isActive}
                   >
                     <Icon className="shrink-0" />
-                    <span>{item.title}</span>
+                    <span>{t(item.title)}</span>
                   </SidebarMenuButton>
                 </SidebarMenuItem>
               )


### PR DESCRIPTION
## Summary
- Translate web2 sidebar labels and tooltips with existing `general` locale keys
- Translate header breadcrumbs and account menu labels
- Keep breadcrumb detail segments as raw path values unless they are known resource labels
- Simplify the language selector state by reading the current i18n language during render