### PR TITLE
fix: wire store list count links to scoped list routes

### DIFF
--- a/web/app/hooks/useStoreFilter.ts
+++ b/web/app/hooks/useStoreFilter.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react"
+import { useParams } from "react-router"
 
 function readStore(): string | undefined {
   try {
@@ -9,12 +10,18 @@ function readStore(): string | undefined {
   }
 }
 
+function storeFromRouteParams(storeName: string | undefined): string | undefined {
+  return storeName && storeName !== "" ? storeName : undefined
+}
+
 export function useStoreFilter(): string | undefined {
-  const [store, setStore] = useState(readStore)
+  const { storeName } = useParams()
+  const routeStore = storeFromRouteParams(storeName)
+  const [store, setStore] = useState(() => routeStore ?? readStore())
 
   const sync = useCallback(() => {
-    setStore(readStore())
-  }, [])
+    setStore(routeStore ?? readStore())
+  }, [routeStore])
 
   useEffect(() => {
     window.addEventListener("globalStoreChanged", sync)

--- a/web/app/routes.ts
+++ b/web/app/routes.ts
@@ -11,6 +11,9 @@ export default [
 
     // Stores
     route("stores", "routes/StoreListPage.tsx"),
+    route("stores/:owner/:storeName/chats", "routes/ChatListPage.tsx", { id: "store-chats-list" }),
+    route("stores/:owner/:storeName/messages", "routes/MessageListPage.tsx", { id: "store-messages-list" }),
+    route("stores/:owner/:storeName/vectors", "routes/VectorListPage.tsx", { id: "store-vectors-list" }),
     route("stores/:owner/:storeName", "routes/StoreEditPage.tsx"),
 
     // Providers


### PR DESCRIPTION
## Summary

- Register missing React Router paths for store-scoped chat, message, and vector list pages (`/stores/:owner/:storeName/chats|messages|vectors`).
- Resolve the active store filter from route `storeName` so those list pages query the correct store instead of only localStorage.

## Problem

On the Data Warehouse (store list) page, the session, message, and vector count links navigate to store-scoped URLs that were never registered after the web2 → web migration, so clicks did not land on a matching route.

## Test plan

- [ ] Open **Stores** and click session count for a store → lands on `/stores/{owner}/{store}/chats` with that store filtered.
- [ ] Click message count → `/stores/{owner}/{store}/messages` with correct data.
- [ ] Click vector count → `/stores/{owner}/{store}/vectors` with correct data.
- [ ] Confirm `CI=false npm run build` in `web/` succeeds (matches frontend CI job).