### PR TITLE
feat: fix auto chat titles with user-message fallback

### DIFF
--- a/carrier/title.go
+++ b/carrier/title.go
@@ -14,7 +14,25 @@
 
 package carrier
 
-import "strings"
+import (
+	"regexp"
+	"strings"
+)
+
+const (
+	// TitleDivider separates the model answer body from the generated chat title.
+	TitleDivider = "====="
+	// FallbackTitleMaxRunes is the maximum length of a fallback title derived from the user's first message.
+	FallbackTitleMaxRunes = 16
+	// MaxChatDisplayNameRunes matches object.Chat.DisplayName varchar(100).
+	MaxChatDisplayNameRunes = 100
+)
+
+var (
+	htmlTagRegexp        = regexp.MustCompile(`(?is)<[^>]+>`)
+	whitespaceRegexp     = regexp.MustCompile(`\s+`)
+	suggestionLeakRegexp = regexp.MustCompile(`\|\|\|`)
+)
 
 type TitleCarrier struct {
 	divider   string
@@ -22,7 +40,12 @@ type TitleCarrier struct {
 }
 
 func NewTitleCarrier(needTitle bool) (*TitleCarrier, error) {
-	return &TitleCarrier{divider: "=====", needTitle: needTitle}, nil
+	return &TitleCarrier{divider: TitleDivider, needTitle: needTitle}, nil
+}
+
+// HasTitleDivider reports whether the streamed answer already contains a title suffix.
+func HasTitleDivider(answer string) bool {
+	return strings.Contains(answer, TitleDivider)
 }
 
 func (p *TitleCarrier) GetQuestion(question string) (string, error) {
@@ -32,12 +55,12 @@ func (p *TitleCarrier) GetQuestion(question string) (string, error) {
 
 	format := "<title>"
 	question = question +
-		"\n\n**At the end of your answer, if and only if a clear, concise, and meaningful topic title can be generated — based on both the user's input and your response — then append it.**\n" +
+		"\n\n**At the end of your answer, you MUST append a clear, concise, and meaningful topic title based on both the user's input and your response.**\n" +
 		"A meaningful topic title should be able to represent the user's purpose or the overall theme of this conversation.\n" +
 		"Examples of generated title:\n" +
 		"\tquery: what is openagent? title: introduction to openagent\n" +
 		"It should appear at the very end of the response, prefixed by: " + p.divider + "\n" +
-		"Do not include the divider or title if a meaningful title cannot be generated.\n" +
+		"Only skip the divider and title when the user's message is completely empty.\n" +
 		"Format:\n<Your complete answer>\n" + p.divider + format + "\n"
 
 	return question, nil
@@ -54,7 +77,75 @@ func (p *TitleCarrier) ParseAnswer(answer string) (string, []string, error) {
 	}
 
 	parsedAnswer := parts[0]
-	title := strings.TrimSpace(parts[1])
+	title := normalizeAITitle(parts[1])
 
 	return parsedAnswer, []string{title}, nil
+}
+
+// ResolveChatTitle prefers the AI-generated title and falls back to a truncated user message.
+func ResolveChatTitle(aiTitle, userMessage string) string {
+	aiTitle = normalizeAITitle(aiTitle)
+	if aiTitle != "" {
+		return truncateRunes(aiTitle, MaxChatDisplayNameRunes, false)
+	}
+
+	fallback := FallbackTitleFromUserMessage(userMessage, FallbackTitleMaxRunes)
+	return truncateRunes(fallback, MaxChatDisplayNameRunes, false)
+}
+
+// FallbackTitleFromUserMessage builds a sidebar title from the first user message when the model omits one.
+func FallbackTitleFromUserMessage(text string, maxRunes int) string {
+	if maxRunes <= 0 {
+		maxRunes = FallbackTitleMaxRunes
+	}
+	text = SanitizeUserMessageForTitle(text)
+	if text == "" {
+		return ""
+	}
+	return truncateRunes(text, maxRunes, true)
+}
+
+// SanitizeUserMessageForTitle strips markup and collapses whitespace for title fallback input.
+// The tag regex is intentionally simple: user messages rarely contain complex HTML, and
+// attributes with ">" inside quoted values are a known limitation.
+func SanitizeUserMessageForTitle(text string) string {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return ""
+	}
+
+	text = htmlTagRegexp.ReplaceAllString(text, " ")
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+	text = strings.ReplaceAll(text, "\n", " ")
+	text = whitespaceRegexp.ReplaceAllString(text, " ")
+	return strings.TrimSpace(text)
+}
+
+func normalizeAITitle(title string) string {
+	title = strings.TrimSpace(title)
+	if title == "" {
+		return ""
+	}
+	if idx := strings.IndexAny(title, "\r\n"); idx >= 0 {
+		title = title[:idx]
+	}
+	if suggestionLeakRegexp.MatchString(title) {
+		title = suggestionLeakRegexp.Split(title, 2)[0]
+	}
+	return strings.TrimSpace(title)
+}
+
+func truncateRunes(text string, maxRunes int, withEllipsis bool) string {
+	if maxRunes <= 0 || text == "" {
+		return ""
+	}
+
+	runes := []rune(text)
+	if len(runes) <= maxRunes {
+		return text
+	}
+	if withEllipsis && maxRunes > 1 {
+		return string(runes[:maxRunes-1]) + "…"
+	}
+	return string(runes[:maxRunes])
 }

--- a/carrier/title.go
+++ b/carrier/title.go
@@ -43,11 +43,6 @@ func NewTitleCarrier(needTitle bool) (*TitleCarrier, error) {
 	return &TitleCarrier{divider: TitleDivider, needTitle: needTitle}, nil
 }
 
-// HasTitleDivider reports whether the streamed answer already contains a title suffix.
-func HasTitleDivider(answer string) bool {
-	return strings.Contains(answer, TitleDivider)
-}
-
 func (p *TitleCarrier) GetQuestion(question string) (string, error) {
 	if !p.needTitle {
 		return question, nil

--- a/controllers/message_answer.go
+++ b/controllers/message_answer.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/beego/beego/context"
+	"github.com/the-open-agent/openagent/carrier"
 	"github.com/the-open-agent/openagent/conf"
 	"github.com/the-open-agent/openagent/embedding"
 	"github.com/the-open-agent/openagent/i18n"
@@ -434,14 +435,14 @@ func generateMessageAnswer(id string, responseWriter http.ResponseWriter, host s
 
 	fmt.Printf("]\n")
 
-	event := fmt.Sprintf("event: end\ndata: %s\n\n", "end")
-	_, err = responseWriter.Write([]byte(event))
-	if err != nil {
-		responseErrorStream(message, err.Error())
-		return
-	}
-
 	answer := writer.MessageString()
+	defer func() {
+		event := fmt.Sprintf("event: end\ndata: %s\n\n", "end")
+		_, _ = responseWriter.Write([]byte(event))
+		if flusher, ok := responseWriter.(http.Flusher); ok {
+			flusher.Flush()
+		}
+	}()
 	message.ReasonText = writer.ReasonString()
 	message.ToolCalls = model.GetToolCallsFromWriter(writer.ToolString())
 	searchString := writer.SearchString()
@@ -505,9 +506,18 @@ func generateMessageAnswer(id string, responseWriter http.ResponseWriter, host s
 		chat.ModelProvider = modelProvider.Name
 	}
 
-	if chat.NeedTitle && textTitle != "" {
-		chat.DisplayName = textTitle
-		chat.NeedTitle = false
+	emitChatUpdate := false
+	if chat.NeedTitle {
+		userTextForTitle := question
+		if firstUserText, firstErr := object.GetFirstUserMessageText(chat.Name); firstErr == nil && strings.TrimSpace(firstUserText) != "" {
+			userTextForTitle = firstUserText
+		}
+		resolvedTitle := carrier.ResolveChatTitle(textTitle, userTextForTitle)
+		if resolvedTitle != "" {
+			chat.DisplayName = resolvedTitle
+			chat.NeedTitle = false
+			emitChatUpdate = true
+		}
 	}
 
 	if questionMessage != nil {
@@ -521,6 +531,13 @@ func generateMessageAnswer(id string, responseWriter http.ResponseWriter, host s
 	if err != nil {
 		responseErrorStream(message, err.Error())
 		return
+	}
+
+	if emitChatUpdate {
+		if err := writeChatUpdateStream(responseWriter, chat); err != nil {
+			responseErrorStream(message, err.Error())
+			return
+		}
 	}
 
 	object.StartExperienceReview(object.ExperienceReviewRequest{

--- a/controllers/message_answer.go
+++ b/controllers/message_answer.go
@@ -438,7 +438,9 @@ func generateMessageAnswer(id string, responseWriter http.ResponseWriter, host s
 	answer := writer.MessageString()
 	defer func() {
 		event := fmt.Sprintf("event: end\ndata: %s\n\n", "end")
-		_, _ = responseWriter.Write([]byte(event))
+		if _, writeErr := responseWriter.Write([]byte(event)); writeErr != nil {
+			fmt.Printf("write end SSE event failed: %s\n", writeErr.Error())
+		}
 		if flusher, ok := responseWriter.(http.Flusher); ok {
 			flusher.Flush()
 		}

--- a/controllers/message_carrier.go
+++ b/controllers/message_carrier.go
@@ -139,7 +139,7 @@ A meaningful topic title should be able to represent the user's purpose or the o
 Examples of generated title:
 	query: what is openagent? title: introduction to openagent
 - The title must start with "=====" (five equals signs, no space).
-- Do not include the divider or title if a meaningful title cannot be generated.
+- You MUST output a title unless the user's message is completely empty.
 - Do NOT include any explanations or extra text—just output the title.`)
 	}
 

--- a/controllers/message_util.go
+++ b/controllers/message_util.go
@@ -77,6 +77,31 @@ func writeInfoStream(responseWriter http.ResponseWriter, infoText string) error 
 	return nil
 }
 
+func writeChatUpdateStream(responseWriter http.ResponseWriter, chat *object.Chat) error {
+	if chat == nil {
+		return nil
+	}
+
+	payload, err := json.Marshal(map[string]interface{}{
+		"owner":       chat.Owner,
+		"name":        chat.Name,
+		"displayName": chat.DisplayName,
+		"needTitle":   chat.NeedTitle,
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = responseWriter.Write([]byte(fmt.Sprintf("event: chat\ndata: %s\n\n", payload)))
+	if err != nil {
+		return err
+	}
+	if flusher, ok := responseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
+	return nil
+}
+
 func (c *ApiController) ResponseErrorStream(message *object.Message, errorText string) {
 	if err := writeMessageErrorStream(c.Ctx.ResponseWriter, c.GetAcceptLanguage(), message, errorText); err != nil {
 		c.ResponseError(err.Error())

--- a/object/message.go
+++ b/object/message.go
@@ -115,6 +115,23 @@ func GetChatMessages(chat string) ([]*Message, error) {
 	return messages, nil
 }
 
+// GetFirstUserMessageText returns the earliest non-hidden user message in a chat.
+func GetFirstUserMessageText(chatName string) (string, error) {
+	message := &Message{}
+	has, err := adapter.engine.Where("chat = ? AND author != ? AND is_hidden = ?", chatName, "AI", false).
+		Asc("created_time").
+		Limit(1, 0).
+		Get(message)
+	if err != nil {
+		return "", err
+	}
+	if !has || message == nil {
+		return "", nil
+	}
+
+	return strings.TrimSpace(message.Text), nil
+}
+
 func GetMessages(owner string, user string, storeName string) ([]*Message, error) {
 	messages := []*Message{}
 	err := adapter.engine.Desc("created_time").Find(&messages, &Message{Owner: owner, User: user, Store: storeName})

--- a/web/src/ChatPage.js
+++ b/web/src/ChatPage.js
@@ -28,6 +28,7 @@ import * as MessageBackend from "./backend/MessageBackend";
 import i18next from "i18next";
 import BaseListPage from "./BaseListPage";
 import {MessageCarrier} from "./chat/MessageCarrier";
+import {getFirstUserMessageText} from "./carrier/titleUtils";
 
 class ChatPage extends BaseListPage {
   constructor(props) {
@@ -328,6 +329,7 @@ class ChatPage extends BaseListPage {
               return;
             }
             const mssageCarrier = new MessageCarrier(chat.needTitle);
+            const userTextForTitle = getFirstUserMessageText(res.data);
             MessageBackend.getMessageAnswer(lastMessage.owner, lastMessage.name, (data) => {
               const jsonData = JSON.parse(data);
 
@@ -337,9 +339,9 @@ class ChatPage extends BaseListPage {
               const currentMessage = res.data[res.data.length - 1];
               const lastMessage2 = Setting.deepCopy(currentMessage);
               text += jsonData.text;
-              const parsedResult = mssageCarrier.parseAnswerWithCarriers(text);
+              const parsedResult = mssageCarrier.parseAnswerWithCarriers(text, userTextForTitle);
               this.updateChatDisplayName(parsedResult.title, chat);
-              if (!chat || (this.state.chat.name !== chat.name)) {
+              if (!chat || (this.state.chat?.name !== chat.name)) {
                 return;
               }
               lastMessage2.text = parsedResult.finalAnswer;
@@ -359,7 +361,7 @@ class ChatPage extends BaseListPage {
                 messageError: false,
               });
             }, (data) => {
-              if (!chat || (this.state.chat.name !== chat.name)) {
+              if (!chat || (this.state.chat?.name !== chat.name)) {
                 return;
               }
               const jsonData = JSON.parse(data);
@@ -387,7 +389,7 @@ class ChatPage extends BaseListPage {
               });
             }, (data) => {
               // onTool callback (handles both tool-start and tool-complete events)
-              if (!chat || (this.state.chat.name !== chat.name)) {
+              if (!chat || (this.state.chat?.name !== chat.name)) {
                 return;
               }
               const jsonData = JSON.parse(data);
@@ -434,7 +436,7 @@ class ChatPage extends BaseListPage {
               });
             }, (data) => {
               // onSearch callback
-              if (!chat || (this.state.chat.name !== chat.name)) {
+              if (!chat || (this.state.chat?.name !== chat.name)) {
                 return;
               }
               const searchResults = JSON.parse(data);
@@ -448,7 +450,7 @@ class ChatPage extends BaseListPage {
                 messages: res.data,
               });
             }, (data) => {
-              if (!chat || (this.state.chat.name !== chat.name)) {
+              if (!chat || (this.state.chat?.name !== chat.name)) {
                 return;
               }
               const vectorScores = JSON.parse(data);
@@ -475,7 +477,7 @@ class ChatPage extends BaseListPage {
                 messageError: true,
               });
             }, (data) => {
-              if (!chat || (this.state.chat.name !== chat.name)) {
+              if (!chat || (this.state.chat?.name !== chat.name)) {
                 return;
               }
               const lastMessage2 = Setting.deepCopy(lastMessage);
@@ -505,11 +507,12 @@ class ChatPage extends BaseListPage {
               // We're no longer in reasoning phase
               lastMessage2.isReasoningPhase = false;
               // If there are suggestions or title , split them from the text
-              const parsedResult = mssageCarrier.parseAnswerWithCarriers(text);
+              const parsedResult = mssageCarrier.parseAnswerWithCarriers(text, userTextForTitle);
               text = parsedResult.finalAnswer;
               if (parsedResult.title !== "") {
                 chat.displayName = parsedResult.title;
                 chat.needTitle = false;
+                this.updateChatDisplayName(parsedResult.title, chat);
               }
               lastMessage2.text = parsedResult.finalAnswer;
               lastMessage2.suggestions = parsedResult.suggestionArray;
@@ -537,7 +540,7 @@ class ChatPage extends BaseListPage {
                 }
               }
             }, (infoText) => {
-              if (!chat || (this.state.chat.name !== chat.name)) {
+              if (!chat || (this.state.chat?.name !== chat.name)) {
                 return;
               }
               const currentMessage = res.data[res.data.length - 1];
@@ -545,6 +548,11 @@ class ChatPage extends BaseListPage {
               lastMessage2.hintText = infoText;
               res.data[res.data.length - 1] = lastMessage2;
               this.setState({messages: res.data});
+            }, (update) => {
+              if (!chat || update?.name !== chat.name || !update.displayName) {
+                return;
+              }
+              this.updateChatDisplayName(update.displayName, {...chat, needTitle: update.needTitle ?? false});
             });
           } else {
             this.setState({
@@ -563,7 +571,12 @@ class ChatPage extends BaseListPage {
       const index = updatedChats.findIndex(c => c.name === chat.name);
       if (index !== -1) {
         updatedChats[index].displayName = title;
-        this.setState({data: updatedChats});
+        updatedChats[index].needTitle = false;
+        const nextState = {data: updatedChats};
+        if (this.state.chat?.name === chat.name) {
+          nextState.chat = {...this.state.chat, displayName: title, needTitle: false};
+        }
+        this.setState(nextState);
       }
     }
   }

--- a/web/src/MultiPaneManager.js
+++ b/web/src/MultiPaneManager.js
@@ -24,6 +24,7 @@ import * as MessageBackend from "./backend/MessageBackend";
 import * as ProviderBackend from "./backend/ProviderBackend";
 import i18next from "i18next";
 import {MessageCarrier} from "./chat/MessageCarrier";
+import {getFirstUserMessageText} from "./carrier/titleUtils";
 
 const {TextArea} = Input;
 
@@ -134,6 +135,7 @@ const MultiPaneManager = ({
     }
 
     const messageCarrier = new MessageCarrier(chat.needTitle);
+    const userTextForTitle = getFirstUserMessageText(messages);
 
     MessageBackend.getMessageAnswer(
       lastMessage.owner,
@@ -144,7 +146,7 @@ const MultiPaneManager = ({
 
         const lastMessage2 = Setting.deepCopy(lastMessage);
         text += jsonData.text;
-        const parsedResult = messageCarrier.parseAnswerWithCarriers(text);
+        const parsedResult = messageCarrier.parseAnswerWithCarriers(text, userTextForTitle);
 
         if (parsedResult.title) {
           const updatedChat = {...chat, displayName: parsedResult.title, needTitle: false};
@@ -254,7 +256,7 @@ const MultiPaneManager = ({
           finalMessage.vectorScores = messages[messages.length - 1].vectorScores;
         }
 
-        const parsedResult = messageCarrier.parseAnswerWithCarriers(text);
+        const parsedResult = messageCarrier.parseAnswerWithCarriers(text, userTextForTitle);
         if (parsedResult.title) {
           const updatedChat = {...chat, displayName: parsedResult.title, needTitle: false};
           setPanes(prev => prev.map((pane, i) =>
@@ -275,6 +277,16 @@ const MultiPaneManager = ({
           i === paneIndex ? {...pane, messages: [...messages]} : pane
         ));
         setLoadingForPane(paneIndex, false);
+      },
+      null,
+      (update) => {
+        if (!update?.displayName || update.name !== chat.name) {
+          return;
+        }
+        const updatedChat = {...chat, displayName: update.displayName, needTitle: update.needTitle ?? false};
+        setPanes(prev => prev.map((pane, i) =>
+          i === paneIndex ? {...pane, chat: updatedChat} : pane
+        ));
       }
     );
   }, [setLoadingForPane]);

--- a/web/src/backend/MessageBackend.js
+++ b/web/src/backend/MessageBackend.js
@@ -46,7 +46,7 @@ export function getChatMessages(owner, chat) {
 
 const eventSourceMap = new Map();
 
-export function getMessageAnswer(owner, name, onMessage, onReason, onTool, onSearch, onVector, onError, onEnd, onInfo) {
+export function getMessageAnswer(owner, name, onMessage, onReason, onTool, onSearch, onVector, onError, onEnd, onInfo, onChat) {
   if (eventSourceMap.has(`${owner}/${name}`)) {
     return;
   }
@@ -84,6 +84,16 @@ export function getMessageAnswer(owner, name, onMessage, onReason, onTool, onSea
   if (onInfo) {
     eventSource.addEventListener("myinfo", (e) => {
       onInfo(e.data);
+    });
+  }
+
+  if (onChat) {
+    eventSource.addEventListener("chat", (e) => {
+      try {
+        onChat(JSON.parse(e.data));
+      } catch {
+        // ignore malformed chat events
+      }
     });
   }
 

--- a/web/src/carrier/TitleCarrier.js
+++ b/web/src/carrier/TitleCarrier.js
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {normalizeAITitle} from "./titleUtils";
+
 export class TitleCarrier {
   constructor(needTitle) {
     this.needTitle = needTitle;
@@ -28,11 +30,11 @@ export class TitleCarrier {
     }
 
     const parsedAnswer = parts[0];
-    const title = parts[1];
+    const title = normalizeAITitle(parts[1]);
 
     return {
       parsedAnswer,
-      title: title,
+      title,
     };
   };
 }

--- a/web/src/carrier/titleUtils.js
+++ b/web/src/carrier/titleUtils.js
@@ -1,0 +1,86 @@
+// Copyright 2025 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export const FALLBACK_TITLE_MAX_RUNES = 16;
+export const MAX_CHAT_DISPLAY_NAME_RUNES = 100;
+
+const HTML_TAG_RE = /<[^>]+>/gi;
+const WHITESPACE_RE = /\s+/g;
+const SUGGESTION_LEAK_RE = /\|\|\|/;
+
+export function sanitizeUserMessageForTitle(text) {
+  let value = (text || "").trim();
+  if (!value) {
+    return "";
+  }
+
+  value = value.replace(HTML_TAG_RE, " ");
+  value = value.replace(/\r\n/g, "\n").replace(/\n/g, " ");
+  value = value.replace(WHITESPACE_RE, " ").trim();
+  return value;
+}
+
+export function normalizeAITitle(title) {
+  let value = (title || "").trim();
+  if (!value) {
+    return "";
+  }
+
+  const lineBreak = value.search(/[\r\n]/);
+  if (lineBreak >= 0) {
+    value = value.slice(0, lineBreak).trim();
+  }
+  if (SUGGESTION_LEAK_RE.test(value)) {
+    value = value.split(SUGGESTION_LEAK_RE, 1)[0].trim();
+  }
+  return value.trim();
+}
+
+export function truncateRunes(text, maxRunes, withEllipsis) {
+  if (maxRunes <= 0 || !text) {
+    return "";
+  }
+
+  const runes = Array.from(text);
+  if (runes.length <= maxRunes) {
+    return text;
+  }
+  if (withEllipsis && maxRunes > 1) {
+    return `${runes.slice(0, maxRunes - 1).join("")}…`;
+  }
+  return runes.slice(0, maxRunes).join("");
+}
+
+export function fallbackTitleFromUserMessage(text, maxRunes = FALLBACK_TITLE_MAX_RUNES) {
+  const sanitized = sanitizeUserMessageForTitle(text);
+  if (!sanitized) {
+    return "";
+  }
+  return truncateRunes(sanitized, maxRunes, true);
+}
+
+export function resolveChatTitle(aiTitle, userMessage) {
+  const normalized = normalizeAITitle(aiTitle);
+  if (normalized) {
+    return truncateRunes(normalized, MAX_CHAT_DISPLAY_NAME_RUNES, false);
+  }
+  return truncateRunes(fallbackTitleFromUserMessage(userMessage), MAX_CHAT_DISPLAY_NAME_RUNES, false);
+}
+
+export function getFirstUserMessageText(messages) {
+  const message = (messages || []).find(
+    (item) => item.author !== "AI" && !item.isHidden && (item.text || "").trim() !== ""
+  );
+  return message?.text || "";
+}

--- a/web/src/chat/MessageCarrier.js
+++ b/web/src/chat/MessageCarrier.js
@@ -14,6 +14,7 @@
 
 import {SuggestionCarrier} from "../carrier/SuggestionCarrier";
 import {TitleCarrier} from "../carrier/TitleCarrier";
+import {resolveChatTitle} from "../carrier/titleUtils";
 
 export class MessageCarrier {
   constructor(needTitle) {
@@ -21,17 +22,15 @@ export class MessageCarrier {
     this.titleCarrier = new TitleCarrier(needTitle);
   }
 
-  parseAnswerWithCarriers = (answer) => {
-    // First extract title
+  parseAnswerWithCarriers = (answer, userMessage = "") => {
     const {parsedAnswer, title} = this.titleCarrier.parseAnswerAndTitle(answer);
 
-    // Then extract suggestions
     const {finalAnswer, suggestionArray} = this.suggestionCarrier.parseAnswerAndSuggestions(parsedAnswer);
 
     return {
       finalAnswer,
       suggestionArray,
-      title,
+      title: resolveChatTitle(title, userMessage),
     };
   };
 }

--- a/web/src/chat/MessageCarrier.js
+++ b/web/src/chat/MessageCarrier.js
@@ -18,6 +18,7 @@ import {resolveChatTitle} from "../carrier/titleUtils";
 
 export class MessageCarrier {
   constructor(needTitle) {
+    this.needTitle = needTitle;
     this.suggestionCarrier = new SuggestionCarrier();
     this.titleCarrier = new TitleCarrier(needTitle);
   }
@@ -30,7 +31,7 @@ export class MessageCarrier {
     return {
       finalAnswer,
       suggestionArray,
-      title: resolveChatTitle(title, userMessage),
+      title: this.needTitle ? resolveChatTitle(title, userMessage) : "",
     };
   };
 }

--- a/web/src/common/ChatWidget.js
+++ b/web/src/common/ChatWidget.js
@@ -21,6 +21,7 @@ import * as ProviderBackend from "../backend/ProviderBackend";
 import i18next from "i18next";
 import ChatBox from "../ChatBox";
 import {MessageCarrier} from "../chat/MessageCarrier";
+import {getFirstUserMessageText} from "../carrier/titleUtils";
 
 /**
  * ChatWidget - A complete chat component with header, model selector, and chat interface
@@ -440,6 +441,7 @@ class ChatWidget extends React.Component {
     }
 
     const messageCarrier = new MessageCarrier(chat.needTitle);
+    const userTextForTitle = getFirstUserMessageText(messages);
 
     MessageBackend.getMessageAnswer(lastMessage.owner, lastMessage.name,
       // onMessage
@@ -450,7 +452,7 @@ class ChatWidget extends React.Component {
         }
         const lastMessage2 = Setting.deepCopy(lastMessage);
         text += jsonData.text;
-        const parsedResult = messageCarrier.parseAnswerWithCarriers(text);
+        const parsedResult = messageCarrier.parseAnswerWithCarriers(text, userTextForTitle);
 
         this.updateChatDisplayName(parsedResult.title, chat);
 
@@ -642,12 +644,13 @@ class ChatWidget extends React.Component {
         }
 
         // Parse the final answer and suggestions
-        const parsedResult = messageCarrier.parseAnswerWithCarriers(text);
+        const parsedResult = messageCarrier.parseAnswerWithCarriers(text, userTextForTitle);
         text = parsedResult.finalAnswer;
 
         if (parsedResult.title !== "") {
           chat.displayName = parsedResult.title;
           chat.needTitle = false;
+          this.updateChatDisplayName(parsedResult.title, chat);
         }
 
         lastMessage2.text = parsedResult.finalAnswer;
@@ -674,6 +677,13 @@ class ChatWidget extends React.Component {
         setTimeout(() => {
           Setting.scrollToDiv(`chatbox-list-item-${updatedMessages.length}`);
         }, 100);
+      },
+      null,
+      (update) => {
+        if (!chat || !update?.displayName || update.name !== chat.name) {
+          return;
+        }
+        this.updateChatDisplayName(update.displayName, {...chat, needTitle: update.needTitle ?? false});
       }
     );
   }
@@ -681,6 +691,7 @@ class ChatWidget extends React.Component {
   updateChatDisplayName(title, chat) {
     if (title !== "" && chat) {
       chat.displayName = title;
+      chat.needTitle = false;
       this.setState({
         currentChat: chat,
       });


### PR DESCRIPTION
## Summary

Port the chat title improvements from #2267 to `master` while Ant Design `web/` remains the default frontend.

When the model omits the `=====` title suffix (common with tool calls), the sidebar no longer stays on "New Chat". The backend resolves a title from the AI output or falls back to the first user message; the legacy `web/` UI listens for SSE `chat` events and applies the same fallback during streaming.

Also fixes a pre-existing crash in `ChatPage.js` where SSE handlers accessed `this.state.chat.name` when `this.state.chat` was undefined.

## Changes

**Backend**
- `carrier/title.go`: `ResolveChatTitle`, `FallbackTitleFromUserMessage`, stronger title prompt
- `object/message.go`: `GetFirstUserMessageText`
- `controllers/message_answer.go`: persist resolved title, emit `event: chat` before `end`
- `controllers/message_util.go`: `writeChatUpdateStream`
- `controllers/message_carrier.go`: require title unless user message is empty

**Frontend (`web/`)**
- `titleUtils.js`, `TitleCarrier.js`, `MessageCarrier.js`: mirror backend fallback rules
- `MessageBackend.js`: handle SSE `chat` events
- `ChatPage.js`, `ChatWidget.js`, `MultiPaneManager.js`: wire streaming title updates

## Test plan

- [ ] Start a new chat with a simple question; confirm the sidebar shows a meaningful title after the first reply
- [ ] Start a chat that triggers Tools; confirm the sidebar no longer stays "New Chat" when the model omits the `=====` title
- [ ] Verify title updates during streaming and via SSE `chat` event
- [ ] Switch chats / open new chat while a stream is active; confirm no runtime error in the console
- [ ] Regression: manual rename, refresh, and chat list title match the database