### PR TITLE
fix: Improve PPTX worker source-mode setup

### DIFF
--- a/tool/office_ppt_write.go
+++ b/tool/office_ppt_write.go
@@ -148,7 +148,7 @@ func (t *pptxWriteBuiltin) Execute(ctx context.Context, arguments map[string]int
 	if err != nil {
 		return officeToolError("Node.js was not found; install Node.js to enable PowerPoint generation"), nil
 	}
-	workerPath, err := findPptxWorkerPath()
+	workerPath, err := findPptxWorkerPath(ctx)
 	if err != nil {
 		return officeToolError(err.Error()), nil
 	}
@@ -205,7 +205,7 @@ func (t *pptxWriteBuiltin) Execute(ctx context.Context, arguments map[string]int
 	)), nil
 }
 
-func findPptxWorkerPath() (string, error) {
+func findPptxWorkerPath(ctx context.Context) (string, error) {
 	var candidates []pptxWorkerCandidate
 	if exeDir, err := pptxExecutableDir(); err == nil {
 		candidates = append(candidates,
@@ -232,8 +232,10 @@ func findPptxWorkerPath() (string, error) {
 		if err != nil {
 			absPath = candidate.path
 		}
-		if candidate.requireNodeModules && !sourcePptxWorkerReady(absPath) {
-			continue
+		if candidate.requireNodeModules {
+			if err := ensureSourcePptxWorkerReady(ctx, absPath); err != nil {
+				return "", err
+			}
 		}
 		return absPath, nil
 	}
@@ -248,6 +250,34 @@ func findPptxWorkerPath() (string, error) {
 	}
 
 	return "", fmt.Errorf("PowerPoint worker not found next to the executable or in tool/pptx-worker; build with -tags embed or place worker.bundle.mjs or worker.mjs in pptx-worker")
+}
+
+func ensureSourcePptxWorkerReady(ctx context.Context, workerPath string) error {
+	if sourcePptxWorkerReady(workerPath) {
+		return nil
+	}
+
+	npmPath, err := exec.LookPath("npm")
+	if err != nil {
+		return fmt.Errorf("npm was not found; run npm ci --prefix tool/pptx-worker or install npm")
+	}
+
+	workerDir := filepath.Dir(workerPath)
+	cmd := exec.CommandContext(ctx, npmPath, "ci")
+	cmd.Dir = workerDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		detail := strings.TrimSpace(string(output))
+		if detail == "" {
+			detail = err.Error()
+		}
+		return fmt.Errorf("Failed to install PowerPoint worker dependencies with npm ci in %s: %s", workerDir, detail)
+	}
+
+	if !sourcePptxWorkerReady(workerPath) {
+		return fmt.Errorf("PowerPoint worker dependencies are still missing after npm ci in %s", workerDir)
+	}
+	return nil
 }
 
 func sourcePptxWorkerReady(workerPath string) bool {


### PR DESCRIPTION
Auto-install PPTX worker dependencies with `npm ci` when running from source and `node_modules` is missing.