### PR TITLE
fix: sidebar inset overflow with min-w-0

### DIFF
--- a/web2/app/components/ui/sidebar.tsx
+++ b/web2/app/components/ui/sidebar.tsx
@@ -307,7 +307,7 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
     <main
       data-slot="sidebar-inset"
       className={cn(
-        "relative flex w-full flex-1 flex-col bg-background md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
+        "relative flex min-w-0 flex-1 flex-col bg-background md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary

Tables wider than the viewport expanded SidebarInset past the sidebar because it lacked min-w-0. Replace redundant w-full with min-w-0.

<img width="1960" height="1634" alt="image" src="https://github.com/user-attachments/assets/886dfb22-244d-4b4d-8c9c-00722dea6add" />
