### PR TITLE
feat: add global store selector in header

### DIFF
--- a/web/app/components/layout/AppHeader.tsx
+++ b/web/app/components/layout/AppHeader.tsx
@@ -23,6 +23,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "~/components/ui/dropdown-menu"
+import { HeaderStoreSelect } from "~/components/layout/HeaderStoreSelect"
 import { Separator } from "~/components/ui/separator"
 import { SidebarTrigger } from "~/components/ui/sidebar"
 import { useTheme } from "~/hooks/useTheme"
@@ -170,6 +171,8 @@ export function AppHeader({ account, onSignOut }: AppHeaderProps) {
 
       {/* Right side */}
       <div className="ml-auto flex items-center gap-1">
+        <HeaderStoreSelect className="hidden h-8 w-40 md:flex" />
+
         {/* Language switcher */}
         <div onMouseEnter={langDropdown.onMouseEnter} onMouseLeave={langDropdown.onMouseLeave}>
           <DropdownMenu open={langDropdown.open} onOpenChange={langDropdown.setOpen}>

--- a/web/app/components/layout/HeaderStoreSelect.tsx
+++ b/web/app/components/layout/HeaderStoreSelect.tsx
@@ -1,0 +1,106 @@
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { useTranslation } from "react-i18next"
+import { getGlobalStores, type Store } from "~/backend/StoreBackend"
+import { useStoreFilterEnabled } from "~/context/StoreFilterContext"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "~/components/ui/select"
+
+type Props = {
+  className?: string
+}
+
+function getStoredStore(): string {
+  try {
+    return localStorage.getItem("store") || "All"
+  } catch {
+    return "All"
+  }
+}
+
+function setStoredStore(value: string) {
+  try {
+    localStorage.setItem("store", value)
+  } catch {
+    // ignore
+  }
+}
+
+export function HeaderStoreSelect({ className }: Props) {
+  const { t } = useTranslation()
+  const { storeFilterEnabled } = useStoreFilterEnabled()
+  const [stores, setStores] = useState<Store[]>([])
+  const [value, setValue] = useState(getStoredStore)
+
+  const fetchStores = useCallback(() => {
+    getGlobalStores().then((res) => {
+      if (res.status === "ok") {
+        setStores(res.data || [])
+      }
+    })
+  }, [])
+
+  useEffect(() => {
+    fetchStores()
+
+    function onStoresChanged() {
+      fetchStores()
+    }
+
+    window.addEventListener("storesChanged", onStoresChanged)
+
+    function handleStorage(e: StorageEvent) {
+      if (e.key === "store") setValue(getStoredStore())
+    }
+    window.addEventListener("storage", handleStorage)
+
+    return () => {
+      window.removeEventListener("storesChanged", onStoresChanged)
+      window.removeEventListener("storage", handleStorage)
+    }
+  }, [fetchStores])
+
+  const options = useMemo(
+    () => [
+      { name: "All", displayName: t("store:All"), avatar: "" },
+      ...stores,
+    ],
+    [stores, t]
+  )
+
+  function handleChange(nextValue: string | null) {
+    if (!nextValue) return
+    setValue(nextValue)
+    setStoredStore(nextValue)
+    window.dispatchEvent(new Event("globalStoreChanged"))
+  }
+
+  return (
+    <Select value={value} onValueChange={handleChange} disabled={!storeFilterEnabled}>
+      <SelectTrigger className={className ?? "h-8 w-40"}>
+        <SelectValue placeholder={t("store:All")} />
+      </SelectTrigger>
+      <SelectContent align="end">
+        {options.map((store) => (
+          <SelectItem key={store.name} value={store.name}>
+            <span className="flex items-center gap-1.5">
+              {store.avatar ? (
+                <img
+                  src={store.avatar}
+                  alt=""
+                  className="h-4 w-4 rounded object-cover"
+                  onError={(e) => { (e.currentTarget as HTMLImageElement).style.display = "none" }}
+                />
+              ) : null}
+              <span className="truncate">{store.displayName || store.name}</span>
+            </span>
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}

--- a/web/app/context/StoreFilterContext.tsx
+++ b/web/app/context/StoreFilterContext.tsx
@@ -1,0 +1,37 @@
+import { createContext, useContext, useEffect, useState, useCallback, type ReactNode } from "react"
+
+type StoreFilterContextValue = {
+  storeFilterEnabled: boolean
+  setStoreFilterEnabled: (enabled: boolean) => void
+}
+
+const StoreFilterContext = createContext<StoreFilterContextValue>({
+  storeFilterEnabled: false,
+  setStoreFilterEnabled: () => {},
+})
+
+export function StoreFilterProvider({ children }: { children: ReactNode }) {
+  const [enabled, setEnabled] = useState(false)
+
+  const setStoreFilterEnabled = useCallback((v: boolean) => {
+    setEnabled(v)
+  }, [])
+
+  return (
+    <StoreFilterContext.Provider value={{ storeFilterEnabled: enabled, setStoreFilterEnabled }}>
+      {children}
+    </StoreFilterContext.Provider>
+  )
+}
+
+export function useStoreFilterEnabled() {
+  return useContext(StoreFilterContext)
+}
+
+export function useDeclareStoreFilter(enabled: boolean) {
+  const { setStoreFilterEnabled } = useContext(StoreFilterContext)
+  useEffect(() => {
+    setStoreFilterEnabled(enabled)
+    return () => setStoreFilterEnabled(false)
+  }, [enabled, setStoreFilterEnabled])
+}

--- a/web/app/hooks/useStoreFilter.ts
+++ b/web/app/hooks/useStoreFilter.ts
@@ -1,0 +1,34 @@
+import { useCallback, useEffect, useState } from "react"
+
+function readStore(): string | undefined {
+  try {
+    const v = localStorage.getItem("store")
+    return v && v !== "All" ? v : undefined
+  } catch {
+    return undefined
+  }
+}
+
+export function useStoreFilter(): string | undefined {
+  const [store, setStore] = useState(readStore)
+
+  const sync = useCallback(() => {
+    setStore(readStore())
+  }, [])
+
+  useEffect(() => {
+    window.addEventListener("globalStoreChanged", sync)
+
+    function handleStorage(e: StorageEvent) {
+      if (e.key === "store") sync()
+    }
+    window.addEventListener("storage", handleStorage)
+
+    return () => {
+      window.removeEventListener("globalStoreChanged", sync)
+      window.removeEventListener("storage", handleStorage)
+    }
+  }, [sync])
+
+  return store
+}

--- a/web/app/routes/ChatListPage.tsx
+++ b/web/app/routes/ChatListPage.tsx
@@ -16,6 +16,7 @@ import {
 import { getProviders, getProviderLogoUrl, type Provider } from "~/backend/ProviderBackend"
 import { getChatMessages } from "~/backend/MessageBackend"
 import { useAccount } from "~/context/AccountContext"
+import { useStoreFilter } from "~/hooks/useStoreFilter"
 import { getAuthConfig } from "~/lib/AuthConfig"
 import {
   AlertDialog,
@@ -52,6 +53,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "~/components/ui/tooltip"
+import { useDeclareStoreFilter } from "~/context/StoreFilterContext"
 
 export function meta() {
   return [{ title: "Chats - OpenAgent" }]
@@ -132,8 +134,10 @@ function ChatMessagesPreview({ messages }: { messages: Array<{ author: string; t
 }
 
 export default function ChatListPage() {
+  useDeclareStoreFilter(true)
   const navigate = useNavigate()
   const { account } = useAccount()
+  const storeFilter = useStoreFilter()
   const [chats, setChats] = useState<Chat[]>([])
   const [pagination, setPagination] = useState<Pagination>({ current: 1, pageSize: 20, total: 0 })
   const [loading, setLoading] = useState(false)
@@ -174,7 +178,7 @@ export default function ChatListPage() {
       const field = params.field ?? searchField
       const value = params.value ?? searchValue
       setLoading(true)
-      getGlobalChats(current, pageSize, field, value, sf, so, "")
+      getGlobalChats(current, pageSize, field, value, sf, so, storeFilter ?? "")
         .then((res) => {
           setLoading(false)
           if (res.status === "ok") {
@@ -205,7 +209,7 @@ export default function ChatListPage() {
         })
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [account?.name, pagination.current, pagination.pageSize, sortField, sortOrder, searchField, searchValue]
+    [account?.name, pagination.current, pagination.pageSize, sortField, sortOrder, searchField, searchValue, storeFilter]
   )
 
   function fetchMessages(chatName: string) {
@@ -221,7 +225,7 @@ export default function ChatListPage() {
       fetchChats({ current: 1 })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [account?.name])
+  }, [account?.name, storeFilter])
 
   useEffect(() => {
     getProviders("admin", "", "", "10000", "", "", "", "").then((res) => {
@@ -235,7 +239,7 @@ export default function ChatListPage() {
 
   function handleAdd() {
     if (!account) return
-    const chat = newChat(account)
+    const chat = { ...newChat(account), store: storeFilter ?? "" }
     addChat(chat)
       .then((res) => {
         if (res.status === "ok") {
@@ -304,7 +308,7 @@ export default function ChatListPage() {
       const all: Chat[] = []
       let page = 1
       while (all.length < total) {
-        const res = await getGlobalChats(page, pageSize, searchField, searchValue, sortField, sortOrder, "")
+        const res = await getGlobalChats(page, pageSize, searchField, searchValue, sortField, sortOrder, storeFilter ?? "")
         if (res.status !== "ok") {
           toast.error(res.msg)
           return

--- a/web/app/routes/ChatPage.tsx
+++ b/web/app/routes/ChatPage.tsx
@@ -24,6 +24,8 @@ import type { Store } from "~/backend/StoreBackend"
 import { useMessageStream } from "~/hooks/useMessageStream"
 import { useChatMessageHandlers } from "~/hooks/useChatMessageHandlers"
 import { useTts } from "~/hooks/useTts"
+import { useStoreFilter } from "~/hooks/useStoreFilter"
+import { useDeclareStoreFilter } from "~/context/StoreFilterContext"
 
 type UploadedFile = {
   uid: number
@@ -33,6 +35,7 @@ type UploadedFile = {
 }
 
 export default function ChatPage() {
+  useDeclareStoreFilter(true)
   const { t } = useTranslation()
   const navigate = useNavigate()
   const { chatName: chatNameParam, storeName: storeNameParam } = useParams<{
@@ -40,6 +43,14 @@ export default function ChatPage() {
     storeName?: string
   }>()
   const { account } = useAccount()
+  const storeFilter = useStoreFilter()
+
+  useEffect(() => {
+    if (storeNameParam) {
+      try { localStorage.setItem("store", storeNameParam) } catch {}
+      window.dispatchEvent(new Event("globalStoreChanged"))
+    }
+  }, [storeNameParam])
 
   // State
   const [chats, setChats] = useState<Chat[]>([])
@@ -54,7 +65,7 @@ export default function ChatPage() {
     try { return JSON.parse(localStorage.getItem("chatMenuCollapsed") || "false") } catch { return false }
   })
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
-  const [draftStoreName, setDraftStoreName] = useState<string | undefined>(storeNameParam)
+  const [draftStoreName, setDraftStoreName] = useState<string | undefined>(storeFilter)
 
   // Input state (lifted up from ChatBox)
   const [inputValue, setInputValue] = useState("")
@@ -85,7 +96,7 @@ export default function ChatPage() {
   }
 
   function generateChatUrl(cName?: string, sName?: string, owner = "admin"): string {
-    const effectiveSName = sName || storeNameParam
+    const effectiveSName = sName || storeNameParam || storeFilter
     if (!effectiveSName) {
       return cName ? `/chat/${cName}` : "/chat"
     }
@@ -194,8 +205,8 @@ export default function ChatPage() {
     const shouldShowPageLoading = !chatsLoadedRef.current
     if (shouldShowPageLoading) setLoading(true)
 
-    const storeName = storeNameParam || ""
-    getChats(account.name, storeName, -1, -1, "user", account.name).then((res) => {
+    const effectiveStore = (storeNameParam || storeFilter) ?? ""
+    getChats(account.name, effectiveStore, -1, -1, "user", account.name).then((res) => {
       if (res.status !== "ok") {
         chatsLoadedRef.current = true
         setLoading(false)
@@ -211,7 +222,7 @@ export default function ChatPage() {
         latestMessageChatRef.current = ""
         setChat(undefined)
         setMessages([])
-        setDraftStoreName(storeNameParam)
+        setDraftStoreName(storeNameParam || storeFilter)
         menuRef.current?.clearSelectedKey()
         fetchStores()
         return
@@ -222,9 +233,9 @@ export default function ChatPage() {
         latestMessageChatRef.current = ""
         setChat(undefined)
         setMessages([])
-        setDraftStoreName(storeNameParam)
+        setDraftStoreName(storeNameParam || storeFilter)
         menuRef.current?.clearSelectedKey()
-        navigate(generateChatUrl(undefined, storeNameParam), { replace: true })
+        navigate(generateChatUrl(undefined, storeNameParam || storeFilter), { replace: true })
         fetchStores()
         return
       }
@@ -234,7 +245,7 @@ export default function ChatPage() {
       loadMessages(targetChat)
       fetchStores()
     })
-  }, [account?.name, chatNameParam, storeNameParam])
+  }, [account?.name, chatNameParam, storeNameParam, storeFilter])
 
   useEffect(() => {
     fetchChats()
@@ -271,7 +282,7 @@ export default function ChatPage() {
       name: `message_${randomName}`,
       createdTime: new Date().toISOString(),
       organization: account.owner,
-      store: chat?.store || draftStoreName || storeNameParam || defaultStore?.name || "",
+      store: chat?.store || draftStoreName || storeNameParam || storeFilter || defaultStore?.name || "",
       user: account.name,
       chat: chat?.name,
       replyTo: "",
@@ -300,7 +311,7 @@ export default function ChatPage() {
       navigate(generateChatUrl(returnedChat.name, returnedChat.store), { replace: true })
 
       // Refresh chat list
-      getChats(account.name, storeNameParam || "", -1, -1, "user", account.name).then((r) => {
+      getChats(account.name, (storeNameParam || storeFilter) ?? "", -1, -1, "user", account.name).then((r) => {
         if (r.status === "ok") {
           setChats(r.data || [])
           menuRef.current?.setSelectedKeyToChat(r.data || [], returnedChat.name)
@@ -371,7 +382,7 @@ export default function ChatPage() {
   }
 
   function handleAddChat(store?: Store) {
-    const sName = store?.name || storeNameParam || ""
+    const sName = store?.name || storeNameParam || storeFilter || ""
     latestMessageChatRef.current = ""
     setChat(undefined)
     setMessages([])
@@ -446,7 +457,7 @@ export default function ChatPage() {
       onDeleteChat={handleDeleteChat}
       onUpdateChatName={handleUpdateChatName}
       stores={stores}
-      currentStoreName={storeNameParam}
+      currentStoreName={storeNameParam || storeFilter}
     />
   )
 

--- a/web/app/routes/FileListPage.tsx
+++ b/web/app/routes/FileListPage.tsx
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useEffect, useRef, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import { Link, useNavigate } from "react-router"
+import { useStoreFilter } from "~/hooks/useStoreFilter"
 import {
   EditIcon,
   Loader2Icon,
@@ -68,6 +69,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "~/components/ui/tooltip"
+import { useDeclareStoreFilter } from "~/context/StoreFilterContext"
 
 export function meta() {
   return [{ title: "Files — OpenAgent" }]
@@ -86,8 +88,10 @@ function getFormattedSize(size: number | undefined): string {
 type SearchField = "store" | "name" | "filename" | "storageProvider" | "status" | "errorText"
 
 export default function FileListPage() {
+  useDeclareStoreFilter(true)
   const navigate = useNavigate()
   const { account } = useAccount()
+  const storeFilter = useStoreFilter()
   const isAdmin = isLocalAdminUser(account)
 
   const [files, setFiles] = useState<FileItem[]>([])
@@ -104,14 +108,9 @@ export default function FileListPage() {
 
   const fileInputRef = useRef<HTMLInputElement>(null)
 
-  useEffect(() => {
-    fetchFiles()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-
-  function fetchFiles() {
+  const fetchFiles = useCallback(() => {
     setLoading(true)
-    getFiles("admin")
+    getFiles("admin", storeFilter ?? "")
       .then((res) => {
         if (res.status === "ok") {
           const data: FileItem[] = res.data ?? []
@@ -125,7 +124,11 @@ export default function FileListPage() {
       })
       .catch((err: Error) => toast.error(err.message))
       .finally(() => setLoading(false))
-  }
+  }, [storeFilter])
+
+  useEffect(() => {
+    fetchFiles()
+  }, [fetchFiles])
 
   function handleSearch() {
     if (!searchValue.trim()) {
@@ -198,7 +201,8 @@ export default function FileListPage() {
     if (!file) return
     e.target.value = ""
     setUploading(true)
-    uploadFile("admin/store-built-in", file)
+    const storeName = storeFilter || "store-built-in"
+    uploadFile(`admin/${storeName}`, file)
       .then((res) => {
         if (res.status === "ok") {
           toast.success(i18next.t("general:Successfully uploaded"))

--- a/web/app/routes/MessageListPage.tsx
+++ b/web/app/routes/MessageListPage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react"
 import { Link, useNavigate, useSearchParams } from "react-router"
+import { useStoreFilter } from "~/hooks/useStoreFilter"
 import { DownloadIcon, EditIcon, Loader2Icon, PlusIcon, Trash2Icon } from "lucide-react"
 import { toast } from "sonner"
 import i18next from "i18next"
@@ -47,6 +48,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "~/components/ui/tooltip"
+import { useDeclareStoreFilter } from "~/context/StoreFilterContext"
 
 export function meta() {
   return [{ title: "Messages - OpenAgent" }]
@@ -122,9 +124,11 @@ function LongTextCell({ text }: { text?: string | null }) {
 }
 
 export default function MessageListPage() {
+  useDeclareStoreFilter(true)
   const navigate = useNavigate()
   const [searchParams] = useSearchParams()
   const { account } = useAccount()
+  const storeFilter = useStoreFilter()
 
   const [messages, setMessages] = useState<Message[]>([])
   const [pagination, setPagination] = useState<Pagination>({ current: 1, pageSize: 10, total: 0 })
@@ -142,9 +146,6 @@ export default function MessageListPage() {
   const isAdmin = isLocalAdminUser(account)
   const isRealAdmin = account?.name === "admin"
 
-  const storeParam = searchParams.get("store") || ""
-  const storeForApi = storeParam && account ? `${account.owner}/${storeParam}` : ""
-
   const fetchMessages = useCallback(
     (params: {
       current?: number
@@ -161,7 +162,7 @@ export default function MessageListPage() {
       const field = params.field ?? searchField
       const value = params.value ?? searchValue
       setLoading(true)
-      getGlobalMessages(current, pageSize, field, value, sf, so, storeForApi)
+      getGlobalMessages(current, pageSize, field, value, sf, so, storeFilter ?? "")
         .then((res) => {
           setLoading(false)
           if (res.status === "ok") {
@@ -182,7 +183,7 @@ export default function MessageListPage() {
         })
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [pagination.current, pagination.pageSize, sortField, sortOrder, searchField, searchValue, storeForApi]
+    [pagination.current, pagination.pageSize, sortField, sortOrder, searchField, searchValue, storeFilter]
   )
 
   useEffect(() => {
@@ -196,7 +197,7 @@ export default function MessageListPage() {
       fetchMessages({ current: 1 })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [account?.name])
+  }, [account?.name, storeFilter])
 
   useEffect(() => {
     getProviders("admin", "", "", "10000", "", "", "", "").then((res) => {
@@ -224,7 +225,7 @@ export default function MessageListPage() {
       tokenCount: 0,
       textTokenCount: 0,
       price: 0,
-      store: storeForApi,
+      store: storeFilter ?? "",
     }
     addMessage(msg)
       .then((res) => {
@@ -287,7 +288,7 @@ export default function MessageListPage() {
       const all: Message[] = []
       let page = 1
       while (all.length < total) {
-        const res = await getGlobalMessages(page, pageSize, searchField, searchValue, sortField, sortOrder, storeForApi)
+        const res = await getGlobalMessages(page, pageSize, searchField, searchValue, sortField, sortOrder, storeFilter ?? "")
         if (res.status !== "ok") {
           toast.error(res.msg)
           return

--- a/web/app/routes/ProviderListPage.tsx
+++ b/web/app/routes/ProviderListPage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react"
 import { Link, useNavigate } from "react-router"
+import { useStoreFilter } from "~/hooks/useStoreFilter"
 import { EditIcon, Loader2Icon, PlusIcon, Trash2Icon } from "lucide-react"
 import { toast } from "sonner"
 import i18next from "i18next"
@@ -52,6 +53,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "~/components/ui/tooltip"
+import { useDeclareStoreFilter } from "~/context/StoreFilterContext"
 
 export function meta() {
   return [{ title: "Providers - OpenAgent" }]
@@ -143,8 +145,10 @@ function ProviderLogoCell({ provider }: { provider: Provider }) {
 }
 
 export default function ProviderListPage() {
+  useDeclareStoreFilter(true)
   const navigate = useNavigate()
   const { account } = useAccount()
+  const storeFilter = useStoreFilter()
   const [providers, setProviders] = useState<Provider[]>([])
   const [pagination, setPagination] = useState<Pagination>({ current: 1, pageSize: 10, total: 0 })
   const [loading, setLoading] = useState(false)
@@ -174,7 +178,7 @@ export default function ProviderListPage() {
       const field = params.field ?? searchField
       const value = params.value ?? searchValue
       setLoading(true)
-      getProviders(account?.name || "admin", "", String(current), String(pageSize), field, value, sf, so)
+      getProviders(account?.name || "admin", storeFilter ?? "", String(current), String(pageSize), field, value, sf, so)
         .then((res) => {
           setLoading(false)
           if (res.status === "ok") {
@@ -194,13 +198,14 @@ export default function ProviderListPage() {
           toast.error(err.message)
         })
     },
-    [account?.name, pagination, searchField, searchValue, sortField, sortOrder]
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [account?.name, pagination, searchField, searchValue, sortField, sortOrder, storeFilter]
   )
 
   useEffect(() => {
     fetchProviders({ current: 1 })
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [account?.name])
+  }, [account?.name, storeFilter])
 
   function handleAdd() {
     const provider = newProvider(account?.name || "admin")

--- a/web/app/routes/StoreListPage.tsx
+++ b/web/app/routes/StoreListPage.tsx
@@ -200,6 +200,7 @@ export default function StoreListPage() {
       .then((res) => {
         if (res.status === "ok") {
           toast.success(i18next.t("general:Successfully added"))
+          window.dispatchEvent(new Event("storesChanged"))
           navigate(`/stores/${s.owner}/${s.name}`)
         } else {
           toast.error(`${i18next.t("general:Failed to add")}: ${res.msg}`)
@@ -213,6 +214,7 @@ export default function StoreListPage() {
       .then((res) => {
         if (res.status === "ok") {
           toast.success(i18next.t("general:Successfully deleted"))
+          window.dispatchEvent(new Event("storesChanged"))
           setStores((prev) => prev.filter((s) => s.name !== store.name))
           setPagination((p) => ({ ...p, total: Math.max(0, p.total - 1) }))
         } else {

--- a/web/app/routes/UsagePage.tsx
+++ b/web/app/routes/UsagePage.tsx
@@ -14,6 +14,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { Link } from "react-router"
+import { useStoreFilter } from "~/hooks/useStoreFilter"
 import {
   Bar,
   BarChart,
@@ -66,6 +67,7 @@ import {
   TableRow,
 } from "~/components/ui/table"
 import { useTheme } from "~/hooks/useTheme"
+import { useDeclareStoreFilter } from "~/context/StoreFilterContext"
 
 export function meta() {
   return [{ title: "Usages - OpenAgent" }]
@@ -541,6 +543,8 @@ function UsageTable({ data, isAdmin, loading }: {
 // ── Main Page ──────────────────────────────────────────────────────────────────
 
 export default function UsagePage() {
+  useDeclareStoreFilter(true)
+  const storeFilter = useStoreFilter()
   const { account } = useAccount()
   const { theme } = useTheme()
   const isDark = theme === "dark"
@@ -579,7 +583,7 @@ export default function UsagePage() {
     setRangeUsagesWeek(null)
     setRangeUsagesMonth(null)
 
-    getUsages("", user, 30).then((res) => {
+    getUsages(storeFilter ?? "", user, 30).then((res) => {
       if (res.status === "ok") {
         setUsages(res.data ?? [])
         setUsageMetadata(res.data2 ?? null)
@@ -595,15 +599,16 @@ export default function UsagePage() {
       ["Month", setRangeUsagesMonth],
     ]
     for (const [rt, setter] of rangeSetters) {
-      getRangeUsages(rt, getCountFromRangeType(rt as RangeType), "", user).then((res) => {
+      getRangeUsages(rt, getCountFromRangeType(rt as RangeType), storeFilter ?? "", user).then((res) => {
         if (res.status === "ok") setter(res.data ?? [])
       })
     }
-  }, [])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [storeFilter])
 
   const fetchTableInfo = useCallback((user: string, accountName: string) => {
     setTableLoading(true)
-    getUserTableInfos("", accountName).then((res) => {
+    getUserTableInfos(storeFilter ?? "", accountName).then((res) => {
       setTableLoading(false)
       if (res.status === "ok") {
         const data: UserTableInfo[] = res.data ?? []
@@ -613,7 +618,8 @@ export default function UsagePage() {
         toast.error(`${i18next.t("general:Failed to get")}: ${res.msg}`)
       }
     }).catch(() => setTableLoading(false))
-  }, [])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [storeFilter])
 
   const fetchProviderAndHeatmap = useCallback((owner: string) => {
     getUsageProviders(owner).then((res) => {
@@ -625,26 +631,31 @@ export default function UsagePage() {
   }, [])
 
   useEffect(() => {
-    if (!account || initialized.current) return
-    initialized.current = true
-
+    if (!account) return
     const accountName = account.name
     const owner = account.owner ?? "admin"
 
-    getUsers(accountName, "").then((res) => {
-      if (res.status === "ok") {
-        const userList: string[] = res.data ?? []
-        setUsers(userList)
-        const initUser = isAdmin ? "All" : (userList[0] ?? "All")
-        setSelectedUser(initUser)
-        fetchAllUsageData(initUser)
-        fetchTableInfo(initUser, accountName)
-        fetchProviderAndHeatmap(owner)
-      } else {
-        toast.error(`${i18next.t("general:Failed to get")}: ${res.msg}`)
-      }
-    })
-  }, [account, isAdmin, fetchAllUsageData, fetchTableInfo, fetchProviderAndHeatmap])
+    if (!initialized.current) {
+      initialized.current = true
+      getUsers(accountName, "").then((res) => {
+        if (res.status === "ok") {
+          const userList: string[] = res.data ?? []
+          setUsers(userList)
+          const initUser = isAdmin ? "All" : (userList[0] ?? "All")
+          setSelectedUser(initUser)
+          fetchAllUsageData(initUser)
+          fetchTableInfo(initUser, accountName)
+        } else {
+          toast.error(`${i18next.t("general:Failed to get")}: ${res.msg}`)
+        }
+      })
+      fetchProviderAndHeatmap(owner)
+    } else {
+      fetchAllUsageData(selectedUser)
+      fetchTableInfo(selectedUser, accountName)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [account, storeFilter])
 
   function handleUserChange(value: string) {
     setSelectedUser(value)

--- a/web/app/routes/VectorListPage.tsx
+++ b/web/app/routes/VectorListPage.tsx
@@ -14,6 +14,7 @@
 
 import { useCallback, useEffect, useState } from "react"
 import { Link, useNavigate } from "react-router"
+import { useStoreFilter } from "~/hooks/useStoreFilter"
 import { EditIcon, Loader2Icon, PlusIcon, SearchIcon, Trash2Icon, TriangleAlertIcon } from "lucide-react"
 import { toast } from "sonner"
 import i18next from "i18next"
@@ -58,6 +59,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "~/components/ui/tooltip"
+import { useDeclareStoreFilter } from "~/context/StoreFilterContext"
 
 export function meta() {
   return [{ title: "Vectors — OpenAgent" }]
@@ -73,7 +75,7 @@ function newVector(): Vector {
     name: `vector_${rand}`,
     createdTime: new Date().toISOString(),
     displayName: `New Vector - ${rand}`,
-    store: "store-built-in",
+    store: "",
     file: "/aaa/openagent.txt",
     text: "The text of vector",
     data: [0.1, 0.2, 0.3],
@@ -87,7 +89,9 @@ function getShortText(text: string, maxLen: number): string {
 }
 
 export default function VectorListPage() {
+  useDeclareStoreFilter(true)
   const navigate = useNavigate()
+  const storeFilter = useStoreFilter()
   const [vectors, setVectors] = useState<Vector[]>([])
   const [pagination, setPagination] = useState<Pagination>({ current: 1, pageSize: 10, total: 0 })
   const [loading, setLoading] = useState(false)
@@ -116,7 +120,7 @@ export default function VectorListPage() {
       const field = params.field ?? searchField
       const value = params.value ?? searchValue
       setLoading(true)
-      getVectors("admin", "", String(current), String(pageSize), field, value, sf, so)
+      getVectors("admin", storeFilter ?? "", String(current), String(pageSize), field, value, sf, so)
         .then((res) => {
           if (res.status === "ok") {
             setVectors(res.data ?? [])
@@ -132,16 +136,16 @@ export default function VectorListPage() {
         .catch((err: Error) => toast.error(err.message))
         .finally(() => setLoading(false))
     },
-    [pagination, searchField, searchValue, sortField, sortOrder]
+    [pagination, searchField, searchValue, sortField, sortOrder, storeFilter]
   )
 
   useEffect(() => {
     fetchVectors({ current: 1 })
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [storeFilter])
 
   function handleAdd() {
-    const v = newVector()
+    const v = { ...newVector(), store: storeFilter || "store-built-in" }
     addVector(v)
       .then((res) => {
         if (res.status === "ok") {

--- a/web/app/routes/_layout.tsx
+++ b/web/app/routes/_layout.tsx
@@ -3,6 +3,7 @@ import { Navigate, Outlet } from "react-router"
 import { useTranslation } from "react-i18next"
 
 import { AccountProvider, useAccount } from "~/context/AccountContext"
+import { StoreFilterProvider } from "~/context/StoreFilterContext"
 import { AppFooter } from "~/components/layout/AppFooter"
 import { AppHeader } from "~/components/layout/AppHeader"
 import { AppSidebar } from "~/components/layout/AppSidebar"
@@ -53,7 +54,9 @@ function LayoutInner() {
 export default function AppLayout() {
   return (
     <AccountProvider>
-      <LayoutInner />
+      <StoreFilterProvider>
+        <LayoutInner />
+      </StoreFilterProvider>
     </AccountProvider>
   )
 }


### PR DESCRIPTION
Migrate the global store selector from the old frontend to new. The old frontend's StoreSelect component persists the selected store to localStorage and notifies the app via DOM events, so the store filter stays consistent across all pages and auto-refreshes when stores are added or deleted.

This PR ports the same behavior:

- HeaderStoreSelect: dropdown in the header matching old frontend's StoreSelect — localStorage-backed, cross-component event notification
- useStoreFilter: shared hook for all list pages, matching old frontend's BaseListPage store filtering pattern
- All list pages (Chat, Message, Vector, Provider, Usage, File): unified store filtering via the shared hook
- StoreListPage: dispatches store list change events on add/delete so the header dropdown stays in sync

<img width="752" height="290" alt="image" src="https://github.com/user-attachments/assets/923c34d7-e64f-44b7-9885-73d4c777925c" />
