### PR TITLE
fix: fix bugs for chat status indicators

### DIFF
--- a/controllers/chat.go
+++ b/controllers/chat.go
@@ -198,7 +198,7 @@ func (c *ApiController) GetChatStatus() {
 	}
 
 	c.ResponseOk(map[string]bool{
-		"isRead":       chat.IsRead,
+		"isUnread":     chat.IsUnread,
 		"isGenerating": chat.IsGenerating,
 	})
 }

--- a/controllers/message.go
+++ b/controllers/message.go
@@ -408,7 +408,7 @@ func (c *ApiController) AddMessage() {
 				return
 			}
 
-			chat.IsRead = false
+			chat.IsUnread = true
 			chat.IsGenerating = true
 			_, err = object.UpdateChat(chatId, chat)
 			if err != nil {

--- a/main.go
+++ b/main.go
@@ -49,8 +49,8 @@ func main() {
 
 	object.InitDb()
 	object.InitSiteEndpoint()
-	if err := object.ResetGeneratingChats(); err != nil {
-		logs.Warning("Failed to reset generating chats during startup: %v", err)
+	if err := object.ResetChatStatus(); err != nil {
+		logs.Warning("Failed to reset chat status during startup: %v", err)
 	}
 	authz.InitEnforcer()
 	proxy.InitHttpClient()

--- a/object/chat.go
+++ b/object/chat.go
@@ -44,7 +44,7 @@ type Chat struct {
 	Currency      string  `xorm:"varchar(100)" json:"currency"`
 	IsHidden      bool    `json:"isHidden"`
 	IsDeleted     bool    `json:"isDeleted"`
-	IsRead        bool    `json:"isRead"`
+	IsUnread      bool    `json:"isUnread"`
 	IsGenerating  bool    `json:"isGenerating"`
 	NeedTitle     bool    `json:"needTitle"`
 }
@@ -113,13 +113,12 @@ func UpdateChat(id string, chat *Chat) (bool, error) {
 	return true, nil
 }
 
-func ResetGeneratingChats() error {
+func ResetChatStatus() error {
 	_, err := adapter.engine.Where("is_generating = ?", true).Cols("is_generating").Update(&Chat{IsGenerating: false})
 	return err
 }
 
 func AddChat(chat *Chat) (bool, error) {
-	chat.IsRead = true
 	affected, err := adapter.engine.Insert(chat)
 	if err != nil {
 		return false, err

--- a/web/src/App.less
+++ b/web/src/App.less
@@ -39,7 +39,7 @@ img {
   box-shadow: 0 2px 8px 0 rgb(0 0 0 / 8%);
   flex: 1;
   align-items: stretch;
-  margin: 0 3px 3px 3px !important;
+  margin: 0 3px 3px !important;
   border-radius: 12px !important;
   overflow: hidden;
 }
@@ -83,12 +83,12 @@ img {
   transition: background-color 0.15s ease;
 
   &:hover {
-    background-color: rgba(0, 0, 0, 0.05) !important;
+    background-color: rgb(0 0 0 / 5%) !important;
   }
 }
 
 [data-theme="dark"] .select-box:hover {
-  background-color: rgba(255, 255, 255, 0.08) !important;
+  background-color: rgb(255 255 255 / 8%) !important;
 }
 
 .store-select {
@@ -112,12 +112,12 @@ img {
   transition: background-color 0.15s ease;
 
   &:hover {
-    background-color: rgba(0, 0, 0, 0.05) !important;
+    background-color: rgb(0 0 0 / 5%) !important;
   }
 }
 
 [data-theme="dark"] .rightDropDown:hover {
-  background-color: rgba(255, 255, 255, 0.08) !important;
+  background-color: rgb(255 255 255 / 8%) !important;
 }
 
 .cs-conversation-header__content .cs-conversation-header__user-name {
@@ -160,6 +160,23 @@ img {
   color: inherit;
   transition: color 0.3s;
   justify-content: flex-end;
+}
+
+.chat-menu-item {
+  position: relative;
+  padding-inline-start: 40px !important;
+}
+
+.chat-menu-item .chat-status-indicator {
+  position: absolute;
+  inset-inline-start: 1.25em;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1em;
+  pointer-events: none;
 }
 
 .suggestions-item:hover {

--- a/web/src/ChatBox.js
+++ b/web/src/ChatBox.js
@@ -358,7 +358,7 @@ class ChatBox extends React.Component {
           const chat = res.data;
 
           if (this.props.onMessageEdit) {
-            this.props.onMessageEdit(chat.name);
+            this.props.onMessageEdit(chat);
           }
 
           if (!silent) {

--- a/web/src/ChatMenu.js
+++ b/web/src/ChatMenu.js
@@ -39,32 +39,34 @@ class ChatMenu extends React.Component {
 
   renderIndicator(chat) {
     const isDark = Setting.getIsDark();
-    const color = isDark ? "#ffffff" : "#000000";
+    const themeColor = ThemeDefault.colorPrimary || "#262626";
+    const readBorderColor = isDark ? "rgba(255,255,255,0.25)" : "rgba(0,0,0,0.15)";
 
     if (chat.isGenerating) {
       return (
-        <LoadingOutlined spin style={{
-          fontSize: "12px",
-          color: ThemeDefault.colorPrimary,
-          marginRight: "12px",
-          flexShrink: 0,
-        }} />
+        <span className="chat-status-indicator">
+          <LoadingOutlined spin style={{
+            width: "1em",
+            height: "1em",
+            fontSize: "1em",
+            lineHeight: 1,
+            color: themeColor,
+          }} />
+        </span>
       );
     }
 
     return (
-      <div style={{
-        width: "10px",
-        height: "10px",
-        borderRadius: "50%",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        marginRight: "14px",
-        flexShrink: 0,
-        backgroundColor: chat.isRead === false ? color : "transparent",
-        border: chat.isRead === false ? `1px solid ${color}` : `1px solid ${isDark ? "rgba(255,255,255,0.25)" : "rgba(0,0,0,0.15)"}`,
-      }} />
+      <span className="chat-status-indicator">
+        <span style={{
+          width: "0.625em",
+          height: "0.625em",
+          borderRadius: "50%",
+          display: "block",
+          backgroundColor: chat.isUnread ? themeColor : "transparent",
+          border: chat.isUnread ? `0.0625em solid ${themeColor}` : `0.0625em solid ${readBorderColor}`,
+        }} />
+      </span>
     );
   }
 
@@ -122,6 +124,7 @@ class ChatMenu extends React.Component {
           return {
             key: `${index}-${chatIndex}`,
             index: globalChatIndex,
+            className: "chat-menu-item",
             label: (
               isSelected && this.state.editChat ? (
                 <div className="menu-item-container">
@@ -150,9 +153,10 @@ class ChatMenu extends React.Component {
                 <div className="menu-item-container"
                   onMouseEnter={() => this.setState({hoveredKey: itemKey})}
                   onMouseLeave={() => this.setState({hoveredKey: null})}
+                  style={{width: "100%"}}
                 >
-                  <div style={{flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", display: "flex", alignItems: "center"}}>
-                    {this.renderIndicator(chat)}
+                  {this.renderIndicator(chat)}
+                  <div style={{flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap"}}>
                     <Tooltip title={chat.displayName}>
                       <span style={{overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap"}}>
                         {chat.displayName}

--- a/web/src/ChatPage.js
+++ b/web/src/ChatPage.js
@@ -109,13 +109,12 @@ class ChatPage extends BaseListPage {
             const status = res.data;
             const isViewing = this.state.chat?.name === chat.name;
 
-            if (chat.isGenerating && !status.isGenerating && isViewing && status.isRead === false) {
-              this.updateChatStatus(chat.name, status);
+            if (chat.isGenerating && !status.isGenerating && isViewing && status.isUnread) {
               this.markChatRead({...chat, ...status});
               return;
             }
 
-            if (status.isGenerating !== chat.isGenerating || status.isRead !== chat.isRead) {
+            if (status.isGenerating !== chat.isGenerating || status.isUnread !== chat.isUnread) {
               this.updateChatStatus(chat.name, status);
             }
           })
@@ -245,18 +244,18 @@ class ChatPage extends BaseListPage {
   };
 
   markChatRead = (chat) => {
-    if (!chat || chat.isRead !== false || chat.isGenerating) {
+    if (!chat || !chat.isUnread || chat.isGenerating) {
       return;
     }
 
-    const updatedChat = {...chat, isRead: true};
+    const updatedChat = {...chat, isUnread: false};
     ChatBackend.updateChat(chat.owner, chat.name, updatedChat)
       .then(res => {
         if (this.isChatPageUnmounted) {
           return;
         }
         if (res.status === "ok") {
-          this.updateChatStatus(chat.name, {isRead: true, isGenerating: chat.isGenerating});
+          this.updateChatStatus(chat.name, {isUnread: false, isGenerating: chat.isGenerating});
         }
       })
       .catch(error => {
@@ -787,8 +786,14 @@ class ChatPage extends BaseListPage {
       });
   }
 
-  handleMessageEdit = (chatName) => {
-    const chat = this.state.data.find(c => c.name === chatName);
+  handleMessageEdit = (updatedChat) => {
+    const hasUpdatedChat = updatedChat && typeof updatedChat !== "string";
+    const chatName = hasUpdatedChat ? updatedChat.name : updatedChat;
+    if (hasUpdatedChat) {
+      this.updateChatStatus(updatedChat.name, updatedChat);
+    }
+
+    const chat = hasUpdatedChat ? updatedChat : this.state.data.find(c => c.name === chatName);
     if (chat) {
       // get new messages
       this.getMessages(chat);


### PR DESCRIPTION
## Summary

- Replace `isRead` with `isUnread` so old chats without the field default to read.
- Reset stale chat status on startup via `ResetChatStatus`.
- Fix regenerate flow so the chat immediately enters generating state.
- Improve chat menu indicator positioning and unread/loading display.