### PR TITLE
fix: prevent duplicate message send during streaming

### DIFF
--- a/web/app/components/chat/ChatInput.tsx
+++ b/web/app/components/chat/ChatInput.tsx
@@ -74,7 +74,7 @@ const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput(
     el.style.height = Math.min(el.scrollHeight, 200) + "px"
   }, [value])
 
-  const canSend = !messageError && (value.trim() !== "" || files.length > 0) && !disableInput
+  const canSend = !messageError && !loading && (value.trim() !== "" || files.length > 0) && !disableInput
 
   const handleFileUploadClick = useCallback(() => {
     const input = document.createElement("input")


### PR DESCRIPTION
## Summary

The send button was disabled during streaming, but the Enter key still triggered onSend because canSend did not check the loading state. This caused duplicate user messages when pressing Enter while a response was streaming.

Added `!loading` to the canSend condition in ChatInput so that both the Enter key and the send button are gated by the same guard.