### PR TITLE
feat: show default admin startup hint

### DIFF
--- a/controllers/message_answer_job.go
+++ b/controllers/message_answer_job.go
@@ -75,7 +75,10 @@ func (m *messageAnswerJobManager) getOrStart(id string, host string, lang string
 	m.mu.Unlock()
 
 	go func() {
-		defer job.finish()
+		defer func() {
+			job.finish()
+			cleanupMessageAnswerJobChatStatus(id)
+		}()
 		generateMessageAnswer(id, job.writer, host, lang, signedIn, nil)
 	}()
 
@@ -92,6 +95,19 @@ func (m *messageAnswerJobManager) cancel(id string) bool {
 
 	job.cancel()
 	return true
+}
+
+func cleanupMessageAnswerJobChatStatus(id string) {
+	message, err := object.GetMessage(id)
+	if err != nil || message == nil || message.Author != "AI" || message.Chat == "" {
+		return
+	}
+	if message.Text != "" || message.ErrorText != "" {
+		return
+	}
+	if err = clearMessageChatGenerating(message); err != nil {
+		fmt.Printf("failed to clear generating chat for message answer job %s: %s\n", id, err.Error())
+	}
 }
 
 func (m *messageAnswerJobManager) remove(id string, job *messageAnswerJob) {

--- a/main.go
+++ b/main.go
@@ -137,5 +137,14 @@ func main() {
 		go util.OpenBrowser(fmt.Sprintf("http://localhost:%v/", port))
 	}
 
+	if object.IsAdminUsingDefaultPassword() {
+		fmt.Println()
+		fmt.Println("OpenAgent default admin account")
+		fmt.Println("  Username: admin")
+		fmt.Println("  Password: 123")
+		fmt.Println("Please change the default password after signing in.")
+		fmt.Println()
+	}
+
 	beego.Run(fmt.Sprintf(":%v", port))
 }

--- a/web/src/ChatBox.js
+++ b/web/src/ChatBox.js
@@ -176,6 +176,10 @@ class ChatBox extends React.Component {
     this.handleEditMessage({...message, text: message.text, updatedTime: new Date().toISOString()}, true);
   };
 
+  sendSuggestionMessage = (text, fileName = "") => {
+    this.props.sendMessage(text, fileName, false, false, this.state.webSearchEnabled);
+  };
+
   copyMessageFromHTML(message) {
     const parts = [];
 
@@ -407,7 +411,7 @@ class ChatBox extends React.Component {
             isReading={this.state.isReading}
             isLoadingTTS={this.state.isLoadingTTS}
             readingMessage={this.state.readingMessage}
-            sendMessage={(text, fileName = "") => this.props.sendMessage(text, fileName, false, false, this.state.webSearchEnabled)}
+            sendMessage={this.sendSuggestionMessage}
             files={this.state.files}
             hideThinking={this.props.store?.hideThinking === true}
           />
@@ -438,7 +442,7 @@ class ChatBox extends React.Component {
 
         {messages.length === 0 ? (
           <ChatExampleQuestions
-            sendMessage={(text, fileName = "") => this.props.sendMessage(text, fileName, false, false, this.state.webSearchEnabled)}
+            sendMessage={this.sendSuggestionMessage}
             exampleQuestions={exampleQuestions}
           />
         ) : null}

--- a/web/src/ChatPage.js
+++ b/web/src/ChatPage.js
@@ -108,8 +108,20 @@ class ChatPage extends BaseListPage {
 
             const status = res.data;
             const isViewing = this.state.chat?.name === chat.name;
+            const generationFinished = chat.isGenerating && !status.isGenerating;
 
-            if (chat.isGenerating && !status.isGenerating && isViewing && status.isUnread) {
+            if (generationFinished && isViewing && this.state.messageLoading) {
+              const lastMessage = this.state.messages?.[this.state.messages.length - 1];
+              if (lastMessage?.author === "AI") {
+                MessageBackend.closeMessageEventSource(lastMessage.owner, lastMessage.name, false);
+              }
+              this.setState({
+                messageLoading: false,
+              });
+              this.getMessages({...chat, ...status}, {skipPendingAnswer: true});
+            }
+
+            if (generationFinished && isViewing && status.isUnread) {
               this.markChatRead({...chat, ...status});
               return;
             }
@@ -417,7 +429,7 @@ class ChatPage extends BaseListPage {
       });
   }
 
-  getMessages(chat) {
+  getMessages(chat, options = {}) {
     this.setState({
       messageError: false,
     });
@@ -435,6 +447,13 @@ class ChatPage extends BaseListPage {
         if (res.data.length > 0) {
           const lastMessage = res.data[res.data.length - 1];
           if (lastMessage.author === "AI" && lastMessage.replyTo !== "" && lastMessage.text === "") {
+            if (options.skipPendingAnswer) {
+              this.setState({
+                messageLoading: false,
+                messageError: lastMessage.errorText !== "",
+              });
+              return;
+            }
             let text = "";
             let reasonText = "";
             this.setState({

--- a/web/src/chat/MessageList.js
+++ b/web/src/chat/MessageList.js
@@ -18,6 +18,21 @@ import MessageItem from "./MessageItem";
 import * as Setting from "../Setting";
 
 class MessageList extends React.Component {
+  shouldComponentUpdate(nextProps) {
+    return (
+      nextProps.messages !== this.props.messages ||
+      nextProps.account !== this.props.account ||
+      nextProps.store !== this.props.store ||
+      nextProps.hideInput !== this.props.hideInput ||
+      nextProps.disableInput !== this.props.disableInput ||
+      nextProps.isReading !== this.props.isReading ||
+      nextProps.isLoadingTTS !== this.props.isLoadingTTS ||
+      nextProps.readingMessage !== this.props.readingMessage ||
+      nextProps.files !== this.props.files ||
+      nextProps.hideThinking !== this.props.hideThinking
+    );
+  }
+
   render() {
     const {
       messages,


### PR DESCRIPTION
## Summary

Show the default local admin account in the startup logs when the built-in admin user is still using the default password.

## Changes

- Print a small startup hint only when `admin` still uses the default password.