### PR TITLE
fix: remove duplicate fields from store edit page

### DIFF
--- a/web/app/routes/StoreEditPage.tsx
+++ b/web/app/routes/StoreEditPage.tsx
@@ -500,23 +500,6 @@ export default function StoreEditPage() {
             </FormField>
           </>
         )}
-        <FormField label={i18next.t("store:Memory limit")} tooltip={i18next.t("store:Memory limit - Tooltip")}>
-          <NumberInput
-            value={store.memoryLimit}
-            onChange={(v) => update("memoryLimit", v)}
-            min={0}
-          />
-        </FormField>
-        {store.enableExtraOptions && (
-          <>
-            <FormField label={i18next.t("store:Frequency")} tooltip={i18next.t("store:Frequency - Tooltip")}>
-              <NumberInput value={store.frequency} onChange={(v) => update("frequency", v)} min={0} />
-            </FormField>
-            <FormField label={i18next.t("store:Limit minutes")} tooltip={i18next.t("store:Limit minutes - Tooltip")}>
-              <NumberInput value={store.limitMinutes} onChange={(v) => update("limitMinutes", v)} min={0} />
-            </FormField>
-          </>
-        )}
       </SectionCard>
 
       {/* Chat */}


### PR DESCRIPTION
## Summary

Memory limit, Frequency, and Limit minutes appeared twice in the store edit page — once in the Providers section and again in the Options section. Both sets bound to the same state, causing user confusion.

Removed the duplicate fields from the Providers section, keeping them only in the Options section where they belong.