### PR TITLE
feat: add support for GPT-5.5 and Claude Opus 4.7 models

### DIFF
--- a/model/claude.go
+++ b/model/claude.go
@@ -44,6 +44,7 @@ https://docs.anthropic.com/en/docs/about-claude/pricing
 
 | Model family        | Context window | Input Pricing         | Output Pricing        |
 |---------------------|----------------|-----------------------|-----------------------|
+| Claude Opus 4.7     | 1,000,000 tokens| $5.00/million tokens  | $25.00/million tokens |
 | Claude Opus 4.5     | 200,000 tokens | $5.00/million tokens  | $25.00/million tokens |
 | Claude Opus 4.1     | 200,000 tokens | $15.00/million tokens | $75.00/million tokens |
 | Claude Opus 4       | 200,000 tokens | $15.00/million tokens | $75.00/million tokens |
@@ -59,6 +60,7 @@ https://docs.anthropic.com/en/docs/about-claude/pricing
 func (p *ClaudeModelProvider) calculatePrice(modelResult *ModelResult, lang string) error {
 	var inputPricePerThousandTokens, outputPricePerThousandTokens float64
 	priceTable := map[string][]float64{
+		"claude-opus-4-7":            {0.005, 0.025},
 		"claude-opus-4-5":            {0.005, 0.025},
 		"claude-opus-4-1":            {0.015, 0.075},
 		"claude-opus-4-0":            {0.015, 0.075},

--- a/model/context_length_util.go
+++ b/model/context_length_util.go
@@ -128,6 +128,9 @@ func getContextLength(typ string) int {
 			if strings.Contains(typ, "sonnet") {
 				return 64000
 			} else if strings.Contains(typ, "opus") {
+				if strings.Contains(typ, "4-7") {
+					return 1000000
+				}
 				return 32000
 			}
 		} else if strings.Contains(typ, "3-7") {
@@ -194,6 +197,8 @@ func getContextLength(typ string) int {
 			return 128000
 		} else if strings.Contains(typ, "deep-research") {
 			return 200000
+		} else if strings.Contains(typ, "5.5") {
+			return 1050000
 		} else if strings.Contains(typ, "5.2") || strings.Contains(typ, "5.1") || strings.Contains(typ, "5") {
 			return 400000
 		} else if strings.Contains(typ, "4.5") || strings.Contains(typ, "4o") {

--- a/model/openai.go
+++ b/model/openai.go
@@ -135,6 +135,12 @@ func CalculateOpenAIModelPrice(model string, modelResult *ModelResult, lang stri
 		}
 		modelResult.Currency = "USD"
 
+	// gpt 5.5 model
+	case strings.Contains(model, "gpt-5.5"):
+		inputPricePerThousandTokens = 0.005
+		outputPricePerThousandTokens = 0.030
+		modelResult.Currency = "USD"
+
 	// gpt 5.2 model (includes gpt-5.2-chat which uses same pricing)
 	case strings.Contains(model, "gpt-5.2"):
 		if strings.Contains(model, "5.2-mini") {
@@ -251,6 +257,10 @@ Language models:
 | o3                    | 200K    | $0.002                   | $0.008                   |
 | o3-mini               | 200K    | $0.0011                  | $0.0044                  |
 | o4-mini               | 200K    | $0.0011                  | $0.0044                  |
+| GPT-5.5               | 1050K   | $0.005                   | $0.030                   |
+| GPT-5.5-Pro           | 1050K   | $0.005                   | $0.030                   |
+| GPT-5.5-Instant       | 1050K   | $0.005                   | $0.030                   |
+| GPT-5.5-Cyber         | 1050K   | $0.005                   | $0.030                   |
 | GPT-5                 | 400K    | $0.00125                 | $0.01                    |
 | GPT-5-mini            | 400K    | $0.00025                 | $0.002                   |
 | GPT-5-nano            | 400K    | $0.00005                 | $0.0004                  |

--- a/model/openai_util.go
+++ b/model/openai_util.go
@@ -60,7 +60,9 @@ func GetOpenAiMaxTokens(model string) int {
 
 func getOpenAiModelType(model string) string {
 	chatModels := []string{
-		// GPT-5.4 series (latest)
+		// GPT-5.5 series (latest)
+		"gpt-5.5", "gpt-5.5-pro", "gpt-5.5-instant", "gpt-5.5-cyber",
+		// GPT-5.4 series
 		"gpt-5.4", "gpt-5.4-pro", "gpt-5.4-mini", "gpt-5.4-nano",
 		// GPT-5.3 series
 		"gpt-5.3-codex", "gpt-5.3-chat",

--- a/web/src/ProviderSetting.js
+++ b/web/src/ProviderSetting.js
@@ -392,7 +392,12 @@ export function getCompatibleProviderOptions(category) {
   if (category === "Model") {
     return (
       [
-        // GPT-5.4 series (latest)
+        // GPT-5.5 series (latest)
+        {"id": "gpt-5.5", "name": "gpt-5.5"},
+        {"id": "gpt-5.5-pro", "name": "gpt-5.5-pro"},
+        {"id": "gpt-5.5-instant", "name": "gpt-5.5-instant"},
+        {"id": "gpt-5.5-cyber", "name": "gpt-5.5-cyber"},
+        // GPT-5.4 series
         {"id": "gpt-5.4", "name": "gpt-5.4"},
         {"id": "gpt-5.4-pro", "name": "gpt-5.4-pro"},
         {"id": "gpt-5.4-mini", "name": "gpt-5.4-mini"},
@@ -447,7 +452,12 @@ export function getCompatibleProviderOptions(category) {
 }
 
 const openaiModels = [
-  // GPT-5.4 series (latest)
+  // GPT-5.5 series (latest)
+  {id: "gpt-5.5", name: "gpt-5.5"},
+  {id: "gpt-5.5-pro", name: "gpt-5.5-pro"},
+  {id: "gpt-5.5-instant", name: "gpt-5.5-instant"},
+  {id: "gpt-5.5-cyber", name: "gpt-5.5-cyber"},
+  // GPT-5.4 series
   {id: "gpt-5.4", name: "gpt-5.4"},
   {id: "gpt-5.4-pro", name: "gpt-5.4-pro"},
   {id: "gpt-5.4-mini", name: "gpt-5.4-mini"},
@@ -767,6 +777,7 @@ export function getModelSubTypeOptions(type) {
     ];
   } else if (type === "Claude") {
     return [
+      {id: "claude-opus-4-7", name: "claude-opus-4-7"},
       {id: "claude-opus-4-5", name: "claude-opus-4-5"},
       {id: "claude-opus-4-1", name: "claude-opus-4-1"},
       {id: "claude-opus-4-0", name: "claude-opus-4-0"},
@@ -785,6 +796,7 @@ export function getModelSubTypeOptions(type) {
     ];
   } else if (type === "OpenRouter") {
     return [
+      {id: "anthropic/claude-opus-4-7", name: "anthropic/claude-opus-4-7"},
       {id: "anthropic/claude-opus-4-5", name: "anthropic/claude-opus-4-5"},
       {id: "anthropic/claude-sonnet-4-0", name: "anthropic/claude-sonnet-4-0"},
       {id: "openai/gpt-4.1", name: "openai/gpt-4.1"},
@@ -1332,15 +1344,15 @@ export function getQuickSetupModelTypes() {
 
 export function getModelProviderMetadata(type) {
   const metadata = {
-    "OpenAI": {desc: "GPT-5.4, GPT-4.1, o3...", needsApiKey: true, needsUrl: false, needsClientId: false, needsRegion: false, defaultSubType: "gpt-5.4"},
-    "Claude": {desc: "Claude Opus, Sonnet...", needsApiKey: true, needsUrl: false, needsClientId: false, needsRegion: false, defaultSubType: "claude-opus-4-5"},
+    "OpenAI": {desc: "GPT-5.5, GPT-4.1, o3...", needsApiKey: true, needsUrl: false, needsClientId: false, needsRegion: false, defaultSubType: "gpt-5.5"},
+    "Claude": {desc: "Claude Opus, Sonnet...", needsApiKey: true, needsUrl: false, needsClientId: false, needsRegion: false, defaultSubType: "claude-opus-4-7"},
     "Gemini": {desc: "Gemini 2.5 Pro, Flash...", needsApiKey: true, needsUrl: false, needsClientId: false, needsRegion: false, defaultSubType: "gemini-2.5-pro"},
     "DeepSeek": {desc: "DeepSeek-V4, R1...", needsApiKey: true, needsUrl: false, needsClientId: false, needsRegion: false, defaultSubType: "deepseek-v4-pro"},
     "Grok": {desc: "Grok-3, Grok-2...", needsApiKey: true, needsUrl: false, needsClientId: false, needsRegion: false, defaultSubType: "grok-3-latest"},
     "Ollama": {desc: "Run models locally", needsApiKey: false, needsUrl: true, needsClientId: false, needsRegion: false, defaultSubType: "deepseek-r1:671b", urlPlaceholder: "http://localhost:11434", defaultUrl: "http://localhost:11434"},
-    "OpenRouter": {desc: "100+ models unified", needsApiKey: true, needsUrl: false, needsClientId: false, needsRegion: false, defaultSubType: "anthropic/claude-opus-4-5"},
+    "OpenRouter": {desc: "100+ models unified", needsApiKey: true, needsUrl: false, needsClientId: false, needsRegion: false, defaultSubType: "anthropic/claude-opus-4-7"},
     "Mistral": {desc: "Mistral Large, Medium...", needsApiKey: true, needsUrl: false, needsClientId: false, needsRegion: false, defaultSubType: "mistral-large-latest"},
-    "Azure": {desc: "Azure-hosted GPT models", needsApiKey: true, needsUrl: true, needsClientId: false, needsRegion: false, defaultSubType: "gpt-5.4", urlPlaceholder: "https://your-resource.openai.azure.com"},
+    "Azure": {desc: "Azure-hosted GPT models", needsApiKey: true, needsUrl: true, needsClientId: false, needsRegion: false, defaultSubType: "gpt-5.5", urlPlaceholder: "https://your-resource.openai.azure.com"},
     "OpenAI Compatible": {desc: "Any compatible API", needsApiKey: true, needsUrl: true, needsClientId: false, needsRegion: false, defaultSubType: "", urlPlaceholder: "https://api.example.com/v1"},
     "Alibaba Cloud": {desc: "Qwen3, Qwen-Max...", needsApiKey: true, needsUrl: false, needsClientId: false, needsRegion: false, defaultSubType: "qwen3-235b-a22b"},
     "Moonshot": {desc: "Kimi K2, long-context models", needsApiKey: true, needsUrl: false, needsClientId: false, needsRegion: false, defaultSubType: "kimi-k2-0905-preview"},


### PR DESCRIPTION
## Summary

This PR introduces support for the latest flagship models released in April/May 2026: 

OpenAI GPT-5.5 and Anthropic Claude 4.7 Opus. 

The update covers both backend logic (pricing, context limits, model identification) and frontend UI (model selection, default provider settings).

## References
- **OpenAI GPT-5.5**: [Official Announcement](https://openai.com), [OpenRouter Specs](https://openrouter.ai/models/openai/gpt-5.5)
- **Claude 4.7 Opus**: [Anthropic News](https://www.anthropic.com/news/claude-4-7-opus), [Caylent Benchmarks](https://caylent.com/blog/claude-4-7-opus-analysis)