### PR TITLE
fix: clean up SSE stream and states on chat switch

### DIFF
--- a/web2/app/routes/ChatPage.tsx
+++ b/web2/app/routes/ChatPage.tsx
@@ -71,6 +71,8 @@ export default function ChatPage() {
   const inputStore = useRef(new Map<string | undefined, string>())
   const streamOwnerRef = useRef("")
   const streamNameRef = useRef("")
+  const inputValueRef = useRef(inputValue)
+  inputValueRef.current = inputValue
 
   const streamAnswer = useMessageStream(setMessages, setMessageLoading, setMessageError)
   const { handleMessageLike, copyMessageText } = useChatMessageHandlers(setMessages)
@@ -235,7 +237,7 @@ export default function ChatPage() {
         streamOwnerRef.current = ""
         streamNameRef.current = ""
       }
-      inputStore.current.set(chat?.name, inputValue)
+      inputStore.current.set(chat?.name, inputValueRef.current)
     }
   }, [chat?.name])
 

--- a/web2/app/routes/ChatPage.tsx
+++ b/web2/app/routes/ChatPage.tsx
@@ -69,6 +69,8 @@ export default function ChatPage() {
   const inputRef = useRef<ChatInputHandle>(null)
   const messageListRef = useRef<HTMLDivElement>(null)
   const inputStore = useRef(new Map<string | undefined, string>())
+  const streamOwnerRef = useRef("")
+  const streamNameRef = useRef("")
 
   const streamAnswer = useMessageStream(setMessages, setMessageLoading, setMessageError)
   const { handleMessageLike, copyMessageText } = useChatMessageHandlers(setMessages)
@@ -128,6 +130,8 @@ export default function ChatPage() {
               setMessageError(true)
               return
             }
+            streamOwnerRef.current = lastMsg.owner
+            streamNameRef.current = lastMsg.name
             streamAnswer(lastMsg, targetChat, {
               userTextForTitle: getFirstUserMessageText(msgs),
               onTitle: updateChatDisplayName,
@@ -223,9 +227,14 @@ export default function ChatPage() {
     fetchChats()
   }, [fetchChats])
 
-  // Save/restore input when chat changes
+  // Clean up stream and save/restore input when chat changes
   useEffect(() => {
     return () => {
+      if (streamOwnerRef.current) {
+        closeMessageEventSource(streamOwnerRef.current, streamNameRef.current)
+        streamOwnerRef.current = ""
+        streamNameRef.current = ""
+      }
       inputStore.current.set(chat?.name, inputValue)
     }
   }, [chat?.name])
@@ -334,6 +343,8 @@ export default function ChatPage() {
     setChat(selected)
     setDraftStoreName(selected.store)
     setMessageError(false)
+    setMessageLoading(false)
+    setFiles([])
     setMobileMenuOpen(false)
     loadMessages(selected)
     navigate(generateChatUrl(selected.name, selected.store), { replace: true })


### PR DESCRIPTION
## Summary

- Track active stream owner/name in refs
- Close EventSource in useEffect cleanup when chat changes
- Reset messageLoading and clear files in handleSelectChat