### PR TITLE
fix: show action buttons for last message

### DIFF
--- a/web2/app/components/chat/MessageItem.tsx
+++ b/web2/app/components/chat/MessageItem.tsx
@@ -306,7 +306,7 @@ export default function MessageItem({
           </div>
 
           {/* Footer */}
-          {!message.isReasoningPhase && (disableInput === false || !isLastMessage) && (
+          {!message.isReasoningPhase && (!disableInput || !isLastMessage) && (
             <div className="mt-2 flex flex-col gap-2">
               <div className="flex flex-wrap items-center gap-2">
                 <MessageActions


### PR DESCRIPTION
## Summary

`disableInput` is optional (defaults to undefined). The strict check `disableInput === false` was always false for the default case, hiding copy/like/regenerate buttons and suggestions on the last message. This PR changes the check to `!disableInput` to solve it.