### PR TITLE
fix: improve powerpoint skill

### DIFF
--- a/skills/powerpoint/SKILL.md
+++ b/skills/powerpoint/SKILL.md
@@ -15,6 +15,14 @@ Use this skill whenever a PowerPoint deck is involved. For new decks, write a tr
 4. Call `pptx_write` with `path`, `script_path`, optional `assets_dir`, and optional `data`.
 5. Verify the result with `pptx_read`; for visual QA, convert the PPTX to images if the environment has LibreOffice and Poppler.
 
+## Script File Creation
+
+- Prefer `local_file_write` to create the `.mjs` script in one complete write. Use `overwrite: true` when revising a script.
+- Do not build long JavaScript files with repeated `shell` commands such as `echo ... >> build.mjs`, especially on Windows. Shell escaping for `{}`, `()`, `>`, `&`, `|`, `%`, quotes, and newlines is fragile.
+- After the `.mjs` script is written, call `pptx_write` directly. Do not keep appending, rewriting, or checking the script with shell unless there is a concrete error.
+- To inspect a script, prefer `local_file_read`. If only shell is available, use `type C:\path\build.mjs` on Windows or `cat /path/build.mjs` on Linux/macOS.
+- `echo ... >> file` commonly returns no stdout on success. A `(no output)` shell result is not evidence that the write failed; do not retry only because output is empty.
+
 ## Tool Contract
 
 ```json

--- a/skills/powerpoint/references/pptxgenjs.md
+++ b/skills/powerpoint/references/pptxgenjs.md
@@ -1,6 +1,10 @@
 # PptxGenJS Reference
 
-Use this reference when writing the `.mjs` build script for the `pptx_generate` tool.
+Use this reference when writing the `.mjs` build script for the `pptx_write` tool.
+
+## Script File Creation
+
+Use `local_file_write` to write the `.mjs` script in one complete operation whenever that tool is available. Avoid repeated `shell` commands like `echo ... >> build.mjs`; they are brittle for JavaScript, especially on Windows. If you need to inspect the script, prefer `local_file_read`; if shell is the only option, use `type C:\path\build.mjs` on Windows or `cat /path/build.mjs` on Linux/macOS. Empty shell output from `echo ... >> file` is normal and should not trigger another rewrite by itself.
 
 ## Basic Structure
 


### PR DESCRIPTION
## Summary
- Improve the PowerPoint skill instructions for creating PptxGenJS `.mjs` scripts.
- Prefer `local_file_write` for writing build scripts instead of repeated `shell echo ... >> build.mjs`.
- Clarify Windows script inspection should use `type`, and empty output from `echo >> file` is not a failure.
- Update the PptxGenJS reference to use the current `pptx_write` tool name.