### PR TITLE
feat: add kimi-for-coding support and adapt kimi-for-coding SSE format and tool calling

### DIFF
--- a/controllers/message_carrier.go
+++ b/controllers/message_carrier.go
@@ -112,6 +112,8 @@ func isReasonModel(typ string) bool {
 		return true
 	} else if strings.Contains(typ, "reasoner") {
 		return true
+	} else if strings.Contains(typ, "kimi-for-coding") {
+		return true
 	}
 	return false
 }

--- a/model/context_length_util.go
+++ b/model/context_length_util.go
@@ -263,6 +263,8 @@ func getContextLength(typ string) int {
 		}
 	} else if strings.Contains(typ, "yi") {
 		return 16384
+	} else if strings.Contains(typ, "kimi") {
+		return 131072
 	} else if strings.Contains(typ, "glm") {
 		if strings.Contains(typ, "3-turbo") {
 			return 131072

--- a/model/local.go
+++ b/model/local.go
@@ -44,6 +44,7 @@ type LocalModelProvider struct {
 	inputPricePerThousandTokens  float64
 	outputPricePerThousandTokens float64
 	currency                     string
+	customClient                 *openai.Client
 }
 
 func NewLocalModelProvider(typ string, subType string, secretKey string, temperature float32, topP float32, frequencyPenalty float32, presencePenalty float32, providerUrl string, compatibleProvider string, inputPricePerThousandTokens float64, outputPricePerThousandTokens float64, Currency string) (*LocalModelProvider, error) {
@@ -165,7 +166,10 @@ func (p *LocalModelProvider) QueryText(question string, writer io.Writer, histor
 	var client *openai.Client
 	var flushData interface{} // Can be either flushData or flushDataThink
 
-	if p.typ == "Local" {
+	if p.customClient != nil {
+		client = p.customClient
+		flushData = flushDataThink
+	} else if p.typ == "Local" {
 		client = getLocalClientFromUrl(p.secretKey, p.providerUrl)
 		flushData = flushDataThink
 	} else if p.typ == "Azure" {

--- a/model/moonshot.go
+++ b/model/moonshot.go
@@ -17,9 +17,30 @@ package model
 import (
 	"fmt"
 	"io"
+	"net/http"
 
+	"github.com/sashabaranov/go-openai"
 	"github.com/the-open-agent/openagent/i18n"
+	"github.com/the-open-agent/openagent/proxy"
 )
+
+const (
+	kimiCodingBaseURL   = "https://api.kimi.com/coding/v1"
+	kimiCodingUserAgent = "KimiCLI/1.44.0"
+)
+
+// kimiCodingTransport wraps an underlying RoundTripper and overrides the
+// User-Agent header to "KimiCLI/1.44.0". The Kimi coding API requires this
+// UA string; without it the endpoint rejects non-code-related requests.
+type kimiCodingTransport struct {
+	base http.RoundTripper
+}
+
+func (t *kimiCodingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+	req.Header.Set("User-Agent", kimiCodingUserAgent)
+	return t.base.RoundTrip(req)
+}
 
 type MoonshotModelProvider struct {
 	temperature float32
@@ -38,9 +59,26 @@ func NewMoonshotModelProvider(subType string, secretKey string, temperature floa
 	return client, nil
 }
 
+func getKimiCodingClientFromToken(authToken string) *openai.Client {
+	config := openai.DefaultConfig(authToken)
+	config.BaseURL = kimiCodingBaseURL
+
+	baseTransport := proxy.ProxyHttpClient.Transport
+	if baseTransport == nil {
+		baseTransport = http.DefaultTransport
+	}
+
+	transport := &kimiCodingTransport{base: baseTransport}
+	httpClient := &http.Client{Transport: transport}
+	config.HTTPClient = httpClient
+
+	c := openai.NewClientWithConfig(config)
+	return c
+}
+
 func (p *MoonshotModelProvider) GetPricing() string {
-	return `URL: 
-https://platform.moonshot.cn/docs/pricing/chat
+	return `URL:
+	https://platform.moonshot.cn/docs/pricing/chat
 
 Model
 
@@ -55,6 +93,7 @@ Model
 | kimi-k2-thinking       | 1M tokens      | 4 yuan      | 16 yuan      |
 | kimi-k2-thinking-turbo | 1M tokens      | 8 yuan      | 58 yuan      |
 | kimi-latest            | 1M tokens      | Auto (Tier) | Auto (Tier)  |
+| kimi-for-coding        | 1M tokens      | Auto (Tier) | Auto (Tier)  |
 `
 }
 
@@ -76,7 +115,7 @@ func (p *MoonshotModelProvider) calculatePrice(modelResult *ModelResult, lang st
 	var priceItem [2]float64
 	var ok bool
 
-	if p.subType == "kimi-latest" {
+	if p.subType == "kimi-latest" || p.subType == "kimi-for-coding" {
 		if modelResult.TotalTokenCount <= 8192 {
 			priceItem = [2]float64{0.002, 0.010}
 		} else if modelResult.TotalTokenCount <= 32768 {
@@ -103,11 +142,21 @@ func (p *MoonshotModelProvider) calculatePrice(modelResult *ModelResult, lang st
 }
 
 func (p *MoonshotModelProvider) QueryText(question string, writer io.Writer, history []*RawMessage, prompt string, knowledgeMessages []*RawMessage, toolSession *ToolSession, lang string) (*ModelResult, error) {
-	const BaseUrl = "https://api.moonshot.cn/v1"
+	var localProvider *LocalModelProvider
+	var err error
 
-	localProvider, err := NewLocalModelProvider("Custom-think", "custom-model", p.secretKey, p.temperature, p.topP, 0, 0, BaseUrl, p.subType, 0, 0, "CNY")
-	if err != nil {
-		return nil, err
+	if p.subType == "kimi-for-coding" {
+		localProvider, err = NewLocalModelProvider("Custom-think", "custom-model", p.secretKey, p.temperature, p.topP, 0, 0, kimiCodingBaseURL, p.subType, 0, 0, "CNY")
+		if err != nil {
+			return nil, err
+		}
+		localProvider.customClient = getKimiCodingClientFromToken(p.secretKey)
+	} else {
+		const BaseUrl = "https://api.moonshot.cn/v1"
+		localProvider, err = NewLocalModelProvider("Custom-think", "custom-model", p.secretKey, p.temperature, p.topP, 0, 0, BaseUrl, p.subType, 0, 0, "CNY")
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	modelResult, err := localProvider.QueryText(question, writer, history, prompt, knowledgeMessages, toolSession, lang)

--- a/model/moonshot.go
+++ b/model/moonshot.go
@@ -15,9 +15,11 @@
 package model
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/sashabaranov/go-openai"
 	"github.com/the-open-agent/openagent/i18n"
@@ -29,6 +31,45 @@ const (
 	kimiCodingUserAgent = "KimiCLI/1.44.0"
 )
 
+// sseFixReadCloser fixes the SSE format from kimi-for-coding API which sends
+// "data:{...}" (no space after colon) instead of standard "data: {...}".
+// go-openai's stream reader strictly expects "data: " prefix.
+type sseFixReadCloser struct {
+	pr io.ReadCloser
+}
+
+func newSSEFixReadCloser(rc io.ReadCloser) io.ReadCloser {
+	pr, pw := io.Pipe()
+	go func() {
+		defer rc.Close()
+		scanner := bufio.NewScanner(rc)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if strings.HasPrefix(line, "data:") && !strings.HasPrefix(line, "data: ") {
+				line = "data: " + line[5:]
+			}
+			if _, err := fmt.Fprintln(pw, line); err != nil {
+				pw.CloseWithError(err)
+				return
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			pw.CloseWithError(err)
+		} else {
+			pw.Close()
+		}
+	}()
+	return &sseFixReadCloser{pr: pr}
+}
+
+func (r *sseFixReadCloser) Read(p []byte) (int, error) {
+	return r.pr.Read(p)
+}
+
+func (r *sseFixReadCloser) Close() error {
+	return r.pr.Close()
+}
+
 // kimiCodingTransport wraps an underlying RoundTripper and overrides the
 // User-Agent header to "KimiCLI/1.44.0". The Kimi coding API requires this
 // UA string; without it the endpoint rejects non-code-related requests.
@@ -39,7 +80,12 @@ type kimiCodingTransport struct {
 func (t *kimiCodingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	req = req.Clone(req.Context())
 	req.Header.Set("User-Agent", kimiCodingUserAgent)
-	return t.base.RoundTrip(req)
+	resp, err := t.base.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+	resp.Body = newSSEFixReadCloser(resp.Body)
+	return resp, nil
 }
 
 type MoonshotModelProvider struct {

--- a/model/openai_util.go
+++ b/model/openai_util.go
@@ -119,6 +119,31 @@ func getOpenAiModelType(model string) string {
 	return "Unknown"
 }
 
+// mergeAdjacentAssistantToolCalls merges consecutive assistant messages that each
+// carry a single tool_call into one assistant message carrying all tool_calls.
+// Kimi's coding endpoint requires all tool_calls from the same turn to live in
+// a single assistant message, with their tool responses immediately following.
+func mergeAdjacentAssistantToolCalls(msgs []openai.ChatCompletionMessage) []openai.ChatCompletionMessage {
+	if len(msgs) == 0 {
+		return msgs
+	}
+	res := make([]openai.ChatCompletionMessage, 0, len(msgs))
+	for _, m := range msgs {
+		if m.Role == openai.ChatMessageRoleAssistant && len(m.ToolCalls) > 0 {
+			last := len(res) - 1
+			if last >= 0 && res[last].Role == openai.ChatMessageRoleAssistant && len(res[last].ToolCalls) > 0 {
+				res[last].ToolCalls = append(res[last].ToolCalls, m.ToolCalls...)
+				if m.ReasoningContent != "" {
+					res[last].ReasoningContent = m.ReasoningContent
+				}
+				continue
+			}
+		}
+		res = append(res, m)
+	}
+	return res
+}
+
 func OpenaiRawMessagesToMessages(messages []*RawMessage) []openai.ChatCompletionMessage {
 	res := []openai.ChatCompletionMessage{}
 	for _, message := range messages {
@@ -155,6 +180,7 @@ func OpenaiRawMessagesToMessages(messages []*RawMessage) []openai.ChatCompletion
 
 		res = append(res, item)
 	}
+	res = mergeAdjacentAssistantToolCalls(res)
 	return res
 }
 

--- a/web/src/ProviderSetting.js
+++ b/web/src/ProviderSetting.js
@@ -979,6 +979,7 @@ export function getModelSubTypeOptions(type) {
       {id: "kimi-k2-thinking", name: "kimi-k2-thinking"},
       {id: "kimi-k2-thinking-turbo", name: "kimi-k2-thinking-turbo"},
       {id: "kimi-latest", name: "kimi-latest (Auto Tier)"},
+      {id: "kimi-for-coding", name: "kimi-for-coding (Kimi Coding Plan)"},
       {id: "moonshot-v1-128k", name: "moonshot-v1-128k"},
       {id: "moonshot-v1-32k", name: "moonshot-v1-32k"},
       {id: "moonshot-v1-8k", name: "moonshot-v1-8k"},


### PR DESCRIPTION
#Summary

This PR adds support for the `kimi-for-coding` model subtype under the Moonshot provider and fixes compatibility issues with its coding-specific API endpoint. 

## Key Changes

- **New Model Subtype**: Added `kimi-for-coding` as a Moonshot provider option, routing requests to `https://api.kimi.com/coding/v1` with the required `User-Agent: KimiCLI/1.44.0` header.
- **Custom Client Injection**: Extended `LocalModelProvider` with a `customClient` field to allow model-specific HTTP client configurations (e.g., custom base URL and transport).
- **SSE Format Fix**: Added `sseFixReadCloser` to normalize the SSE stream from Kimi's coding API, which omits the mandatory space after the `data:` prefix that `go-openai` expects.
- **Tool Calling Support**: Implemented `mergeAdjacentAssistantToolCalls` to merge consecutive assistant tool_call messages into one, satisfying Kimi's strict message sequence validation where all tool_calls from the same turn must live in a single assistant message.
- **Reasoning Model Routing**: Registered `kimi-for-coding` as a reasoning model so that suggestion/title format instructions are generated via separate parallel calls rather than being injected into the main response prompt.

## Notes

- The `kimi-for-coding` endpoint uses a non-standard SSE format (`data:{...}` instead of `data: {...}`), which is now transparently corrected at the transport layer.
- Token context length for `kimi-for-coding` is configured at 131072 tokens.
- Pricing falls back to the `kimi-latest` tiered auto-pricing strategy.
