### PR TITLE
fix: correct default storage provider lookup

### DIFF
--- a/object/provider_default.go
+++ b/object/provider_default.go
@@ -88,17 +88,41 @@ func getFilteredProviders(providers []*Provider, needStorage bool) []*Provider {
 }
 
 func GetDefaultStorageProvider() (*Provider, error) {
-	provider := Provider{Owner: "admin", Category: "Storage", State: "Active"}
-	existed, err := adapter.engine.Get(&provider)
+	provider := Provider{Owner: "admin", Category: "Storage", IsDefault: true}
+	existed, err := adapter.engine.UseBool("is_default").Get(&provider)
 	if err != nil {
-		return &provider, err
+		return nil, err
+	}
+
+	if providerAdapter != nil && !existed {
+		existed, err = providerAdapter.engine.UseBool("is_default").Get(&provider)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if existed {
+		return &provider, nil
+	}
+
+	activeProvider := Provider{Owner: "admin", Category: "Storage", State: "Active"}
+	existed, err = adapter.engine.Get(&activeProvider)
+	if err != nil {
+		return nil, err
+	}
+
+	if providerAdapter != nil && !existed {
+		existed, err = providerAdapter.engine.Get(&activeProvider)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if !existed {
 		return nil, nil
 	}
 
-	return &provider, nil
+	return &activeProvider, nil
 }
 
 func GetDefaultModelProvider() (*Provider, error) {


### PR DESCRIPTION
## Summary
- Fixes default Storage Provider lookup when a provider is marked with `is_default=true`.
- Keeps the existing `state=Active` lookup as a fallback for compatibility.

## Details
`GetDefaultStorageProvider()` previously only queried Storage providers with `state=Active`. This caused configured default providers with `is_default=true` but empty state to be ignored, resulting in `no default storage provider configured`.