### PR TITLE
fix: align docker-compose HTTP port and database host

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ yarn start   # Dev server on http://localhost:3000 (proxies API to :14444)
 
 ```bash
 docker-compose up
-# Opens on http://localhost:14444
+# Opens on http://localhost:14000
 ```
 
 ## Making Changes

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ cd web && yarn install && yarn start
 docker-compose up
 ```
 
+Open [http://localhost:14000](http://localhost:14000) once the containers are running.
+
 ---
 
 ## Features

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -146,8 +146,10 @@ func GetConfigDataSourceName() string {
 
 	runningInDocker := os.Getenv("RUNNING_IN_DOCKER")
 	if runningInDocker == "true" {
-		// https://stackoverflow.com/questions/48546124/what-is-linux-equivalent-of-host-docker-internal
-		if runtime.GOOS == "linux" {
+		if dbHost := os.Getenv("DOCKER_DB_HOST"); dbHost != "" {
+			dataSourceName = strings.ReplaceAll(dataSourceName, "localhost", dbHost)
+		} else if runtime.GOOS == "linux" {
+			// https://stackoverflow.com/questions/48546124/what-is-linux-equivalent-of-host-docker-internal
 			dataSourceName = strings.ReplaceAll(dataSourceName, "localhost", "172.17.0.1")
 		} else {
 			dataSourceName = strings.ReplaceAll(dataSourceName, "localhost", "host.docker.internal")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,11 +8,12 @@ services:
       target: STANDARD
     entrypoint: /bin/sh -c './server --createDatabase=true'
     ports:
-      - "8000:8000"
+      - "14000:14000"
     depends_on:
       - db
     environment:
       RUNNING_IN_DOCKER: "true"
+      DOCKER_DB_HOST: db
     volumes:
       - ./conf:/conf/
   db:


### PR DESCRIPTION
## Summary

- Fix Docker Compose port mapping from `8000:8000` to `14000:14000` to match `conf/app.conf` (`httpport = 14000`) and the rest of the project defaults.
- Fix database connectivity in Compose by setting `DOCKER_DB_HOST=db` and teaching `GetConfigDataSourceName()` to use that host instead of rewriting `localhost` to `172.17.0.1`, which does not reach the `db` service on the Compose network.
- Update README and CONTRIBUTING Docker instructions to point users to `http://localhost:14000`.

## Problem

After `docker-compose up`, visiting `http://localhost:8000` failed because the app listens on port `14000` inside the container. Even with a corrected port, MySQL access was unreliable because the app tried to connect via `172.17.0.1` instead of the Compose service name `db`.

## Test plan

- [ ] Run `docker-compose up --build`
- [ ] Open `http://localhost:14000` and confirm the UI loads
- [ ] Confirm the app connects to MySQL and starts without database connection errors
- [ ] Verify standalone Docker / host-MySQL setups still work when `DOCKER_DB_HOST` is not set