### PR TITLE
feat: reduce long chat input lag performance

### DIFF
--- a/web/src/ChatBox.js
+++ b/web/src/ChatBox.js
@@ -176,6 +176,10 @@ class ChatBox extends React.Component {
     this.handleEditMessage({...message, text: message.text, updatedTime: new Date().toISOString()}, true);
   };
 
+  sendSuggestionMessage = (text, fileName = "") => {
+    this.props.sendMessage(text, fileName, false, false, this.state.webSearchEnabled);
+  };
+
   copyMessageFromHTML(message) {
     const parts = [];
 
@@ -407,7 +411,7 @@ class ChatBox extends React.Component {
             isReading={this.state.isReading}
             isLoadingTTS={this.state.isLoadingTTS}
             readingMessage={this.state.readingMessage}
-            sendMessage={(text, fileName = "") => this.props.sendMessage(text, fileName, false, false, this.state.webSearchEnabled)}
+            sendMessage={this.sendSuggestionMessage}
             files={this.state.files}
             hideThinking={this.props.store?.hideThinking === true}
           />
@@ -438,7 +442,7 @@ class ChatBox extends React.Component {
 
         {messages.length === 0 ? (
           <ChatExampleQuestions
-            sendMessage={(text, fileName = "") => this.props.sendMessage(text, fileName, false, false, this.state.webSearchEnabled)}
+            sendMessage={this.sendSuggestionMessage}
             exampleQuestions={exampleQuestions}
           />
         ) : null}

--- a/web/src/ChatPage.js
+++ b/web/src/ChatPage.js
@@ -477,7 +477,7 @@ class ChatPage extends BaseListPage {
                 }
               });
               this.setState({
-                messages: res.data,
+                messages: [...res.data],
                 messageError: false,
               });
             }, (data) => {
@@ -505,7 +505,7 @@ class ChatPage extends BaseListPage {
               res.data[res.data.length - 1] = lastMessage2;
 
               this.setState({
-                messages: res.data,
+                messages: [...res.data],
               });
             }, (data) => {
               // onTool callback (handles both tool-start and tool-complete events)
@@ -552,7 +552,7 @@ class ChatPage extends BaseListPage {
               res.data[res.data.length - 1] = lastMessage2;
 
               this.setState({
-                messages: res.data,
+                messages: [...res.data],
               });
             }, (data) => {
               // onSearch callback
@@ -567,7 +567,7 @@ class ChatPage extends BaseListPage {
               res.data[res.data.length - 1] = lastMessage2;
 
               this.setState({
-                messages: res.data,
+                messages: [...res.data],
               });
             }, (data) => {
               if (!chat || (this.state.chat?.name !== chat.name)) {
@@ -581,7 +581,7 @@ class ChatPage extends BaseListPage {
               res.data[res.data.length - 1] = lastMessage2;
 
               this.setState({
-                messages: res.data,
+                messages: [...res.data],
               });
             }, (error) => {
               this.updateChatStatus(chat.name, {isGenerating: false});
@@ -599,7 +599,7 @@ class ChatPage extends BaseListPage {
               });
 
               this.setState({
-                messages: res.data,
+                messages: [...res.data],
                 messageLoading: false,
                 messageError: true,
               });
@@ -667,7 +667,7 @@ class ChatPage extends BaseListPage {
               });
 
               this.setState({
-                messages: res.data,
+                messages: [...res.data],
                 messageLoading: false,
                 messageError: false,
               });
@@ -685,7 +685,7 @@ class ChatPage extends BaseListPage {
               const lastMessage2 = Setting.deepCopy(currentMessage);
               lastMessage2.hintText = infoText;
               res.data[res.data.length - 1] = lastMessage2;
-              this.setState({messages: res.data});
+              this.setState({messages: [...res.data]});
             }, (update) => {
               if (!chat || update?.name !== chat.name || !update.displayName) {
                 return;

--- a/web/src/chat/MessageList.js
+++ b/web/src/chat/MessageList.js
@@ -18,6 +18,21 @@ import MessageItem from "./MessageItem";
 import * as Setting from "../Setting";
 
 class MessageList extends React.Component {
+  shouldComponentUpdate(nextProps) {
+    return (
+      nextProps.messages !== this.props.messages ||
+      nextProps.account !== this.props.account ||
+      nextProps.store !== this.props.store ||
+      nextProps.hideInput !== this.props.hideInput ||
+      nextProps.disableInput !== this.props.disableInput ||
+      nextProps.isReading !== this.props.isReading ||
+      nextProps.isLoadingTTS !== this.props.isLoadingTTS ||
+      nextProps.readingMessage !== this.props.readingMessage ||
+      nextProps.files !== this.props.files ||
+      nextProps.hideThinking !== this.props.hideThinking
+    );
+  }
+
   render() {
     const {
       messages,


### PR DESCRIPTION
## Summary

Reduce input lag in long chat conversations while preserving streaming updates.

## Root Cause

Typing in the chat input caused the whole `ChatBox` subtree to re-render. In long conversations, this repeatedly re-rendered the full message list, making the input feel very sluggish.

## Changes

- Add `MessageList.shouldComponentUpdate()` so the message list only re-renders when relevant props actually change.
- Replace inline suggestion/example `sendMessage` lambdas with a stable class method to avoid unnecessary prop changes.
- Use new `messages` array references during streaming updates so token/reason/tool/search/error/end events still refresh the message list.
