### PR TITLE
fix: fix New Chat bug in web2

### DIFF
--- a/web2/app/components/chat/ChatMenu.tsx
+++ b/web2/app/components/chat/ChatMenu.tsx
@@ -79,13 +79,8 @@ const ChatMenu = forwardRef<ChatMenuHandle, Props>(function ChatMenu(
   }
 
   function handleAddChat() {
-    if (currentStoreName && stores) {
-      const store = stores.find((s) => s.name === currentStoreName)
-      onAddChat(store)
-    } else {
-      const defaultStore = stores?.find((s) => s.isDefault)
-      onAddChat(defaultStore)
-    }
+    const store = currentStoreName ? stores?.find((s) => s.name === currentStoreName) : undefined
+    onAddChat(store)
   }
 
   return (

--- a/web2/app/routes/ChatPage.tsx
+++ b/web2/app/routes/ChatPage.tsx
@@ -290,20 +290,27 @@ export default function ChatPage() {
       setLoading(false)
       setMessages([])
 
-      if (fetchedChats.length > 0) {
-        let targetChat = chatNameParam
-          ? fetchedChats.find((c) => c.name === chatNameParam)
-          : undefined
-        if (!targetChat) targetChat = fetchedChats[0]
-
-        if (!chatNameParam || !fetchedChats.find((c) => c.name === chatNameParam)) {
-          navigate(generateChatUrl(targetChat.name, targetChat.store), { replace: true })
-        }
-        setChat(targetChat)
-        setDraftStoreName(targetChat.store)
-        loadMessages(targetChat)
+      if (!chatNameParam) {
+        setChat(undefined)
+        setDraftStoreName(storeNameParam)
+        menuRef.current?.clearSelectedKey()
+        fetchStores()
+        return
       }
 
+      const targetChat = fetchedChats.find((c) => c.name === chatNameParam)
+      if (!targetChat) {
+        setChat(undefined)
+        setDraftStoreName(storeNameParam)
+        menuRef.current?.clearSelectedKey()
+        navigate(generateChatUrl(undefined, storeNameParam), { replace: true })
+        fetchStores()
+        return
+      }
+
+      setChat(targetChat)
+      setDraftStoreName(targetChat.store)
+      loadMessages(targetChat)
       fetchStores()
     })
   }, [account?.name, chatNameParam, storeNameParam])
@@ -478,7 +485,7 @@ export default function ChatPage() {
 
   function handleAddChat(store?: Store) {
     inputStore.current.set(chat?.name, inputValue)
-    const sName = store?.name || storeNameParam || defaultStore?.name || ""
+    const sName = store?.name || storeNameParam || ""
     setChat(undefined)
     setMessages([])
     setMessageError(false)


### PR DESCRIPTION
## Summary
- Treat `/chat` and store chat root routes as empty new-chat drafts
- Stop auto-selecting the first existing chat when no chat name is present in the URL
- Keep the New Chat button from redirecting global chat into the default store route