### PR TITLE
fix: remove duplicated LLM call in GetAnswer API

### DIFF
--- a/controllers/message_answer.go
+++ b/controllers/message_answer.go
@@ -574,19 +574,6 @@ func (c *ApiController) GetAnswer() {
 		}
 	}
 
-	var answer string
-	var modelResult *model.ModelResult
-	var err error
-	if tool != "" {
-		answer, modelResult, err = object.GetAnswerWithTool(provider, tool, question, c.GetAcceptLanguage())
-	} else {
-		answer, modelResult, err = object.GetAnswer(provider, question, c.GetAcceptLanguage())
-	}
-	if err != nil {
-		c.ResponseError(err.Error())
-		return
-	}
-
 	chat, err := object.GetChat(util.GetId("admin", chatName))
 	if err != nil {
 		c.ResponseError(err.Error())
@@ -622,6 +609,8 @@ func (c *ApiController) GetAnswer() {
 		}
 	}
 
+	var answer string
+	var modelResult *model.ModelResult
 	if tool != "" {
 		answer, modelResult, err = object.GetAnswerWithTool(provider, tool, question, c.GetAcceptLanguage())
 	} else {


### PR DESCRIPTION
## Summary

- Remove the redundant first LLM call in the synchronous `/get-answer` handler (`controllers/message_answer.go`).
- The endpoint previously invoked `GetAnswer` / `GetAnswerWithTool` twice for the same question: once before chat setup and again before persisting messages. Only the second result was used.
- Keep a single model call after chat creation so chat setup failures do not trigger an unnecessary LLM request.

## Impact

- Cuts LLM API cost and latency roughly in half for each `/get-answer` request.
- Token/price accounting now reflects a single model invocation per request.

## Test plan

- [x] `go build -race -ldflags "-extldflags '-static'"` passes locally
- [ ] CI Go tests, linter, and backend build pass
- [ ] Manual: call `/get-answer` once and confirm a single LLM request is made and the answer is persisted correctly