### PR TITLE
fix: recover interrupted chat status

### DIFF
--- a/controllers/message_answer_job.go
+++ b/controllers/message_answer_job.go
@@ -75,7 +75,10 @@ func (m *messageAnswerJobManager) getOrStart(id string, host string, lang string
 	m.mu.Unlock()
 
 	go func() {
-		defer job.finish()
+		defer func() {
+			job.finish()
+			cleanupMessageAnswerJobChatStatus(id)
+		}()
 		generateMessageAnswer(id, job.writer, host, lang, signedIn, nil)
 	}()
 
@@ -92,6 +95,19 @@ func (m *messageAnswerJobManager) cancel(id string) bool {
 
 	job.cancel()
 	return true
+}
+
+func cleanupMessageAnswerJobChatStatus(id string) {
+	message, err := object.GetMessage(id)
+	if err != nil || message == nil || message.Author != "AI" || message.Chat == "" {
+		return
+	}
+	if message.Text != "" || message.ErrorText != "" {
+		return
+	}
+	if err = clearMessageChatGenerating(message); err != nil {
+		fmt.Printf("failed to clear generating chat for message answer job %s: %s\n", id, err.Error())
+	}
 }
 
 func (m *messageAnswerJobManager) remove(id string, job *messageAnswerJob) {
@@ -199,6 +215,7 @@ func (j *messageAnswerJob) cancel() {
 
 	j.appendChunk([]byte("event: end\ndata: canceled\n\n"))
 	j.finish()
+	cleanupMessageAnswerJobChatStatus(j.id)
 }
 
 type messageAnswerJobWriter struct {

--- a/web/src/ChatPage.js
+++ b/web/src/ChatPage.js
@@ -108,8 +108,20 @@ class ChatPage extends BaseListPage {
 
             const status = res.data;
             const isViewing = this.state.chat?.name === chat.name;
+            const generationFinished = chat.isGenerating && !status.isGenerating;
 
-            if (chat.isGenerating && !status.isGenerating && isViewing && status.isUnread) {
+            if (generationFinished && isViewing && this.state.messageLoading) {
+              const lastMessage = this.state.messages?.[this.state.messages.length - 1];
+              if (lastMessage?.author === "AI") {
+                MessageBackend.closeMessageEventSource(lastMessage.owner, lastMessage.name, false);
+              }
+              this.setState({
+                messageLoading: false,
+              });
+              this.getMessages({...chat, ...status}, {skipPendingAnswer: true});
+            }
+
+            if (generationFinished && isViewing && status.isUnread) {
               this.markChatRead({...chat, ...status});
               return;
             }
@@ -417,7 +429,7 @@ class ChatPage extends BaseListPage {
       });
   }
 
-  getMessages(chat) {
+  getMessages(chat, options = {}) {
     this.setState({
       messageError: false,
     });
@@ -435,6 +447,13 @@ class ChatPage extends BaseListPage {
         if (res.data.length > 0) {
           const lastMessage = res.data[res.data.length - 1];
           if (lastMessage.author === "AI" && lastMessage.replyTo !== "" && lastMessage.text === "") {
+            if (options.skipPendingAnswer) {
+              this.setState({
+                messageLoading: false,
+                messageError: lastMessage.errorText !== "",
+              });
+              return;
+            }
             let text = "";
             let reasonText = "";
             this.setState({


### PR DESCRIPTION
## Summary

Fixes interrupted chat sessions that could leave the UI stuck in loading state or the chat status stuck as generating after the SSE stream ends abnormally.

## Root Cause

The backend chat status and the frontend SSE stream were drifting apart:

- `chat.isGenerating` was only cleared on the normal completion path or some error paths.
- If generation was interrupted by cancel, disconnect, or other early termination, the backend could finish without resetting the chat state.
- The frontend relied on SSE `end/error` events to stop `messageLoading`, so if the stream ended without a clean terminal event, the conversation kept spinning until refresh.

## Changes

- Added a backend cleanup path in `message_answer_job` to clear `chat.isGenerating` when an AI answer job ends or is canceled.
- Added a frontend recovery path in `ChatPage` that detects “status finished but SSE still loading”, closes the stale EventSource, and reloads the message state from the DB without re-subscribing the same pending answer stream.