### PR TITLE
feat: reduce long chat input lag performance

### DIFF
--- a/web/src/ChatBox.js
+++ b/web/src/ChatBox.js
@@ -176,6 +176,10 @@ class ChatBox extends React.Component {
     this.handleEditMessage({...message, text: message.text, updatedTime: new Date().toISOString()}, true);
   };
 
+  sendSuggestionMessage = (text, fileName = "") => {
+    this.props.sendMessage(text, fileName, false, false, this.state.webSearchEnabled);
+  };
+
   copyMessageFromHTML(message) {
     const parts = [];
 
@@ -407,7 +411,7 @@ class ChatBox extends React.Component {
             isReading={this.state.isReading}
             isLoadingTTS={this.state.isLoadingTTS}
             readingMessage={this.state.readingMessage}
-            sendMessage={(text, fileName = "") => this.props.sendMessage(text, fileName, false, false, this.state.webSearchEnabled)}
+            sendMessage={this.sendSuggestionMessage}
             files={this.state.files}
             hideThinking={this.props.store?.hideThinking === true}
           />
@@ -438,7 +442,7 @@ class ChatBox extends React.Component {
 
         {messages.length === 0 ? (
           <ChatExampleQuestions
-            sendMessage={(text, fileName = "") => this.props.sendMessage(text, fileName, false, false, this.state.webSearchEnabled)}
+            sendMessage={this.sendSuggestionMessage}
             exampleQuestions={exampleQuestions}
           />
         ) : null}

--- a/web/src/chat/MessageList.js
+++ b/web/src/chat/MessageList.js
@@ -18,6 +18,21 @@ import MessageItem from "./MessageItem";
 import * as Setting from "../Setting";
 
 class MessageList extends React.Component {
+  shouldComponentUpdate(nextProps) {
+    return (
+      nextProps.messages !== this.props.messages ||
+      nextProps.account !== this.props.account ||
+      nextProps.store !== this.props.store ||
+      nextProps.hideInput !== this.props.hideInput ||
+      nextProps.disableInput !== this.props.disableInput ||
+      nextProps.isReading !== this.props.isReading ||
+      nextProps.isLoadingTTS !== this.props.isLoadingTTS ||
+      nextProps.readingMessage !== this.props.readingMessage ||
+      nextProps.files !== this.props.files ||
+      nextProps.hideThinking !== this.props.hideThinking
+    );
+  }
+
   render() {
     const {
       messages,


### PR DESCRIPTION
## Summary

Fixes severe input lag in long chat conversations by preventing the message list from re-rendering on every composer keystroke.

## Root Cause

`ChatBox` stores the input value in component state. Every input change triggered `ChatBox.render()`, which also recreated props for `MessageList`, causing the full message list and all message items to re-render even though historical messages had not changed.

In long conversations, this becomes expensive because each message item may contain rendered Markdown, LaTeX, code highlighting, tool calls, drawers, and Ant Design chat components.

## Changes

- Added `shouldComponentUpdate` to `MessageList` so it only re-renders when message-list-related props actually change.
- Replaced inline `sendMessage` callbacks in `ChatBox` with a stable `sendSuggestionMessage` method to avoid unnecessary prop churn.