### PR TITLE
feat: add snapshot pages

### DIFF
--- a/controllers/snapshot.go
+++ b/controllers/snapshot.go
@@ -15,6 +15,8 @@
 package controllers
 
 import (
+	"strings"
+
 	"github.com/beego/beego/utils/pagination"
 	"github.com/the-open-agent/openagent/object"
 	"github.com/the-open-agent/openagent/util"
@@ -31,7 +33,11 @@ func (c *ApiController) GetSnapshots() {
 		return
 	}
 
-	owner := "admin"
+	owner := strings.TrimSpace(c.Input().Get("owner"))
+	if owner == "" {
+		c.ResponseError("owner is required")
+		return
+	}
 	limit := c.Input().Get("pageSize")
 	page := c.Input().Get("p")
 	field := c.Input().Get("field")

--- a/controllers/snapshot.go
+++ b/controllers/snapshot.go
@@ -1,0 +1,108 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"github.com/beego/beego/utils/pagination"
+	"github.com/the-open-agent/openagent/object"
+	"github.com/the-open-agent/openagent/util"
+)
+
+// GetSnapshots
+// @Title GetSnapshots
+// @Tag Snapshot API
+// @Description get snapshots
+// @Success 200 {array} object.Snapshot The Response object
+// @router /get-snapshots [get]
+func (c *ApiController) GetSnapshots() {
+	if !c.RequireAdmin() {
+		return
+	}
+
+	owner := "admin"
+	limit := c.Input().Get("pageSize")
+	page := c.Input().Get("p")
+	field := c.Input().Get("field")
+	value := c.Input().Get("value")
+	sortField := c.Input().Get("sortField")
+	sortOrder := c.Input().Get("sortOrder")
+
+	if limit == "" || page == "" {
+		snapshots, err := object.GetSnapshots(owner)
+		if err != nil {
+			c.ResponseError(err.Error())
+			return
+		}
+		c.ResponseOk(snapshots)
+		return
+	}
+
+	limitInt := util.ParseInt(limit)
+	count, err := object.GetSnapshotCount(owner, field, value)
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+
+	paginator := pagination.SetPaginator(c.Ctx, limitInt, count)
+	snapshots, err := object.GetPaginationSnapshots(owner, paginator.Offset(), limitInt, field, value, sortField, sortOrder)
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+	c.ResponseOk(snapshots, paginator.Nums())
+}
+
+// GetSnapshot
+// @Title GetSnapshot
+// @Tag Snapshot API
+// @Description get snapshot
+// @Param id query string true "The id of snapshot"
+// @Success 200 {object} object.Snapshot The Response object
+// @router /get-snapshot [get]
+func (c *ApiController) GetSnapshot() {
+	if !c.RequireAdmin() {
+		return
+	}
+
+	id := c.Input().Get("id")
+	snapshot, err := object.GetSnapshot(id)
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+	c.ResponseOk(snapshot)
+}
+
+// RollbackSnapshot
+// @Title RollbackSnapshot
+// @Tag Snapshot API
+// @Description rollback snapshot
+// @Param id query string true "The id of snapshot"
+// @Success 200 {object} controllers.Response The Response object
+// @router /rollback-snapshot [post]
+func (c *ApiController) RollbackSnapshot() {
+	if !c.RequireAdmin() {
+		return
+	}
+
+	id := c.Input().Get("id")
+	success, err := object.RollbackSnapshot(id)
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+	c.ResponseOk(success)
+}

--- a/object/adapter.go
+++ b/object/adapter.go
@@ -393,6 +393,11 @@ func (a *Adapter) createTable() {
 		panic(err)
 	}
 
+	err = a.engine.Sync2(new(Snapshot))
+	if err != nil {
+		panic(err)
+	}
+
 	err = a.engine.Sync2(new(Server))
 	if err != nil {
 		panic(err)

--- a/object/merge_agent_tools.go
+++ b/object/merge_agent_tools.go
@@ -55,7 +55,7 @@ func buildMergedBuiltinRegistry(store *Store, lang string) *tool.ToolRegistry {
 			continue
 		}
 		for _, bt := range tp.BuiltinTools() {
-			reg.RegisterTool(bt)
+			reg.RegisterTool(wrapSnapshotBuiltin("admin", bt))
 		}
 	}
 

--- a/object/merge_agent_tools.go
+++ b/object/merge_agent_tools.go
@@ -55,7 +55,7 @@ func buildMergedBuiltinRegistry(store *Store, lang string) *tool.ToolRegistry {
 			continue
 		}
 		for _, bt := range tp.BuiltinTools() {
-			reg.RegisterTool(wrapSnapshotBuiltin("admin", bt))
+			reg.RegisterTool(wrapSnapshotBuiltin(store.Owner, bt))
 		}
 	}
 

--- a/object/message_tool.go
+++ b/object/message_tool.go
@@ -44,7 +44,7 @@ func buildToolSetForBuiltinTool(toolName string, lang string) (*mcp.ToolSet, err
 
 	reg := tool.NewToolRegistry()
 	for _, t := range tp.BuiltinTools() {
-		reg.RegisterTool(t)
+		reg.RegisterTool(wrapSnapshotBuiltin("admin", t))
 	}
 
 	allTools := reg.GetToolsAsProtocolTools()

--- a/object/snapshot.go
+++ b/object/snapshot.go
@@ -156,14 +156,14 @@ func RollbackSnapshot(id string) (bool, error) {
 	}
 
 	for _, file := range snapshot.Files {
-		if err = validateSnapshotAfterState(file); err != nil {
-			return false, err
+		if err = validateSnapshotRollbackState(file); err != nil {
+			return false, markSnapshotRollbackError(snapshot, err)
 		}
 	}
 
 	for i := len(snapshot.Files) - 1; i >= 0; i-- {
 		if err = rollbackSnapshotFile(snapshot.Files[i]); err != nil {
-			return false, err
+			return false, markSnapshotRollbackError(snapshot, err)
 		}
 	}
 
@@ -173,9 +173,13 @@ func RollbackSnapshot(id string) (bool, error) {
 	affected, err := adapter.engine.ID(core.PK{snapshot.Owner, snapshot.Name}).
 		Cols("state", "error_text", "rolled_back_time").Update(snapshot)
 	if err != nil {
-		return false, err
+		return false, markSnapshotRollbackError(snapshot, err)
 	}
-	return affected != 0, nil
+	if affected == 0 {
+		err = fmt.Errorf("failed to update snapshot rollback state: %s", id)
+		return false, markSnapshotRollbackError(snapshot, err)
+	}
+	return true, nil
 }
 
 func clearSnapshotsForList(snapshots []*Snapshot) {
@@ -234,24 +238,55 @@ func captureSnapshotFile(path string) (snapshotFileState, error) {
 	return state, nil
 }
 
-func validateSnapshotAfterState(file SnapshotFile) error {
+func validateSnapshotRollbackState(file SnapshotFile) error {
 	current, err := captureSnapshotFile(file.Path)
 	if err != nil {
 		return err
 	}
-	if current.Exists != file.AfterExists {
-		return fmt.Errorf("snapshot rollback conflict: %s existence changed", file.Path)
-	}
-	if !file.AfterExists {
+
+	if snapshotFileMatchesAfterState(current, file) || snapshotFileMatchesBeforeState(current, file) {
 		return nil
 	}
-	if current.Hash != file.AfterHash {
-		return fmt.Errorf("snapshot rollback conflict: %s content changed", file.Path)
+
+	return fmt.Errorf("snapshot rollback conflict: %s current state does not match snapshot before or after state", file.Path)
+}
+
+func snapshotFileMatchesBeforeState(current snapshotFileState, file SnapshotFile) bool {
+	if current.Exists != file.BeforeExists {
+		return false
 	}
-	if current.Mode != file.AfterMode {
-		return fmt.Errorf("snapshot rollback conflict: %s mode changed", file.Path)
+	if !file.BeforeExists {
+		return true
 	}
-	return nil
+	return current.Hash == file.BeforeHash && current.Mode == file.BeforeMode && current.Size == file.BeforeSize
+}
+
+func snapshotFileMatchesAfterState(current snapshotFileState, file SnapshotFile) bool {
+	if current.Exists != file.AfterExists {
+		return false
+	}
+	if !file.AfterExists {
+		return true
+	}
+	return current.Hash == file.AfterHash && current.Mode == file.AfterMode && current.Size == file.AfterSize
+}
+
+func markSnapshotRollbackError(snapshot *Snapshot, rollbackErr error) error {
+	if snapshot == nil || rollbackErr == nil {
+		return rollbackErr
+	}
+
+	snapshot.State = SnapshotStateActive
+	snapshot.ErrorText = rollbackErr.Error()
+	affected, err := adapter.engine.ID(core.PK{snapshot.Owner, snapshot.Name}).
+		Cols("state", "error_text").Update(snapshot)
+	if err != nil {
+		return fmt.Errorf("%w; failed to update snapshot rollback error: %v", rollbackErr, err)
+	}
+	if affected == 0 {
+		return fmt.Errorf("%w; failed to update snapshot rollback error", rollbackErr)
+	}
+	return rollbackErr
 }
 
 func rollbackSnapshotFile(file SnapshotFile) error {

--- a/object/snapshot.go
+++ b/object/snapshot.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"unicode/utf8"
 
 	"github.com/the-open-agent/openagent/util"
 	"xorm.io/core"
@@ -31,7 +30,14 @@ import (
 const (
 	SnapshotStateActive     = "Active"
 	SnapshotStateRolledBack = "RolledBack"
+
+	snapshotMaxFileBytes = 5 * 1024 * 1024
 )
+
+var snapshotListColumns = []string{
+	"owner", "name", "created_time", "tool", "action", "path",
+	"source", "target", "file_count", "state", "error_text", "rolled_back_time",
+}
 
 type Snapshot struct {
 	Owner       string `xorm:"varchar(100) notnull pk" json:"owner"`
@@ -44,6 +50,7 @@ type Snapshot struct {
 	Source         string         `xorm:"varchar(1000)" json:"source"`
 	Target         string         `xorm:"varchar(1000)" json:"target"`
 	Files          []SnapshotFile `xorm:"mediumtext" json:"files"`
+	FileCount      int            `xorm:"int" json:"fileCount"`
 	Diff           string         `xorm:"mediumtext" json:"diff"`
 	State          string         `xorm:"varchar(100)" json:"state"`
 	ErrorText      string         `xorm:"mediumtext" json:"errorText"`
@@ -57,9 +64,11 @@ type SnapshotFile struct {
 	BeforeHash    string `json:"beforeHash"`
 	BeforeContent string `json:"beforeContent,omitempty"`
 	BeforeMode    int64  `json:"beforeMode"`
+	BeforeSize    int64  `json:"beforeSize"`
 	AfterExists   bool   `json:"afterExists"`
 	AfterHash     string `json:"afterHash"`
 	AfterMode     int64  `json:"afterMode"`
+	AfterSize     int64  `json:"afterSize"`
 }
 
 type snapshotFileState struct {
@@ -68,6 +77,7 @@ type snapshotFileState struct {
 	Hash    string
 	Content []byte
 	Mode    int64
+	Size    int64
 }
 
 func AddSnapshot(snapshot *Snapshot) (bool, error) {
@@ -99,17 +109,17 @@ func GetSnapshot(id string) (*Snapshot, error) {
 	if err != nil || snapshot == nil {
 		return snapshot, err
 	}
-	clearSnapshotBeforeContent(snapshot)
+	prepareSnapshotForDetail(snapshot)
 	return snapshot, nil
 }
 
 func GetSnapshots(owner string) ([]*Snapshot, error) {
 	snapshots := []*Snapshot{}
-	err := adapter.engine.Desc("created_time").Find(&snapshots, &Snapshot{Owner: owner})
+	err := adapter.engine.Desc("created_time").Cols(snapshotListColumns...).Find(&snapshots, &Snapshot{Owner: owner})
 	if err != nil {
 		return snapshots, err
 	}
-	clearSnapshotsBeforeContent(snapshots)
+	clearSnapshotsForList(snapshots)
 	return snapshots, nil
 }
 
@@ -121,11 +131,11 @@ func GetSnapshotCount(owner, field, value string) (int64, error) {
 func GetPaginationSnapshots(owner string, offset, limit int, field, value, sortField, sortOrder string) ([]*Snapshot, error) {
 	snapshots := []*Snapshot{}
 	session := GetDbSession(owner, offset, limit, field, value, sortField, sortOrder)
-	err := session.Find(&snapshots)
+	err := session.Cols(snapshotListColumns...).Find(&snapshots)
 	if err != nil {
 		return snapshots, err
 	}
-	clearSnapshotsBeforeContent(snapshots)
+	clearSnapshotsForList(snapshots)
 	return snapshots, nil
 }
 
@@ -168,10 +178,19 @@ func RollbackSnapshot(id string) (bool, error) {
 	return affected != 0, nil
 }
 
-func clearSnapshotsBeforeContent(snapshots []*Snapshot) {
+func clearSnapshotsForList(snapshots []*Snapshot) {
 	for _, snapshot := range snapshots {
-		clearSnapshotBeforeContent(snapshot)
+		if snapshot.FileCount == 0 && len(snapshot.Files) != 0 {
+			snapshot.FileCount = len(snapshot.Files)
+		}
+		snapshot.Files = nil
+		snapshot.Diff = ""
 	}
+}
+
+func prepareSnapshotForDetail(snapshot *Snapshot) {
+	snapshot.Diff = buildSnapshotDiff(snapshot.Files)
+	clearSnapshotBeforeContent(snapshot)
 }
 
 func clearSnapshotBeforeContent(snapshot *Snapshot) {
@@ -182,7 +201,7 @@ func clearSnapshotBeforeContent(snapshot *Snapshot) {
 
 func captureSnapshotFile(path string) (snapshotFileState, error) {
 	state := snapshotFileState{Path: filepath.Clean(path)}
-	info, err := os.Stat(state.Path)
+	info, err := os.Lstat(state.Path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return state, nil
@@ -192,13 +211,24 @@ func captureSnapshotFile(path string) (snapshotFileState, error) {
 
 	state.Exists = true
 	state.Mode = int64(info.Mode().Perm())
-	if info.IsDir() {
-		return state, nil
+	state.Size = info.Size()
+	if info.Mode()&os.ModeSymlink != 0 {
+		return state, fmt.Errorf("snapshot does not support symlink: %s", state.Path)
+	}
+	if !info.Mode().IsRegular() {
+		return state, fmt.Errorf("snapshot only supports regular files: %s", state.Path)
+	}
+	if state.Size > snapshotMaxFileBytes {
+		return state, fmt.Errorf("snapshot file exceeds %d bytes: %s", snapshotMaxFileBytes, state.Path)
 	}
 
 	state.Content, err = os.ReadFile(state.Path)
 	if err != nil {
 		return state, err
+	}
+	state.Size = int64(len(state.Content))
+	if state.Size > snapshotMaxFileBytes {
+		return state, fmt.Errorf("snapshot file exceeds %d bytes: %s", snapshotMaxFileBytes, state.Path)
 	}
 	state.Hash = hashSnapshotContent(state.Content)
 	return state, nil
@@ -226,7 +256,7 @@ func validateSnapshotAfterState(file SnapshotFile) error {
 
 func rollbackSnapshotFile(file SnapshotFile) error {
 	if !file.BeforeExists {
-		if _, err := os.Stat(file.Path); err == nil {
+		if _, err := os.Lstat(file.Path); err == nil {
 			return os.Remove(file.Path)
 		} else if os.IsNotExist(err) {
 			return nil
@@ -263,6 +293,7 @@ func newSnapshot(owner string, action string, path string, source string, target
 		Source:      source,
 		Target:      target,
 		Files:       files,
+		FileCount:   len(files),
 		Diff:        diff,
 		State:       SnapshotStateActive,
 	}
@@ -276,9 +307,11 @@ func makeSnapshotFile(before snapshotFileState, after snapshotFileState) Snapsho
 		BeforeHash:    before.Hash,
 		BeforeContent: base64.StdEncoding.EncodeToString(before.Content),
 		BeforeMode:    before.Mode,
+		BeforeSize:    before.Size,
 		AfterExists:   after.Exists,
 		AfterHash:     after.Hash,
 		AfterMode:     after.Mode,
+		AfterSize:     after.Size,
 	}
 }
 
@@ -304,47 +337,21 @@ func hashSnapshotContent(content []byte) string {
 	return hex.EncodeToString(sum[:])
 }
 
-func buildSnapshotDiff(files []SnapshotFile, beforeStates map[string]snapshotFileState, afterStates map[string]snapshotFileState) string {
+func buildSnapshotDiff(files []SnapshotFile) string {
 	var builder strings.Builder
 	for _, file := range files {
-		before := beforeStates[file.Path]
-		after := afterStates[file.Path]
-		builder.WriteString(fmt.Sprintf("--- %s\n", file.Path))
-		builder.WriteString(fmt.Sprintf("+++ %s\n", file.Path))
-		builder.WriteString(fmt.Sprintf("@@ %s @@\n", file.ChangeType))
-		if before.Exists && after.Exists && utf8.Valid(before.Content) && utf8.Valid(after.Content) {
-			appendLineDiff(&builder, string(before.Content), string(after.Content))
-		} else if before.Exists && !after.Exists {
-			builder.WriteString("- file deleted\n")
-		} else if !before.Exists && after.Exists {
-			builder.WriteString("+ file created\n")
-		} else {
-			builder.WriteString("binary or unreadable file changed\n")
-		}
+		builder.WriteString(fmt.Sprintf("%s %s\n", file.ChangeType, file.Path))
+		appendSnapshotStateSummary(&builder, "before", file.BeforeExists, file.BeforeSize, file.BeforeMode, file.BeforeHash)
+		appendSnapshotStateSummary(&builder, "after", file.AfterExists, file.AfterSize, file.AfterMode, file.AfterHash)
 		builder.WriteString("\n")
 	}
 	return builder.String()
 }
 
-func appendLineDiff(builder *strings.Builder, before string, after string) {
-	if before == after {
-		builder.WriteString(" file unchanged\n")
+func appendSnapshotStateSummary(builder *strings.Builder, label string, exists bool, size int64, mode int64, hash string) {
+	if !exists {
+		builder.WriteString(fmt.Sprintf("%s: missing\n", label))
 		return
 	}
-	beforeLines := strings.Split(strings.TrimSuffix(before, "\n"), "\n")
-	afterLines := strings.Split(strings.TrimSuffix(after, "\n"), "\n")
-	for _, line := range beforeLines {
-		if line != "" {
-			builder.WriteString("- ")
-			builder.WriteString(line)
-			builder.WriteString("\n")
-		}
-	}
-	for _, line := range afterLines {
-		if line != "" {
-			builder.WriteString("+ ")
-			builder.WriteString(line)
-			builder.WriteString("\n")
-		}
-	}
+	builder.WriteString(fmt.Sprintf("%s: size=%d mode=%04o hash=%s\n", label, size, mode, hash))
 }

--- a/object/snapshot.go
+++ b/object/snapshot.go
@@ -1,0 +1,350 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package object
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/the-open-agent/openagent/util"
+	"xorm.io/core"
+)
+
+const (
+	SnapshotStateActive     = "Active"
+	SnapshotStateRolledBack = "RolledBack"
+)
+
+type Snapshot struct {
+	Owner       string `xorm:"varchar(100) notnull pk" json:"owner"`
+	Name        string `xorm:"varchar(100) notnull pk" json:"name"`
+	CreatedTime string `xorm:"varchar(100)" json:"createdTime"`
+
+	Tool           string         `xorm:"varchar(100)" json:"tool"`
+	Action         string         `xorm:"varchar(100)" json:"action"`
+	Path           string         `xorm:"varchar(1000)" json:"path"`
+	Source         string         `xorm:"varchar(1000)" json:"source"`
+	Target         string         `xorm:"varchar(1000)" json:"target"`
+	Files          []SnapshotFile `xorm:"mediumtext" json:"files"`
+	Diff           string         `xorm:"mediumtext" json:"diff"`
+	State          string         `xorm:"varchar(100)" json:"state"`
+	ErrorText      string         `xorm:"mediumtext" json:"errorText"`
+	RolledBackTime string         `xorm:"varchar(100)" json:"rolledBackTime"`
+}
+
+type SnapshotFile struct {
+	Path          string `json:"path"`
+	ChangeType    string `json:"changeType"`
+	BeforeExists  bool   `json:"beforeExists"`
+	BeforeHash    string `json:"beforeHash"`
+	BeforeContent string `json:"beforeContent,omitempty"`
+	BeforeMode    int64  `json:"beforeMode"`
+	AfterExists   bool   `json:"afterExists"`
+	AfterHash     string `json:"afterHash"`
+	AfterMode     int64  `json:"afterMode"`
+}
+
+type snapshotFileState struct {
+	Path    string
+	Exists  bool
+	Hash    string
+	Content []byte
+	Mode    int64
+}
+
+func AddSnapshot(snapshot *Snapshot) (bool, error) {
+	affected, err := adapter.engine.Insert(snapshot)
+	if err != nil {
+		return false, err
+	}
+	return affected != 0, nil
+}
+
+func getSnapshot(owner string, name string) (*Snapshot, error) {
+	snapshot := Snapshot{Owner: owner, Name: name}
+	existed, err := adapter.engine.Get(&snapshot)
+	if err != nil {
+		return &snapshot, err
+	}
+	if existed {
+		return &snapshot, nil
+	}
+	return nil, nil
+}
+
+func GetSnapshot(id string) (*Snapshot, error) {
+	owner, name, err := util.GetOwnerAndNameFromIdWithError(id)
+	if err != nil {
+		return nil, err
+	}
+	snapshot, err := getSnapshot(owner, name)
+	if err != nil || snapshot == nil {
+		return snapshot, err
+	}
+	clearSnapshotBeforeContent(snapshot)
+	return snapshot, nil
+}
+
+func GetSnapshots(owner string) ([]*Snapshot, error) {
+	snapshots := []*Snapshot{}
+	err := adapter.engine.Desc("created_time").Find(&snapshots, &Snapshot{Owner: owner})
+	if err != nil {
+		return snapshots, err
+	}
+	clearSnapshotsBeforeContent(snapshots)
+	return snapshots, nil
+}
+
+func GetSnapshotCount(owner, field, value string) (int64, error) {
+	session := GetDbSession(owner, -1, -1, field, value, "", "")
+	return session.Count(&Snapshot{})
+}
+
+func GetPaginationSnapshots(owner string, offset, limit int, field, value, sortField, sortOrder string) ([]*Snapshot, error) {
+	snapshots := []*Snapshot{}
+	session := GetDbSession(owner, offset, limit, field, value, sortField, sortOrder)
+	err := session.Find(&snapshots)
+	if err != nil {
+		return snapshots, err
+	}
+	clearSnapshotsBeforeContent(snapshots)
+	return snapshots, nil
+}
+
+func RollbackSnapshot(id string) (bool, error) {
+	owner, name, err := util.GetOwnerAndNameFromIdWithError(id)
+	if err != nil {
+		return false, err
+	}
+	snapshot, err := getSnapshot(owner, name)
+	if err != nil {
+		return false, err
+	}
+	if snapshot == nil {
+		return false, fmt.Errorf("snapshot not found: %s", id)
+	}
+	if snapshot.State == SnapshotStateRolledBack {
+		return false, fmt.Errorf("snapshot already rolled back: %s", id)
+	}
+
+	for _, file := range snapshot.Files {
+		if err = validateSnapshotAfterState(file); err != nil {
+			return false, err
+		}
+	}
+
+	for i := len(snapshot.Files) - 1; i >= 0; i-- {
+		if err = rollbackSnapshotFile(snapshot.Files[i]); err != nil {
+			return false, err
+		}
+	}
+
+	snapshot.State = SnapshotStateRolledBack
+	snapshot.ErrorText = ""
+	snapshot.RolledBackTime = util.GetCurrentTime()
+	affected, err := adapter.engine.ID(core.PK{snapshot.Owner, snapshot.Name}).
+		Cols("state", "error_text", "rolled_back_time").Update(snapshot)
+	if err != nil {
+		return false, err
+	}
+	return affected != 0, nil
+}
+
+func clearSnapshotsBeforeContent(snapshots []*Snapshot) {
+	for _, snapshot := range snapshots {
+		clearSnapshotBeforeContent(snapshot)
+	}
+}
+
+func clearSnapshotBeforeContent(snapshot *Snapshot) {
+	for i := range snapshot.Files {
+		snapshot.Files[i].BeforeContent = ""
+	}
+}
+
+func captureSnapshotFile(path string) (snapshotFileState, error) {
+	state := snapshotFileState{Path: filepath.Clean(path)}
+	info, err := os.Stat(state.Path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return state, nil
+		}
+		return state, err
+	}
+
+	state.Exists = true
+	state.Mode = int64(info.Mode().Perm())
+	if info.IsDir() {
+		return state, nil
+	}
+
+	state.Content, err = os.ReadFile(state.Path)
+	if err != nil {
+		return state, err
+	}
+	state.Hash = hashSnapshotContent(state.Content)
+	return state, nil
+}
+
+func validateSnapshotAfterState(file SnapshotFile) error {
+	current, err := captureSnapshotFile(file.Path)
+	if err != nil {
+		return err
+	}
+	if current.Exists != file.AfterExists {
+		return fmt.Errorf("snapshot rollback conflict: %s existence changed", file.Path)
+	}
+	if !file.AfterExists {
+		return nil
+	}
+	if current.Hash != file.AfterHash {
+		return fmt.Errorf("snapshot rollback conflict: %s content changed", file.Path)
+	}
+	if current.Mode != file.AfterMode {
+		return fmt.Errorf("snapshot rollback conflict: %s mode changed", file.Path)
+	}
+	return nil
+}
+
+func rollbackSnapshotFile(file SnapshotFile) error {
+	if !file.BeforeExists {
+		if _, err := os.Stat(file.Path); err == nil {
+			return os.Remove(file.Path)
+		} else if os.IsNotExist(err) {
+			return nil
+		} else {
+			return err
+		}
+	}
+
+	content, err := base64.StdEncoding.DecodeString(file.BeforeContent)
+	if err != nil {
+		return err
+	}
+	if err = os.MkdirAll(filepath.Dir(file.Path), 0o755); err != nil {
+		return err
+	}
+	mode := os.FileMode(file.BeforeMode)
+	if mode == 0 {
+		mode = 0o644
+	}
+	if err = os.WriteFile(file.Path, content, mode); err != nil {
+		return err
+	}
+	return os.Chmod(file.Path, mode)
+}
+
+func newSnapshot(owner string, action string, path string, source string, target string, files []SnapshotFile, diff string) *Snapshot {
+	return &Snapshot{
+		Owner:       owner,
+		Name:        fmt.Sprintf("snapshot_%s", util.GenerateId()),
+		CreatedTime: util.GetCurrentTime(),
+		Tool:        "local_file",
+		Action:      action,
+		Path:        path,
+		Source:      source,
+		Target:      target,
+		Files:       files,
+		Diff:        diff,
+		State:       SnapshotStateActive,
+	}
+}
+
+func makeSnapshotFile(before snapshotFileState, after snapshotFileState) SnapshotFile {
+	return SnapshotFile{
+		Path:          after.Path,
+		ChangeType:    getSnapshotChangeType(before, after),
+		BeforeExists:  before.Exists,
+		BeforeHash:    before.Hash,
+		BeforeContent: base64.StdEncoding.EncodeToString(before.Content),
+		BeforeMode:    before.Mode,
+		AfterExists:   after.Exists,
+		AfterHash:     after.Hash,
+		AfterMode:     after.Mode,
+	}
+}
+
+func getSnapshotChangeType(before snapshotFileState, after snapshotFileState) string {
+	if !before.Exists && after.Exists {
+		return "created"
+	}
+	if before.Exists && !after.Exists {
+		return "deleted"
+	}
+	if before.Hash != after.Hash || before.Mode != after.Mode {
+		return "modified"
+	}
+	return "unchanged"
+}
+
+func snapshotFileChanged(before snapshotFileState, after snapshotFileState) bool {
+	return before.Exists != after.Exists || before.Hash != after.Hash || before.Mode != after.Mode
+}
+
+func hashSnapshotContent(content []byte) string {
+	sum := sha256.Sum256(content)
+	return hex.EncodeToString(sum[:])
+}
+
+func buildSnapshotDiff(files []SnapshotFile, beforeStates map[string]snapshotFileState, afterStates map[string]snapshotFileState) string {
+	var builder strings.Builder
+	for _, file := range files {
+		before := beforeStates[file.Path]
+		after := afterStates[file.Path]
+		builder.WriteString(fmt.Sprintf("--- %s\n", file.Path))
+		builder.WriteString(fmt.Sprintf("+++ %s\n", file.Path))
+		builder.WriteString(fmt.Sprintf("@@ %s @@\n", file.ChangeType))
+		if before.Exists && after.Exists && utf8.Valid(before.Content) && utf8.Valid(after.Content) {
+			appendLineDiff(&builder, string(before.Content), string(after.Content))
+		} else if before.Exists && !after.Exists {
+			builder.WriteString("- file deleted\n")
+		} else if !before.Exists && after.Exists {
+			builder.WriteString("+ file created\n")
+		} else {
+			builder.WriteString("binary or unreadable file changed\n")
+		}
+		builder.WriteString("\n")
+	}
+	return builder.String()
+}
+
+func appendLineDiff(builder *strings.Builder, before string, after string) {
+	if before == after {
+		builder.WriteString(" file unchanged\n")
+		return
+	}
+	beforeLines := strings.Split(strings.TrimSuffix(before, "\n"), "\n")
+	afterLines := strings.Split(strings.TrimSuffix(after, "\n"), "\n")
+	for _, line := range beforeLines {
+		if line != "" {
+			builder.WriteString("- ")
+			builder.WriteString(line)
+			builder.WriteString("\n")
+		}
+	}
+	for _, line := range afterLines {
+		if line != "" {
+			builder.WriteString("+ ")
+			builder.WriteString(line)
+			builder.WriteString("\n")
+		}
+	}
+}

--- a/object/snapshot_tool.go
+++ b/object/snapshot_tool.go
@@ -1,0 +1,146 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package object
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/ThinkInAIXYZ/go-mcp/protocol"
+	"github.com/the-open-agent/openagent/tool"
+)
+
+type snapshotBuiltinTool struct {
+	owner string
+	inner tool.BuiltinTool
+}
+
+func wrapSnapshotBuiltin(owner string, builtin tool.BuiltinTool) tool.BuiltinTool {
+	switch builtin.GetName() {
+	case "local_file_write", "local_file_move":
+		return &snapshotBuiltinTool{owner: owner, inner: builtin}
+	default:
+		return builtin
+	}
+}
+
+func (t *snapshotBuiltinTool) GetName() string {
+	return t.inner.GetName()
+}
+
+func (t *snapshotBuiltinTool) GetDescription() string {
+	return t.inner.GetDescription()
+}
+
+func (t *snapshotBuiltinTool) GetInputSchema() interface{} {
+	return t.inner.GetInputSchema()
+}
+
+func (t *snapshotBuiltinTool) Execute(ctx context.Context, arguments map[string]interface{}) (*protocol.CallToolResult, error) {
+	action, path, source, target, paths := getSnapshotToolPaths(t.GetName(), arguments)
+	if len(paths) == 0 {
+		return t.inner.Execute(ctx, arguments)
+	}
+
+	beforeStates, err := captureSnapshotFiles(paths)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := t.inner.Execute(ctx, arguments)
+	if err != nil || result == nil || result.IsError {
+		return result, err
+	}
+
+	afterStates, err := captureSnapshotFiles(paths)
+	if err != nil {
+		fmt.Printf("snapshot capture failed after %s: %s\n", t.GetName(), err.Error())
+		return result, nil
+	}
+
+	files := make([]SnapshotFile, 0, len(paths))
+	for _, p := range paths {
+		before := beforeStates[p]
+		after := afterStates[p]
+		if !snapshotFileChanged(before, after) {
+			continue
+		}
+		files = append(files, makeSnapshotFile(before, after))
+	}
+	if len(files) == 0 {
+		return result, nil
+	}
+
+	snapshot := newSnapshot(t.owner, action, path, source, target, files, buildSnapshotDiff(files, beforeStates, afterStates))
+	if _, err = AddSnapshot(snapshot); err != nil {
+		fmt.Printf("snapshot save failed after %s: %s\n", t.GetName(), err.Error())
+	}
+	return result, nil
+}
+
+func getSnapshotToolPaths(toolName string, arguments map[string]interface{}) (string, string, string, string, []string) {
+	switch toolName {
+	case "local_file_write":
+		path := snapshotStringArg(arguments, "path")
+		if path == "" {
+			return "", "", "", "", nil
+		}
+		path = filepath.Clean(path)
+		return "write", path, "", "", []string{path}
+	case "local_file_move":
+		source := snapshotStringArg(arguments, "source")
+		target := snapshotStringArg(arguments, "target")
+		if source == "" || target == "" {
+			return "", "", "", "", nil
+		}
+		source = filepath.Clean(source)
+		target = filepath.Clean(target)
+		return "move", "", source, target, uniqueSnapshotPaths(source, target)
+	default:
+		return "", "", "", "", nil
+	}
+}
+
+func snapshotStringArg(arguments map[string]interface{}, key string) string {
+	value, _ := arguments[key].(string)
+	return strings.TrimSpace(value)
+}
+
+func uniqueSnapshotPaths(paths ...string) []string {
+	res := []string{}
+	seen := map[string]bool{}
+	for _, p := range paths {
+		if p == "" || seen[p] {
+			continue
+		}
+		seen[p] = true
+		res = append(res, p)
+	}
+	return res
+}
+
+func captureSnapshotFiles(paths []string) (map[string]snapshotFileState, error) {
+	res := map[string]snapshotFileState{}
+	for _, p := range paths {
+		state, err := captureSnapshotFile(p)
+		if err != nil {
+			return nil, err
+		}
+		res[p] = state
+	}
+	return res, nil
+}

--- a/object/snapshot_tool.go
+++ b/object/snapshot_tool.go
@@ -64,14 +64,11 @@ func (t *snapshotBuiltinTool) Execute(ctx context.Context, arguments map[string]
 		return snapshotToolError(err.Error()), nil
 	}
 
-	result, err := t.inner.Execute(ctx, arguments)
-	if err != nil || result == nil || result.IsError {
-		return result, err
-	}
+	result, innerErr := t.inner.Execute(ctx, arguments)
 
 	afterStates, err := captureSnapshotFiles(paths)
 	if err != nil {
-		return snapshotToolError(fmt.Sprintf("snapshot capture failed after %s: %s; file operation already completed but rollback snapshot was not saved", t.GetName(), err.Error())), nil
+		return snapshotToolError(snapshotToolFailureMessage("snapshot capture failed", t.GetName(), err, result, innerErr)), nil
 	}
 
 	files := make([]SnapshotFile, 0, len(paths))
@@ -84,16 +81,16 @@ func (t *snapshotBuiltinTool) Execute(ctx context.Context, arguments map[string]
 		files = append(files, makeSnapshotFile(before, after))
 	}
 	if len(files) == 0 {
-		return result, nil
+		return result, innerErr
 	}
 
 	snapshot := newSnapshot(t.owner, action, path, source, target, files, buildSnapshotDiff(files))
 	if ok, err := AddSnapshot(snapshot); err != nil {
-		return snapshotToolError(fmt.Sprintf("snapshot save failed after %s: %s; file operation already completed but rollback snapshot was not saved", t.GetName(), err.Error())), nil
+		return snapshotToolError(snapshotToolFailureMessage("snapshot save failed", t.GetName(), err, result, innerErr)), nil
 	} else if !ok {
-		return snapshotToolError(fmt.Sprintf("snapshot save failed after %s: no rows inserted; file operation already completed but rollback snapshot was not saved", t.GetName())), nil
+		return snapshotToolError(snapshotToolFailureMessage("snapshot save failed", t.GetName(), fmt.Errorf("no rows inserted"), result, innerErr)), nil
 	}
-	return result, nil
+	return result, innerErr
 }
 
 func validateSnapshotToolArguments(toolName string, arguments map[string]interface{}) error {
@@ -162,6 +159,35 @@ func captureSnapshotFiles(paths []string) (map[string]snapshotFileState, error) 
 		res[p] = state
 	}
 	return res, nil
+}
+
+func snapshotToolFailureMessage(prefix string, toolName string, cause error, result *protocol.CallToolResult, innerErr error) string {
+	message := fmt.Sprintf("%s after %s: %s; file operation already changed files but rollback snapshot was not saved", prefix, toolName, cause.Error())
+	if innerText := snapshotInnerErrorText(result, innerErr); innerText != "" {
+		message = fmt.Sprintf("%s; original tool error: %s", message, innerText)
+	}
+	return message
+}
+
+func snapshotInnerErrorText(result *protocol.CallToolResult, err error) string {
+	if err != nil {
+		return err.Error()
+	}
+	if result == nil {
+		return "inner tool returned nil result"
+	}
+	if !result.IsError {
+		return ""
+	}
+
+	parts := []string{}
+	for _, content := range result.Content {
+		text, ok := content.(*protocol.TextContent)
+		if ok && text.Text != "" {
+			parts = append(parts, text.Text)
+		}
+	}
+	return strings.Join(parts, "\n")
 }
 
 func snapshotToolError(text string) *protocol.CallToolResult {

--- a/object/snapshot_tool.go
+++ b/object/snapshot_tool.go
@@ -56,9 +56,12 @@ func (t *snapshotBuiltinTool) Execute(ctx context.Context, arguments map[string]
 		return t.inner.Execute(ctx, arguments)
 	}
 
+	if err := validateSnapshotToolArguments(t.GetName(), arguments); err != nil {
+		return snapshotToolError(err.Error()), nil
+	}
 	beforeStates, err := captureSnapshotFiles(paths)
 	if err != nil {
-		return nil, err
+		return snapshotToolError(err.Error()), nil
 	}
 
 	result, err := t.inner.Execute(ctx, arguments)
@@ -68,8 +71,7 @@ func (t *snapshotBuiltinTool) Execute(ctx context.Context, arguments map[string]
 
 	afterStates, err := captureSnapshotFiles(paths)
 	if err != nil {
-		fmt.Printf("snapshot capture failed after %s: %s\n", t.GetName(), err.Error())
-		return result, nil
+		return snapshotToolError(fmt.Sprintf("snapshot capture failed after %s: %s; file operation already completed but rollback snapshot was not saved", t.GetName(), err.Error())), nil
 	}
 
 	files := make([]SnapshotFile, 0, len(paths))
@@ -85,11 +87,28 @@ func (t *snapshotBuiltinTool) Execute(ctx context.Context, arguments map[string]
 		return result, nil
 	}
 
-	snapshot := newSnapshot(t.owner, action, path, source, target, files, buildSnapshotDiff(files, beforeStates, afterStates))
-	if _, err = AddSnapshot(snapshot); err != nil {
-		fmt.Printf("snapshot save failed after %s: %s\n", t.GetName(), err.Error())
+	snapshot := newSnapshot(t.owner, action, path, source, target, files, buildSnapshotDiff(files))
+	if ok, err := AddSnapshot(snapshot); err != nil {
+		return snapshotToolError(fmt.Sprintf("snapshot save failed after %s: %s; file operation already completed but rollback snapshot was not saved", t.GetName(), err.Error())), nil
+	} else if !ok {
+		return snapshotToolError(fmt.Sprintf("snapshot save failed after %s: no rows inserted; file operation already completed but rollback snapshot was not saved", t.GetName())), nil
 	}
 	return result, nil
+}
+
+func validateSnapshotToolArguments(toolName string, arguments map[string]interface{}) error {
+	if toolName != "local_file_write" {
+		return nil
+	}
+
+	content, ok := arguments["content"].(string)
+	if !ok {
+		return nil
+	}
+	if int64(len(content)) > snapshotMaxFileBytes {
+		return fmt.Errorf("snapshot file exceeds %d bytes", snapshotMaxFileBytes)
+	}
+	return nil
 }
 
 func getSnapshotToolPaths(toolName string, arguments map[string]interface{}) (string, string, string, string, []string) {
@@ -143,4 +162,13 @@ func captureSnapshotFiles(paths []string) (map[string]snapshotFileState, error) 
 		res[p] = state
 	}
 	return res, nil
+}
+
+func snapshotToolError(text string) *protocol.CallToolResult {
+	return &protocol.CallToolResult{
+		IsError: true,
+		Content: []protocol.Content{
+			&protocol.TextContent{Type: "text", Text: text},
+		},
+	}
 }

--- a/object/tool.go
+++ b/object/tool.go
@@ -230,6 +230,11 @@ func testToolWithLoader(t *Tool, lang string, loadTool func(owner string, name s
 		payload.Arguments = map[string]interface{}{}
 	}
 
+	owner := strings.TrimSpace(t.Owner)
+	if owner == "" {
+		return "", fmt.Errorf("tool owner is required")
+	}
+
 	tp, err := tool.New(getToolConfig(t), lang)
 	if err != nil {
 		return "", err
@@ -240,7 +245,7 @@ func testToolWithLoader(t *Tool, lang string, loadTool func(owner string, name s
 	}
 	for _, bt := range tp.BuiltinTools() {
 		if bt.GetName() == payload.Tool {
-			foundTool = wrapSnapshotBuiltin("admin", bt)
+			foundTool = wrapSnapshotBuiltin(owner, bt)
 			break
 		}
 	}

--- a/object/tool.go
+++ b/object/tool.go
@@ -240,7 +240,7 @@ func testToolWithLoader(t *Tool, lang string, loadTool func(owner string, name s
 	}
 	for _, bt := range tp.BuiltinTools() {
 		if bt.GetName() == payload.Tool {
-			foundTool = bt
+			foundTool = wrapSnapshotBuiltin("admin", bt)
 			break
 		}
 	}

--- a/routers/router.go
+++ b/routers/router.go
@@ -213,6 +213,10 @@ func initAPI() {
 	beego.Router("/api/delete-session", &controllers.ApiController{}, "POST:DeleteSession")
 	beego.Router("/api/is-session-duplicated", &controllers.ApiController{}, "GET:IsSessionDuplicated")
 
+	beego.Router("/api/get-snapshots", &controllers.ApiController{}, "GET:GetSnapshots")
+	beego.Router("/api/get-snapshot", &controllers.ApiController{}, "GET:GetSnapshot")
+	beego.Router("/api/rollback-snapshot", &controllers.ApiController{}, "POST:RollbackSnapshot")
+
 	beego.Router("/api/get-records", &controllers.ApiController{}, "GET:GetRecords")
 	beego.Router("/api/get-record", &controllers.ApiController{}, "GET:GetRecord")
 	beego.Router("/api/update-record", &controllers.ApiController{}, "POST:UpdateRecord")

--- a/tool/local_file.go
+++ b/tool/local_file.go
@@ -156,6 +156,11 @@ func localFileJSON(v interface{}) *protocol.CallToolResult {
 	return localFileText(string(bs))
 }
 
+var (
+	localFileRename = os.Rename
+	localFileRemove = os.Remove
+)
+
 func localFileStringArg(arguments map[string]interface{}, key string) string {
 	value, _ := arguments[key].(string)
 	return strings.TrimSpace(value)
@@ -770,13 +775,28 @@ func (b *localFileMoveBuiltin) Execute(_ context.Context, arguments map[string]i
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return localFileError(fmt.Sprintf("failed to create target directory: %s", err.Error())), nil
 	}
+	backupPath := ""
 	if targetExists {
-		if err := os.Remove(target); err != nil {
-			return localFileError(fmt.Sprintf("failed to remove existing target: %s", err.Error())), nil
+		backupPath, err = localFileMoveBackupPath(target)
+		if err != nil {
+			return localFileError(fmt.Sprintf("failed to reserve target backup path: %s", err.Error())), nil
+		}
+		if err := localFileRename(target, backupPath); err != nil {
+			return localFileError(fmt.Sprintf("failed to backup existing target: %s", err.Error())), nil
 		}
 	}
-	if err := os.Rename(source, target); err != nil {
+	if err := localFileRename(source, target); err != nil {
+		if backupPath != "" {
+			if restoreErr := localFileRename(backupPath, target); restoreErr != nil {
+				return localFileError(fmt.Sprintf("failed to move file: %s; failed to restore existing target: %s", err.Error(), restoreErr.Error())), nil
+			}
+		}
 		return localFileError(fmt.Sprintf("failed to move file: %s", err.Error())), nil
+	}
+	if backupPath != "" {
+		if err := localFileRemove(backupPath); err != nil {
+			return localFileError(fmt.Sprintf("failed to remove target backup after move: %s", err.Error())), nil
+		}
 	}
 
 	return localFileJSON(localFileMoveResult{
@@ -784,4 +804,18 @@ func (b *localFileMoveBuiltin) Execute(_ context.Context, arguments map[string]i
 		Target:    target,
 		Overwrote: targetExists,
 	}), nil
+}
+
+func localFileMoveBackupPath(target string) (string, error) {
+	dir := filepath.Dir(target)
+	base := filepath.Base(target)
+	for i := 0; i < 100; i++ {
+		path := filepath.Join(dir, fmt.Sprintf(".%s.openagent-move-backup-%d-%d", base, time.Now().UnixNano(), i))
+		if _, err := os.Lstat(path); os.IsNotExist(err) {
+			return path, nil
+		} else if err != nil {
+			return "", err
+		}
+	}
+	return "", fmt.Errorf("failed to generate unique backup path for target: %s", target)
 }

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -134,6 +134,8 @@ class App extends Component {
       this.setState({selectedMenuKey: "/visitors"});
     } else if (uri.includes("/sessions")) {
       this.setState({selectedMenuKey: "/sessions"});
+    } else if (uri.includes("/snapshots")) {
+      this.setState({selectedMenuKey: "/snapshots"});
     } else if (uri.includes("/records")) {
       this.setState({selectedMenuKey: "/records"});
     } else if (uri.includes("/tasks")) {

--- a/web/src/ManagementPage.js
+++ b/web/src/ManagementPage.js
@@ -447,7 +447,7 @@ function ManagementPage(props) {
       res.push(Setting.getItem(<Link style={{color: textColor}} to="/records">{i18next.t("general:Auditing Logs")}</Link>, "/logs", <WalletOutlined />, [
         Setting.getItem(<Link to="/records">{i18next.t("general:Logs")}</Link>, "/records", <DatabaseOutlined />),
         Setting.getItem(<Link to="/sessions">{i18next.t("general:Sessions")}</Link>, "/sessions", <OrderedListOutlined />),
-        Setting.getItem(<Link to="/snapshots">Snapshots</Link>, "/snapshots", <HistoryOutlined />),
+        Setting.getItem(<Link to="/snapshots">{i18next.t("general:Snapshots")}</Link>, "/snapshots", <HistoryOutlined />),
       ]));
 
       res.push(Setting.getItem(<Link style={{color: textColor}} to="#">{i18next.t("general:Identity")}</Link>, "/identity", <LockOutlined />, [

--- a/web/src/ManagementPage.js
+++ b/web/src/ManagementPage.js
@@ -364,11 +364,16 @@ function ManagementPage(props) {
       return menuItems;
     }
 
+    const effectiveNavItems = new Set(navItems);
+    if (effectiveNavItems.has("/records") || effectiveNavItems.has("/sessions") || effectiveNavItems.has("/logs")) {
+      effectiveNavItems.add("/snapshots");
+    }
+
     const filteredItems = menuItems.map(item => {
       if (!Array.isArray(item.children)) {
         return item;
       }
-      const filteredChildren = item.children.filter(child => navItems.includes(child.key));
+      const filteredChildren = item.children.filter(child => effectiveNavItems.has(child.key));
       const newItem = {...item};
       newItem.children = filteredChildren;
       return newItem;
@@ -378,7 +383,7 @@ function ManagementPage(props) {
       if (Array.isArray(item.children)) {
         return item.children.length > 0;
       }
-      return item.key === "/" || navItems.includes(item.key);
+      return item.key === "/" || effectiveNavItems.has(item.key);
     });
   }
 

--- a/web/src/ManagementPage.js
+++ b/web/src/ManagementPage.js
@@ -28,6 +28,7 @@ import {
   FolderOpenOutlined,
   FormOutlined,
   FundOutlined,
+  HistoryOutlined,
   HomeOutlined,
   InboxOutlined,
   LayoutOutlined,
@@ -84,6 +85,7 @@ import ChatListPage from "./ChatListPage";
 import MessageListPage from "./MessageListPage";
 import MessageEditPage from "./MessageEditPage";
 import SessionListPage from "./SessionListPage";
+import SnapshotListPage from "./SnapshotListPage";
 import RecordListPage from "./RecordListPage";
 import RecordEditPage from "./RecordEditPage";
 import TaskListPage from "./TaskListPage";
@@ -110,7 +112,7 @@ function getMenuParentKey(uri) {
   if (uri.includes("/providers") || uri.includes("/pipes") || uri.includes("/tools") || uri.includes("/servers")) {return "/connectors";}
   if (uri.includes("/files") || uri.includes("/vectors") || uri.includes("/resources")) {return "/knowledge-base";}
   if (uri.includes("/tasks") || uri.includes("/scales") || uri.includes("/forms")) {return "/multimedia";}
-  if (uri.includes("/sessions") || uri.includes("/records")) {return "/logs";}
+  if (uri.includes("/sessions") || uri.includes("/records") || uri.includes("/snapshots")) {return "/logs";}
   if (uri.includes("/users") || uri.includes("/casdoor-resources") || uri.includes("/permissions")) {return "/identity";}
   if (uri.includes("/sysinfo") || uri.includes("/swagger") || uri.includes("/visitors") || uri.includes("/sites") || uri.includes("/usages")) {return "/admin";}
   return null;
@@ -445,6 +447,7 @@ function ManagementPage(props) {
       res.push(Setting.getItem(<Link style={{color: textColor}} to="/records">{i18next.t("general:Auditing Logs")}</Link>, "/logs", <WalletOutlined />, [
         Setting.getItem(<Link to="/records">{i18next.t("general:Logs")}</Link>, "/records", <DatabaseOutlined />),
         Setting.getItem(<Link to="/sessions">{i18next.t("general:Sessions")}</Link>, "/sessions", <OrderedListOutlined />),
+        Setting.getItem(<Link to="/snapshots">Snapshots</Link>, "/snapshots", <HistoryOutlined />),
       ]));
 
       res.push(Setting.getItem(<Link style={{color: textColor}} to="#">{i18next.t("general:Identity")}</Link>, "/identity", <LockOutlined />, [
@@ -555,6 +558,7 @@ function ManagementPage(props) {
         <Route exact path="/sites/:siteName" render={(props) => renderSigninIfNotSignedIn(<SiteEditPage account={account} onUpdateSite={onUpdateSite} {...props} />)} />
         <Route exact path="/visitors" render={(props) => renderSigninIfNotSignedIn(<VisitorPage account={account} themeAlgorithm={themeAlgorithm} {...props} />)} />
         <Route exact path="/sessions" render={(props) => renderSigninIfNotSignedIn(<SessionListPage account={account} {...props} />)} />
+        <Route exact path="/snapshots" render={(props) => renderSigninIfNotSignedIn(<SnapshotListPage account={account} {...props} />)} />
         <Route exact path="/records" render={(props) => renderSigninIfNotSignedIn(<RecordListPage account={account} {...props} />)} />
         <Route exact path="/records/:organizationName/:recordName" render={(props) => renderSigninIfNotSignedIn(<RecordEditPage account={account} {...props} />)} />
         <Route exact path="/tasks" render={(props) => renderSigninIfNotSignedIn(<TaskListPage account={account} {...props} />)} />

--- a/web/src/SnapshotListPage.js
+++ b/web/src/SnapshotListPage.js
@@ -39,11 +39,42 @@ class SnapshotListPage extends BaseListPage {
     return record.path;
   }
 
+  getActionText(action) {
+    if (action === "write") {
+      return i18next.t("general:Write");
+    }
+    if (action === "move") {
+      return i18next.t("general:Move");
+    }
+    return action;
+  }
+
+  getChangeTypeText(changeType) {
+    if (changeType === "created") {
+      return i18next.t("general:Created");
+    }
+    if (changeType === "deleted") {
+      return i18next.t("general:Deleted");
+    }
+    if (changeType === "modified") {
+      return i18next.t("general:Modified");
+    }
+    return changeType;
+  }
+
+  getStateText(state) {
+    const stateText = state || "Active";
+    if (stateText === "Active" || stateText === "RolledBack") {
+      return i18next.t(`general:${stateText}`);
+    }
+    return stateText;
+  }
+
   getStateTag(state) {
     if (state === "RolledBack") {
-      return <Tag color="blue">RolledBack</Tag>;
+      return <Tag color="blue">{this.getStateText(state)}</Tag>;
     }
-    return <Tag color="green">{state || "Active"}</Tag>;
+    return <Tag color="green">{this.getStateText(state)}</Tag>;
   }
 
   showDetails(record) {
@@ -69,15 +100,15 @@ class SnapshotListPage extends BaseListPage {
       .then((res) => {
         this.setState({rollbackLoadingName: ""});
         if (res.status === "ok") {
-          Setting.showMessage("success", "Snapshot rolled back");
+          Setting.showMessage("success", i18next.t("general:Snapshot rolled back"));
           this.fetch({pagination: this.state.pagination});
         } else {
-          Setting.showMessage("error", `Rollback failed: ${res.msg}`);
+          Setting.showMessage("error", `${i18next.t("general:Rollback failed")}: ${res.msg}`);
         }
       })
       .catch(error => {
         this.setState({rollbackLoadingName: ""});
-        Setting.showMessage("error", `Rollback failed: ${error}`);
+        Setting.showMessage("error", `${i18next.t("general:Rollback failed")}: ${error}`);
       });
   }
 
@@ -85,35 +116,35 @@ class SnapshotListPage extends BaseListPage {
     const snapshot = this.state.detailSnapshot;
     const fileColumns = [
       {
-        title: "Path",
+        title: i18next.t("general:Path"),
         dataIndex: "path",
         key: "path",
         render: (text) => <Typography.Text copyable>{text}</Typography.Text>,
       },
       {
-        title: "Change",
+        title: i18next.t("general:Change"),
         dataIndex: "changeType",
         key: "changeType",
         width: "110px",
-        render: (text) => <Tag>{text}</Tag>,
+        render: (text) => <Tag>{this.getChangeTypeText(text)}</Tag>,
       },
       {
-        title: "Before",
+        title: i18next.t("general:Before"),
         key: "before",
         width: "240px",
-        render: (_, record) => record.beforeExists ? `${record.beforeHash.slice(0, 12)} ${record.beforeMode.toString(8)} ${Setting.getFriendlyFileSize(record.beforeSize)}` : "missing",
+        render: (_, record) => record.beforeExists ? `${record.beforeHash.slice(0, 12)} ${record.beforeMode.toString(8)} ${Setting.getFriendlyFileSize(record.beforeSize)}` : i18next.t("general:Missing"),
       },
       {
-        title: "After",
+        title: i18next.t("general:After"),
         key: "after",
         width: "240px",
-        render: (_, record) => record.afterExists ? `${record.afterHash.slice(0, 12)} ${record.afterMode.toString(8)} ${Setting.getFriendlyFileSize(record.afterSize)}` : "missing",
+        render: (_, record) => record.afterExists ? `${record.afterHash.slice(0, 12)} ${record.afterMode.toString(8)} ${Setting.getFriendlyFileSize(record.afterSize)}` : i18next.t("general:Missing"),
       },
     ];
 
     return (
       <Modal
-        title="Snapshot details"
+        title={i18next.t("general:Snapshot details")}
         open={this.state.detailVisible}
         onCancel={() => this.setState({detailVisible: false, detailSnapshot: null})}
         footer={null}
@@ -154,14 +185,14 @@ class SnapshotListPage extends BaseListPage {
         key: "action",
         width: "100px",
         filters: [
-          {text: "write", value: "write"},
-          {text: "move", value: "move"},
+          {text: i18next.t("general:Write"), value: "write"},
+          {text: i18next.t("general:Move"), value: "move"},
         ],
         onFilter: (value, record) => record.action === value,
-        render: (text) => <Tag>{text}</Tag>,
+        render: (text) => <Tag>{this.getActionText(text)}</Tag>,
       },
       {
-        title: "Path",
+        title: i18next.t("general:Path"),
         key: "path",
         ...this.getColumnSearchProps("path"),
         render: (_, record) => (
@@ -171,7 +202,7 @@ class SnapshotListPage extends BaseListPage {
         ),
       },
       {
-        title: "Files",
+        title: i18next.t("general:Files"),
         key: "files",
         width: "90px",
         render: (_, record) => record.fileCount || 0,
@@ -184,7 +215,7 @@ class SnapshotListPage extends BaseListPage {
         render: (text) => this.getStateTag(text),
       },
       {
-        title: "Error",
+        title: i18next.t("message:Error text"),
         dataIndex: "errorText",
         key: "errorText",
         width: "220px",
@@ -198,17 +229,17 @@ class SnapshotListPage extends BaseListPage {
         fixed: "right",
         render: (_, record) => (
           <div style={{display: "flex", alignItems: "center", gap: "2px", flexWrap: "nowrap"}}>
-            <Tooltip title="Details">
+            <Tooltip title={i18next.t("general:Details")}>
               <Button type="text" size="small" icon={<EyeOutlined />} style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}} onClick={() => this.showDetails(record)} />
             </Tooltip>
             {record.state === "Active" && (
               <Popconfirm
-                title={`Rollback snapshot: ${record.name}?`}
+                title={`${i18next.t("general:Rollback snapshot")}: ${record.name}?`}
                 onConfirm={() => this.rollbackSnapshot(record)}
                 okText={i18next.t("general:OK")}
                 cancelText={i18next.t("general:Cancel")}
               >
-                <Tooltip title="Rollback">
+                <Tooltip title={i18next.t("general:Rollback")}>
                   <Button type="text" size="small" icon={<RollbackOutlined />} loading={this.state.rollbackLoadingName === record.name} style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}} />
                 </Tooltip>
               </Popconfirm>
@@ -236,7 +267,7 @@ class SnapshotListPage extends BaseListPage {
           size="middle"
           bordered
           pagination={paginationProps}
-          title={() => <div>Snapshots</div>}
+          title={() => <div>{i18next.t("general:Snapshots")}</div>}
           loading={this.state.loading}
           onChange={this.handleTableChange}
         />

--- a/web/src/SnapshotListPage.js
+++ b/web/src/SnapshotListPage.js
@@ -285,8 +285,7 @@ class SnapshotListPage extends BaseListPage {
       searchedColumn: field,
       searchText: value,
     });
-    const owner = Setting.getRequestOrganization(this.props.account);
-    SnapshotBackend.getSnapshots(owner, pagination.current, pagination.pageSize, field, value, params.sortField || "", params.sortOrder || "")
+    SnapshotBackend.getSnapshots("admin", pagination.current, pagination.pageSize, field, value, params.sortField || "", params.sortOrder || "")
       .then((res) => {
         if (res.status === "ok") {
           this.setState({

--- a/web/src/SnapshotListPage.js
+++ b/web/src/SnapshotListPage.js
@@ -100,14 +100,14 @@ class SnapshotListPage extends BaseListPage {
       {
         title: "Before",
         key: "before",
-        width: "180px",
-        render: (_, record) => record.beforeExists ? `${record.beforeHash.slice(0, 12)} ${record.beforeMode.toString(8)}` : "missing",
+        width: "240px",
+        render: (_, record) => record.beforeExists ? `${record.beforeHash.slice(0, 12)} ${record.beforeMode.toString(8)} ${Setting.getFriendlyFileSize(record.beforeSize)}` : "missing",
       },
       {
         title: "After",
         key: "after",
-        width: "180px",
-        render: (_, record) => record.afterExists ? `${record.afterHash.slice(0, 12)} ${record.afterMode.toString(8)}` : "missing",
+        width: "240px",
+        render: (_, record) => record.afterExists ? `${record.afterHash.slice(0, 12)} ${record.afterMode.toString(8)} ${Setting.getFriendlyFileSize(record.afterSize)}` : "missing",
       },
     ];
 
@@ -174,7 +174,7 @@ class SnapshotListPage extends BaseListPage {
         title: "Files",
         key: "files",
         width: "90px",
-        render: (_, record) => record.files?.length || 0,
+        render: (_, record) => record.fileCount || 0,
       },
       {
         title: i18next.t("general:State"),

--- a/web/src/SnapshotListPage.js
+++ b/web/src/SnapshotListPage.js
@@ -285,7 +285,8 @@ class SnapshotListPage extends BaseListPage {
       searchedColumn: field,
       searchText: value,
     });
-    SnapshotBackend.getSnapshots("admin", pagination.current, pagination.pageSize, field, value, params.sortField || "", params.sortOrder || "")
+    const owner = Setting.getRequestOrganization(this.props.account);
+    SnapshotBackend.getSnapshots(owner, pagination.current, pagination.pageSize, field, value, params.sortField || "", params.sortOrder || "")
       .then((res) => {
         if (res.status === "ok") {
           this.setState({

--- a/web/src/SnapshotListPage.js
+++ b/web/src/SnapshotListPage.js
@@ -1,0 +1,280 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from "react";
+import {Button, Modal, Popconfirm, Table, Tag, Tooltip, Typography} from "antd";
+import BaseListPage from "./BaseListPage";
+import * as Setting from "./Setting";
+import * as SnapshotBackend from "./backend/SnapshotBackend";
+import i18next from "i18next";
+import {EyeOutlined, RollbackOutlined} from "@ant-design/icons";
+
+class SnapshotListPage extends BaseListPage {
+  constructor(props) {
+    super(props);
+    this.state = {
+      ...this.state,
+      detailVisible: false,
+      detailSnapshot: null,
+      detailLoading: false,
+      rollbackLoadingName: "",
+    };
+  }
+
+  getSnapshotPath(record) {
+    if (record.action === "move") {
+      return `${record.source} -> ${record.target}`;
+    }
+    return record.path;
+  }
+
+  getStateTag(state) {
+    if (state === "RolledBack") {
+      return <Tag color="blue">RolledBack</Tag>;
+    }
+    return <Tag color="green">{state || "Active"}</Tag>;
+  }
+
+  showDetails(record) {
+    this.setState({detailVisible: true, detailLoading: true, detailSnapshot: null});
+    SnapshotBackend.getSnapshot(record.owner, record.name)
+      .then((res) => {
+        if (res.status === "ok") {
+          this.setState({detailSnapshot: res.data, detailLoading: false});
+        } else {
+          this.setState({detailLoading: false});
+          Setting.showMessage("error", `${i18next.t("general:Failed to get")}: ${res.msg}`);
+        }
+      })
+      .catch(error => {
+        this.setState({detailLoading: false});
+        Setting.showMessage("error", `${i18next.t("general:Failed to get")}: ${error}`);
+      });
+  }
+
+  rollbackSnapshot(record) {
+    this.setState({rollbackLoadingName: record.name});
+    SnapshotBackend.rollbackSnapshot(record.owner, record.name)
+      .then((res) => {
+        this.setState({rollbackLoadingName: ""});
+        if (res.status === "ok") {
+          Setting.showMessage("success", "Snapshot rolled back");
+          this.fetch({pagination: this.state.pagination});
+        } else {
+          Setting.showMessage("error", `Rollback failed: ${res.msg}`);
+        }
+      })
+      .catch(error => {
+        this.setState({rollbackLoadingName: ""});
+        Setting.showMessage("error", `Rollback failed: ${error}`);
+      });
+  }
+
+  renderDetailsModal() {
+    const snapshot = this.state.detailSnapshot;
+    const fileColumns = [
+      {
+        title: "Path",
+        dataIndex: "path",
+        key: "path",
+        render: (text) => <Typography.Text copyable>{text}</Typography.Text>,
+      },
+      {
+        title: "Change",
+        dataIndex: "changeType",
+        key: "changeType",
+        width: "110px",
+        render: (text) => <Tag>{text}</Tag>,
+      },
+      {
+        title: "Before",
+        key: "before",
+        width: "180px",
+        render: (_, record) => record.beforeExists ? `${record.beforeHash.slice(0, 12)} ${record.beforeMode.toString(8)}` : "missing",
+      },
+      {
+        title: "After",
+        key: "after",
+        width: "180px",
+        render: (_, record) => record.afterExists ? `${record.afterHash.slice(0, 12)} ${record.afterMode.toString(8)}` : "missing",
+      },
+    ];
+
+    return (
+      <Modal
+        title="Snapshot details"
+        open={this.state.detailVisible}
+        onCancel={() => this.setState({detailVisible: false, detailSnapshot: null})}
+        footer={null}
+        width={900}
+      >
+        <Table
+          size="small"
+          bordered
+          loading={this.state.detailLoading}
+          columns={fileColumns}
+          dataSource={snapshot?.files || []}
+          rowKey="path"
+          pagination={false}
+          scroll={{x: "max-content"}}
+        />
+        {snapshot?.diff && (
+          <pre style={{marginTop: "12px", maxHeight: "360px", overflow: "auto", background: "rgba(0,0,0,0.04)", padding: "12px", borderRadius: "6px", whiteSpace: "pre-wrap"}}>
+            {snapshot.diff}
+          </pre>
+        )}
+      </Modal>
+    );
+  }
+
+  renderTable(snapshots) {
+    const columns = [
+      {
+        title: i18next.t("general:Created time"),
+        dataIndex: "createdTime",
+        key: "createdTime",
+        width: "180px",
+        sorter: (a, b) => a.createdTime.localeCompare(b.createdTime),
+        render: (text) => Setting.getFormattedDate(text),
+      },
+      {
+        title: i18next.t("general:Action"),
+        dataIndex: "action",
+        key: "action",
+        width: "100px",
+        filters: [
+          {text: "write", value: "write"},
+          {text: "move", value: "move"},
+        ],
+        onFilter: (value, record) => record.action === value,
+        render: (text) => <Tag>{text}</Tag>,
+      },
+      {
+        title: "Path",
+        key: "path",
+        ...this.getColumnSearchProps("path"),
+        render: (_, record) => (
+          <Tooltip title={this.getSnapshotPath(record)}>
+            <Typography.Text copyable>{Setting.getShortText(this.getSnapshotPath(record), 96)}</Typography.Text>
+          </Tooltip>
+        ),
+      },
+      {
+        title: "Files",
+        key: "files",
+        width: "90px",
+        render: (_, record) => record.files?.length || 0,
+      },
+      {
+        title: i18next.t("general:State"),
+        dataIndex: "state",
+        key: "state",
+        width: "120px",
+        render: (text) => this.getStateTag(text),
+      },
+      {
+        title: "Error",
+        dataIndex: "errorText",
+        key: "errorText",
+        width: "220px",
+        render: (text) => text ? Setting.getShortText(text, 80) : null,
+      },
+      {
+        title: i18next.t("general:Action"),
+        dataIndex: "action",
+        key: "tableAction",
+        width: "120px",
+        fixed: "right",
+        render: (_, record) => (
+          <div style={{display: "flex", alignItems: "center", gap: "2px", flexWrap: "nowrap"}}>
+            <Tooltip title="Details">
+              <Button type="text" size="small" icon={<EyeOutlined />} style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}} onClick={() => this.showDetails(record)} />
+            </Tooltip>
+            {record.state === "Active" && (
+              <Popconfirm
+                title={`Rollback snapshot: ${record.name}?`}
+                onConfirm={() => this.rollbackSnapshot(record)}
+                okText={i18next.t("general:OK")}
+                cancelText={i18next.t("general:Cancel")}
+              >
+                <Tooltip title="Rollback">
+                  <Button type="text" size="small" icon={<RollbackOutlined />} loading={this.state.rollbackLoadingName === record.name} style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}} />
+                </Tooltip>
+              </Popconfirm>
+            )}
+          </div>
+        ),
+      },
+    ];
+
+    const paginationProps = {
+      total: this.state.pagination.total,
+      showQuickJumper: true,
+      showSizeChanger: true,
+      pageSizeOptions: ["10", "20", "50", "100"],
+      showTotal: (total) => i18next.t("general:{total} in total").replace("{total}", total),
+    };
+
+    return (
+      <div>
+        <Table
+          scroll={{x: "max-content"}}
+          columns={columns}
+          dataSource={snapshots}
+          rowKey="name"
+          size="middle"
+          bordered
+          pagination={paginationProps}
+          title={() => <div>Snapshots</div>}
+          loading={this.state.loading}
+          onChange={this.handleTableChange}
+        />
+        {this.renderDetailsModal()}
+      </div>
+    );
+  }
+
+  fetch = (params = {}) => {
+    const pagination = params.pagination || this.state.pagination;
+    const field = params.searchedColumn || this.state.searchedColumn || "";
+    const value = params.searchText || this.state.searchText || "";
+    this.setState({
+      loading: true,
+      searchedColumn: field,
+      searchText: value,
+    });
+    SnapshotBackend.getSnapshots("admin", pagination.current, pagination.pageSize, field, value, params.sortField || "", params.sortOrder || "")
+      .then((res) => {
+        if (res.status === "ok") {
+          this.setState({
+            loading: false,
+            data: res.data,
+            pagination: {
+              ...pagination,
+              total: res.data2,
+            },
+          });
+        } else {
+          if (res.status === "error" && res.msg === "Unauthorized") {
+            this.setState({isAuthorized: false, loading: false});
+          } else {
+            this.setState({loading: false});
+            Setting.showMessage("error", `${i18next.t("general:Failed to get")}: ${res.msg}`);
+          }
+        }
+      });
+  };
+}
+
+export default SnapshotListPage;

--- a/web/src/backend/SnapshotBackend.js
+++ b/web/src/backend/SnapshotBackend.js
@@ -1,0 +1,45 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as Setting from "../Setting";
+
+export function getSnapshots(owner, page = "", pageSize = "", field = "", value = "", sortField = "", sortOrder = "") {
+  return fetch(`${Setting.ServerUrl}/api/get-snapshots?owner=${owner}&p=${page}&pageSize=${pageSize}&field=${field}&value=${value}&sortField=${sortField}&sortOrder=${sortOrder}`, {
+    method: "GET",
+    credentials: "include",
+    headers: {
+      "Accept-Language": Setting.getAcceptLanguage(),
+    },
+  }).then(res => Setting.handleFetchResponse(res));
+}
+
+export function getSnapshot(owner, name) {
+  return fetch(`${Setting.ServerUrl}/api/get-snapshot?id=${owner}/${encodeURIComponent(name)}`, {
+    method: "GET",
+    credentials: "include",
+    headers: {
+      "Accept-Language": Setting.getAcceptLanguage(),
+    },
+  }).then(res => Setting.handleFetchResponse(res));
+}
+
+export function rollbackSnapshot(owner, name) {
+  return fetch(`${Setting.ServerUrl}/api/rollback-snapshot?id=${owner}/${encodeURIComponent(name)}`, {
+    method: "POST",
+    credentials: "include",
+    headers: {
+      "Accept-Language": Setting.getAcceptLanguage(),
+    },
+  }).then(res => Setting.handleFetchResponse(res));
+}

--- a/web/src/component/nav-item-tree/NavItemTree.js
+++ b/web/src/component/nav-item-tree/NavItemTree.js
@@ -71,6 +71,7 @@ export const NavItemTree = ({disabled, casdoorAvailable, checkedKeys, defaultExp
           children: [
             {title: i18next.t("general:Logs"), key: "/records"},
             {title: i18next.t("general:Sessions"), key: "/sessions"},
+            {title: i18next.t("general:Snapshots"), key: "/snapshots"},
           ],
         },
         {


### PR DESCRIPTION
## Summary
- Add snapshot records for local file write and move operations.
- Provide a Snapshots page to inspect changed files and rollback snapshots.
- Support rollback for modified, created, and deleted files.
- Add sidebar/navigation entry for Snapshots under Auditing Logs.

## Notes
- Snapshots are created for `local_file_write` and `local_file_move`.