### PR TITLE
fix: switch store in filetree view

### DIFF
--- a/web/src/FileListPage.js
+++ b/web/src/FileListPage.js
@@ -54,7 +54,7 @@ class FileListPage extends BaseListPage {
     let storeName;
     if (Setting.isDefaultStoreSelected(this.props.account)) {
       try {
-        const res = await StoreBackend.getStore("admin", "_default_store_");
+        const res = await StoreBackend.getDefaultStore();
         if (res.status === "ok" && res.data?.name) {
           storeName = res.data.name;
         } else {

--- a/web/src/FileTreePage.js
+++ b/web/src/FileTreePage.js
@@ -19,12 +19,13 @@ import FileTree from "./FileTree";
 import i18next from "i18next";
 import * as Setting from "./Setting";
 
+const ALL_STORES = "All";
+
 class FileTreePage extends React.Component {
   constructor(props) {
     super(props);
     const routeStore = this.getRouteStore(props);
-    this.storeRequestId = 0;
-    this.storeChangeRequestId = 0;
+    this.requestId = 0;
     this.selectedStoreName = Setting.getStore();
     this.state = {
       classes: props,
@@ -35,47 +36,64 @@ class FileTreePage extends React.Component {
   }
 
   componentDidMount() {
-    this.getStore();
+    this.loadRouteStore();
     window.addEventListener("storeChanged", this.handleStoreChange);
   }
 
   componentDidUpdate(prevProps) {
-    const prevRouteStore = this.getRouteStore(prevProps);
     const routeStore = this.getRouteStore();
-    if (prevRouteStore.owner !== routeStore.owner || prevRouteStore.storeName !== routeStore.storeName) {
-      this.loadStore(routeStore.owner, routeStore.storeName);
+    if (this.getStoreOwner(prevProps) !== routeStore.owner || this.getRouteStoreName(prevProps) !== routeStore.storeName) {
+      this.loadRouteStore(routeStore);
     }
   }
 
   componentWillUnmount() {
-    this.storeRequestId += 1;
-    this.storeChangeRequestId += 1;
+    this.invalidateRequests();
     window.removeEventListener("storeChanged", this.handleStoreChange);
+  }
+
+  getStoreOwner(props = this.props) {
+    return props.match?.params?.owner || props.owner || props.account?.owner || StoreBackend.DEFAULT_STORE_OWNER;
+  }
+
+  getRouteStoreName(props = this.props) {
+    return props.match?.params?.storeName || props.storeName || "";
   }
 
   getRouteStore(props = this.props) {
     return {
-      owner: props.match?.params?.owner || "admin",
-      storeName: props.match?.params?.storeName || props.storeName || "_default_store_",
+      owner: this.getStoreOwner(props),
+      storeName: this.getRouteStoreName(props),
     };
   }
 
   getStore() {
-    const {owner, storeName} = this.getRouteStore();
-    this.loadStore(owner, storeName);
+    this.loadRouteStore();
+  }
+
+  loadRouteStore(routeStore = this.getRouteStore()) {
+    if (routeStore.storeName) {
+      this.loadStore(routeStore.owner, routeStore.storeName);
+      return;
+    }
+    this.loadDefaultStore();
+  }
+
+  invalidateRequests() {
+    this.requestId += 1;
+    return this.requestId;
   }
 
   loadStore(owner, storeName) {
-    const requestId = ++this.storeRequestId;
+    const requestId = this.invalidateRequests();
     this.setState({
       owner: owner,
       storeName: storeName,
-      store: null,
     });
 
     StoreBackend.getStore(owner, storeName)
       .then((res) => {
-        if (requestId !== this.storeRequestId) {
+        if (requestId !== this.requestId) {
           return;
         }
 
@@ -95,6 +113,23 @@ class FileTreePage extends React.Component {
       });
   }
 
+  loadDefaultStore() {
+    const requestId = this.invalidateRequests();
+
+    StoreBackend.getDefaultStore()
+      .then((res) => {
+        if (requestId !== this.requestId) {
+          return;
+        }
+
+        if (res.status === "ok" && res.data) {
+          this.navigateToStore(res.data.owner || this.getStoreOwner(), res.data.name);
+        } else {
+          Setting.showMessage("error", `${i18next.t("general:Failed to get")}: ${res.msg}`);
+        }
+      });
+  }
+
   handleStoreChange = () => {
     const storeName = Setting.getStore();
     if (storeName === this.selectedStoreName) {
@@ -102,25 +137,14 @@ class FileTreePage extends React.Component {
     }
 
     this.selectedStoreName = storeName;
-    const requestId = ++this.storeChangeRequestId;
 
-    if (storeName !== "All") {
-      this.navigateToStore("admin", storeName);
+    if (storeName !== ALL_STORES) {
+      this.invalidateRequests();
+      this.navigateToStore(this.getStoreOwner(), storeName);
       return;
     }
 
-    StoreBackend.getStore("admin", "_default_store_")
-      .then((res) => {
-        if (requestId !== this.storeChangeRequestId) {
-          return;
-        }
-
-        if (res.status === "ok" && res.data) {
-          this.navigateToStore(res.data.owner || "admin", res.data.name);
-        } else {
-          Setting.showMessage("error", `${i18next.t("general:Failed to get")}: ${res.msg}`);
-        }
-      });
+    this.loadDefaultStore();
   };
 
   navigateToStore(owner, storeName) {

--- a/web/src/FileTreePage.js
+++ b/web/src/FileTreePage.js
@@ -22,33 +22,118 @@ import * as Setting from "./Setting";
 class FileTreePage extends React.Component {
   constructor(props) {
     super(props);
+    const routeStore = this.getRouteStore(props);
+    this.storeRequestId = 0;
+    this.storeChangeRequestId = 0;
+    this.selectedStoreName = Setting.getStore();
     this.state = {
       classes: props,
-      owner: props.match?.params?.owner !== undefined ? props.match.params.owner : "admin",
-      storeName: props.match?.params?.storeName !== undefined ? props.match.params.storeName : this.props.storeName,
+      owner: routeStore.owner,
+      storeName: routeStore.storeName,
       store: null,
     };
   }
 
-  UNSAFE_componentWillMount() {
+  componentDidMount() {
     this.getStore();
+    window.addEventListener("storeChanged", this.handleStoreChange);
+  }
+
+  componentDidUpdate(prevProps) {
+    const prevRouteStore = this.getRouteStore(prevProps);
+    const routeStore = this.getRouteStore();
+    if (prevRouteStore.owner !== routeStore.owner || prevRouteStore.storeName !== routeStore.storeName) {
+      this.loadStore(routeStore.owner, routeStore.storeName);
+    }
+  }
+
+  componentWillUnmount() {
+    this.storeRequestId += 1;
+    this.storeChangeRequestId += 1;
+    window.removeEventListener("storeChanged", this.handleStoreChange);
+  }
+
+  getRouteStore(props = this.props) {
+    return {
+      owner: props.match?.params?.owner || "admin",
+      storeName: props.match?.params?.storeName || props.storeName || "_default_store_",
+    };
   }
 
   getStore() {
-    StoreBackend.getStore(this.state.owner, this.state.storeName)
+    const {owner, storeName} = this.getRouteStore();
+    this.loadStore(owner, storeName);
+  }
+
+  loadStore(owner, storeName) {
+    const requestId = ++this.storeRequestId;
+    this.setState({
+      owner: owner,
+      storeName: storeName,
+      store: null,
+    });
+
+    StoreBackend.getStore(owner, storeName)
       .then((res) => {
+        if (requestId !== this.storeRequestId) {
+          return;
+        }
+
         if (res.status === "ok") {
           if (res.data && typeof res.data2 === "string" && res.data2 !== "") {
             res.data.error = res.data2;
           }
 
+          const store = res.data;
           this.setState({
-            store: res.data,
+            store: store,
+            ...(store ? {owner: store.owner, storeName: store.name} : {}),
           });
         } else {
           Setting.showMessage("error", `${i18next.t("general:Failed to get")}: ${res.msg}`);
         }
       });
+  }
+
+  handleStoreChange = () => {
+    const storeName = Setting.getStore();
+    if (storeName === this.selectedStoreName) {
+      return;
+    }
+
+    this.selectedStoreName = storeName;
+    const requestId = ++this.storeChangeRequestId;
+
+    if (storeName !== "All") {
+      this.navigateToStore("admin", storeName);
+      return;
+    }
+
+    StoreBackend.getStore("admin", "_default_store_")
+      .then((res) => {
+        if (requestId !== this.storeChangeRequestId) {
+          return;
+        }
+
+        if (res.status === "ok" && res.data) {
+          this.navigateToStore(res.data.owner || "admin", res.data.name);
+        } else {
+          Setting.showMessage("error", `${i18next.t("general:Failed to get")}: ${res.msg}`);
+        }
+      });
+  };
+
+  navigateToStore(owner, storeName) {
+    if (!storeName) {
+      return;
+    }
+
+    const pathname = `/stores/${owner}/${encodeURIComponent(storeName)}/view`;
+    if (this.props.location?.pathname === pathname) {
+      this.loadStore(owner, storeName);
+    } else {
+      this.props.history.push(pathname);
+    }
   }
 
   render() {

--- a/web/src/HomePage.js
+++ b/web/src/HomePage.js
@@ -34,7 +34,7 @@ class HomePage extends React.Component {
   }
 
   getStore() {
-    StoreBackend.getStore("admin", "_default_store_")
+    StoreBackend.getDefaultStore()
       .then((res) => {
         if (res.status === "ok") {
           if (res.data && typeof res.data2 === "string" && res.data2 !== "") {

--- a/web/src/backend/StoreBackend.js
+++ b/web/src/backend/StoreBackend.js
@@ -14,6 +14,9 @@
 
 import * as Setting from "../Setting";
 
+export const DEFAULT_STORE_OWNER = "admin";
+const DEFAULT_STORE_NAME = "_default_store_";
+
 export function getGlobalStores(name = "", page = "", pageSize = "", field = "", value = "", sortField = "", sortOrder = "") {
   return fetch(`${Setting.ServerUrl}/api/get-global-stores?name=${name}&p=${page}&pageSize=${pageSize}&field=${field}&value=${value}&sortField=${sortField}&sortOrder=${sortOrder}`, {
     method: "GET",
@@ -42,6 +45,10 @@ export function getStore(owner, name) {
       "Accept-Language": Setting.getAcceptLanguage(),
     },
   }).then(res => Setting.handleFetchResponse(res));
+}
+
+export function getDefaultStore() {
+  return getStore(DEFAULT_STORE_OWNER, DEFAULT_STORE_NAME);
 }
 
 export function getStoreNames(owner) {


### PR DESCRIPTION
## Summary

- Make `/stores/:owner/:storeName/view` respond to the top store selector.
- Sync the URL to the selected store's file tree view.
- Resolve `All` to the default store before navigating.