### PR TITLE
feat: Add Resources auto-archive for generated Office files

### DIFF
--- a/object/merge_agent_tools.go
+++ b/object/merge_agent_tools.go
@@ -55,7 +55,9 @@ func buildMergedBuiltinRegistry(store *Store, lang string) *tool.ToolRegistry {
 			continue
 		}
 		for _, bt := range tp.BuiltinTools() {
-			reg.RegisterTool(wrapSnapshotBuiltin(store.Owner, bt))
+			wrapped := wrapSnapshotBuiltin(store.Owner, bt)
+			wrapped = wrapGeneratedResourceBuiltin(wrapped)
+			reg.RegisterTool(wrapped)
 		}
 	}
 

--- a/object/message_tool.go
+++ b/object/message_tool.go
@@ -44,7 +44,9 @@ func buildToolSetForBuiltinTool(toolName string, lang string) (*mcp.ToolSet, err
 
 	reg := tool.NewToolRegistry()
 	for _, t := range tp.BuiltinTools() {
-		reg.RegisterTool(wrapSnapshotBuiltin("admin", t))
+		wrapped := wrapSnapshotBuiltin("admin", t)
+		wrapped = wrapGeneratedResourceBuiltin(wrapped)
+		reg.RegisterTool(wrapped)
 	}
 
 	allTools := reg.GetToolsAsProtocolTools()

--- a/object/resource_archive_tool.go
+++ b/object/resource_archive_tool.go
@@ -1,0 +1,181 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package object
+
+import (
+	"context"
+	"fmt"
+	"mime"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ThinkInAIXYZ/go-mcp/protocol"
+	"github.com/the-open-agent/openagent/tool"
+	"github.com/the-open-agent/openagent/util"
+)
+
+type generatedResourceArchiveBuiltinTool struct {
+	inner tool.BuiltinTool
+}
+
+var archiveGeneratedResourceFile = archiveGeneratedResourceFileToStorage
+
+func wrapGeneratedResourceBuiltin(builtin tool.BuiltinTool) tool.BuiltinTool {
+	if builtin == nil {
+		return nil
+	}
+	if !isGeneratedResourceTool(builtin.GetName()) {
+		return builtin
+	}
+	return &generatedResourceArchiveBuiltinTool{inner: builtin}
+}
+
+func isGeneratedResourceTool(toolName string) bool {
+	switch toolName {
+	case "pptx_write", "word_write", "excel_write":
+		return true
+	default:
+		return false
+	}
+}
+
+func (t *generatedResourceArchiveBuiltinTool) GetName() string {
+	return t.inner.GetName()
+}
+
+func (t *generatedResourceArchiveBuiltinTool) GetDescription() string {
+	return t.inner.GetDescription()
+}
+
+func (t *generatedResourceArchiveBuiltinTool) GetInputSchema() interface{} {
+	return t.inner.GetInputSchema()
+}
+
+func (t *generatedResourceArchiveBuiltinTool) Execute(ctx context.Context, arguments map[string]interface{}) (*protocol.CallToolResult, error) {
+	result, innerErr := t.inner.Execute(ctx, arguments)
+	if innerErr != nil || result == nil || result.IsError {
+		return result, innerErr
+	}
+
+	path, ok := generatedResourceTargetPath(t.GetName(), arguments)
+	if !ok {
+		return result, innerErr
+	}
+
+	resource, err := archiveGeneratedResourceFile(path)
+	if err != nil {
+		appendGeneratedResourceArchiveText(result, fmt.Sprintf("Resource archive warning: file was created but could not be saved to Resources: %s", err.Error()))
+		return result, innerErr
+	}
+	if resource == nil {
+		appendGeneratedResourceArchiveText(result, "Resource archive warning: file was created but no Resource record was returned")
+		return result, innerErr
+	}
+
+	appendGeneratedResourceArchiveText(result, fmt.Sprintf("Saved to Resources: %s", resource.Url))
+	return result, innerErr
+}
+
+func generatedResourceTargetPath(toolName string, arguments map[string]interface{}) (string, bool) {
+	switch toolName {
+	case "pptx_write", "word_write", "excel_write":
+		path := resourceArchiveStringArg(arguments, "path")
+		if path == "" {
+			return "", false
+		}
+		return filepath.Clean(tool.ResolveOutputPath(path)), true
+	default:
+		return "", false
+	}
+}
+
+func resourceArchiveStringArg(arguments map[string]interface{}, key string) string {
+	value, _ := arguments[key].(string)
+	return strings.TrimSpace(value)
+}
+
+func archiveGeneratedResourceFileToStorage(path string) (*Resource, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if info.IsDir() {
+		return nil, fmt.Errorf("path is a directory: %s", path)
+	}
+
+	fileBytes, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	fileName := filepath.Base(path)
+	if fileName == "." || fileName == string(os.PathSeparator) || fileName == "" {
+		fileName = "generated_file"
+	}
+	ext := strings.ToLower(filepath.Ext(fileName))
+	fileType := getGeneratedResourceFileType(ext)
+	storageName := fmt.Sprintf(
+		"openagent/resources/generated/%s_%s_%s",
+		resourceArchiveSafePathSegment(util.GetCurrentTime()),
+		util.GetRandomName(),
+		resourceArchiveSafePathSegment(fileName),
+	)
+
+	fileUrl, err := UploadFileToStorageSafe(storageName, fileBytes, "", "")
+	if err != nil {
+		return nil, err
+	}
+
+	resource := NewResourceFromUpload("admin", "", "generated", fileName, fileType, ext, fileUrl, storageName, len(fileBytes), "", "")
+	if _, err = AddResource(resource); err != nil {
+		return nil, err
+	}
+	return resource, nil
+}
+
+func getGeneratedResourceFileType(ext string) string {
+	mimeType := mime.TypeByExtension(ext)
+	if mimeType == "" {
+		return "unknown"
+	}
+	parts := strings.SplitN(mimeType, "/", 2)
+	if len(parts) == 0 || parts[0] == "" {
+		return "unknown"
+	}
+	return parts[0]
+}
+
+func resourceArchiveSafePathSegment(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "unknown"
+	}
+	return strings.Map(func(r rune) rune {
+		switch r {
+		case '/', '\\', 0:
+			return '_'
+		default:
+			return r
+		}
+	}, value)
+}
+
+func appendGeneratedResourceArchiveText(result *protocol.CallToolResult, text string) {
+	if result == nil || text == "" {
+		return
+	}
+	result.Content = append(result.Content, &protocol.TextContent{Type: "text", Text: text})
+}

--- a/tool/office.go
+++ b/tool/office.go
@@ -21,7 +21,7 @@ import (
 	"github.com/ThinkInAIXYZ/go-mcp/protocol"
 )
 
-// resolveOutputPath returns path unchanged if it is absolute.
+// ResolveOutputPath returns path unchanged if it is absolute.
 // For relative paths it resolves them against the current user's Documents
 // folder so that files created by the AI land in a predictable, user-visible
 // location rather than in the server's working directory.
@@ -29,7 +29,7 @@ import (
 // Resolution order:
 //  1. XDG_DOCUMENTS_DIR environment variable (Linux / freedesktop standard)
 //  2. ~/Documents as a cross-platform fallback (Windows, macOS, Linux)
-func resolveOutputPath(path string) string {
+func ResolveOutputPath(path string) string {
 	if filepath.IsAbs(path) {
 		return path
 	}

--- a/tool/office_excel.go
+++ b/tool/office_excel.go
@@ -121,7 +121,7 @@ func (t *excelWriteBuiltin) Execute(_ context.Context, arguments map[string]inte
 		sheetName = "Sheet1"
 	}
 
-	resolvedPath := resolveOutputPath(path)
+	resolvedPath := ResolveOutputPath(path)
 	rowCount, colCount, err := writeExcelFile(path, sheetName, data)
 	if err != nil {
 		return officeToolError(fmt.Sprintf("Failed to write Excel file: %s", err.Error())), nil
@@ -201,7 +201,7 @@ func readExcelFile(path, sheetName string) (string, error) {
 // writeExcelFile creates (or overwrites) an xlsx file from CSV-formatted text.
 // It returns the number of rows and the maximum column count written.
 func writeExcelFile(path, sheetName, csvData string) (rowCount, colCount int, err error) {
-	path = resolveOutputPath(path)
+	path = ResolveOutputPath(path)
 	dir := filepath.Dir(path)
 	if mkErr := os.MkdirAll(dir, 0o755); mkErr != nil {
 		return 0, 0, fmt.Errorf("failed to create directory %q: %w", dir, mkErr)

--- a/tool/office_ppt_write.go
+++ b/tool/office_ppt_write.go
@@ -153,7 +153,7 @@ func (t *pptxWriteBuiltin) Execute(ctx context.Context, arguments map[string]int
 		return officeToolError(err.Error()), nil
 	}
 
-	args.Path = resolveOutputPath(args.Path)
+	args.Path = ResolveOutputPath(args.Path)
 
 	// Pass the job to Node through a temp JSON file so nested data does not
 	// need fragile command-line escaping. The final PPTX is not temporary.

--- a/tool/office_word.go
+++ b/tool/office_word.go
@@ -104,7 +104,7 @@ func (t *wordWriteBuiltin) Execute(_ context.Context, arguments map[string]inter
 		return officeToolError("Missing required parameter: content"), nil
 	}
 
-	resolvedPath := resolveOutputPath(path)
+	resolvedPath := ResolveOutputPath(path)
 	if err := writeWordFile(path, content); err != nil {
 		return officeToolError(fmt.Sprintf("Failed to write Word file: %s", err.Error())), nil
 	}
@@ -131,7 +131,7 @@ func readWordFile(path string) (string, error) {
 }
 
 func writeWordFile(path string, content string) error {
-	path = resolveOutputPath(path)
+	path = ResolveOutputPath(path)
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("failed to create directory %q: %w", dir, err)


### PR DESCRIPTION
## Summary
- Automatically archives successful `pptx_write`, `word_write`, and `excel_write` outputs to Resources.
- Uploads generated Office files to the default Storage Provider and creates `generated` Resource records linked to the current AI message.
- Restricts Resources access so normal users only see their own resources, while admins can view all.
- Adds a Resources download action and `generated` category styling.