### PR TITLE
feat: sync chat UI after interrupted generation

### DIFF
--- a/controllers/message_answer_job.go
+++ b/controllers/message_answer_job.go
@@ -75,7 +75,10 @@ func (m *messageAnswerJobManager) getOrStart(id string, host string, lang string
 	m.mu.Unlock()
 
 	go func() {
-		defer job.finish()
+		defer func() {
+			job.finish()
+			cleanupMessageAnswerJobChatStatus(id)
+		}()
 		generateMessageAnswer(id, job.writer, host, lang, signedIn, nil)
 	}()
 
@@ -92,6 +95,19 @@ func (m *messageAnswerJobManager) cancel(id string) bool {
 
 	job.cancel()
 	return true
+}
+
+func cleanupMessageAnswerJobChatStatus(id string) {
+	message, err := object.GetMessage(id)
+	if err != nil || message == nil || message.Author != "AI" || message.Chat == "" {
+		return
+	}
+	if message.Text != "" || message.ErrorText != "" {
+		return
+	}
+	if err = clearMessageChatGenerating(message); err != nil {
+		fmt.Printf("failed to clear generating chat for message answer job %s: %s\n", id, err.Error())
+	}
 }
 
 func (m *messageAnswerJobManager) remove(id string, job *messageAnswerJob) {

--- a/web/src/ChatMenu.js
+++ b/web/src/ChatMenu.js
@@ -30,7 +30,7 @@ class ChatMenu extends React.Component {
     this.state = {
       openKeys: openKeys,
       selectedKeys: selectedKey ? [selectedKey] : [],
-      editChat: false,
+      editingKey: null,
       editChatName: "",
       hoveredKey: null,
       popconfirmOpenKey: null,
@@ -70,6 +70,10 @@ class ChatMenu extends React.Component {
     );
   }
 
+  getChatItemKey(chat) {
+    return `chat:${chat.owner}/${chat.name}`;
+  }
+
   chatsToItems(chats) {
     const categories = {};
     chats.forEach((chat) => {
@@ -82,16 +86,14 @@ class ChatMenu extends React.Component {
       categories[chat.category].push(chat);
     });
 
-    const selectedKeys = this.state === undefined ? [] : this.state.selectedKeys;
-    return Object.keys(categories).map((category, index) => {
+    return Object.keys(categories).map((category) => {
       return {
-        key: `${index}`,
+        key: `category:${category}`,
         icon: <LayoutOutlined />,
         label: category,
-        children: categories[category].map((chat, chatIndex) => {
+        children: categories[category].map((chat) => {
           const globalChatIndex = chats.indexOf(chat);
-          const itemKey = `${index}-${chatIndex}`;
-          const isSelected = selectedKeys.includes(itemKey);
+          const itemKey = this.getChatItemKey(chat);
           const isHovered = this.state !== undefined && this.state.hoveredKey === itemKey;
           const popconfirmOpenKey = this.state !== undefined ? this.state.popconfirmOpenKey : null;
           const showActionButtons = popconfirmOpenKey === itemKey || (isHovered && popconfirmOpenKey === null);
@@ -118,15 +120,15 @@ class ChatMenu extends React.Component {
           const onSave = (e) => {
             e.stopPropagation();
             this.props.onUpdateChatName(globalChatIndex, this.state.editChatName);
-            this.setState({editChat: false});
+            this.setState({editingKey: null});
           };
 
           return {
-            key: `${index}-${chatIndex}`,
+            key: itemKey,
             index: globalChatIndex,
             className: "chat-menu-item",
             label: (
-              isSelected && this.state.editChat ? (
+              this.state?.editingKey === itemKey ? (
                 <div className="menu-item-container">
                   <Input style={{width: "70%"}} value={this.state.editChatName}
                     onChange={(event) => {this.setState({editChatName: event.target.value});}}
@@ -146,7 +148,7 @@ class ChatMenu extends React.Component {
                     onMouseUp={handleIconMouseUp}
                     onClick={(e) => {
                       e.stopPropagation();
-                      this.setState({editChat: false});
+                      this.setState({editingKey: null});
                     }}
                   />
                 </div>) : (
@@ -174,7 +176,7 @@ class ChatMenu extends React.Component {
                           e.stopPropagation();
                           this.setState({
                             editChatName: this.props.chats[globalChatIndex].displayName,
-                            editChat: true,
+                            editingKey: itemKey,
                           });
                         }} />
                       <Popconfirm
@@ -209,11 +211,15 @@ class ChatMenu extends React.Component {
   }
 
   onSelect = (info) => {
-    const [categoryIndex, chatIndex] = info.selectedKeys[0].split("-").map(Number);
-    const selectedItem = this.chatsToItems(this.props.chats)[categoryIndex].children[chatIndex];
+    const selectedItem = this.chatsToItems(this.props.chats)
+      .flatMap(item => item.children || [])
+      .find(item => item.key === info.key);
+    if (!selectedItem) {
+      return;
+    }
     this.setState({
-      selectedKeys: [`${categoryIndex}-${chatIndex}`],
-      editChat: false,
+      selectedKeys: [selectedItem.key],
+      editingKey: null,
       editChatName: this.props.chats[selectedItem.index].displayName,
     });
 
@@ -229,7 +235,7 @@ class ChatMenu extends React.Component {
   clearSelectedKey() {
     this.setState({
       selectedKeys: [],
-      editChat: false,
+      editingKey: null,
     });
   }
 
@@ -248,23 +254,8 @@ class ChatMenu extends React.Component {
     if (!chatName) {
       return null;
     }
-    const items = this.chatsToItems(chats);
     const chat = chats.find(chat => chat.name === chatName);
-    let selectedKey = null;
-
-    for (let categoryIndex = 0; categoryIndex < items.length; categoryIndex++) {
-      const category = items[categoryIndex];
-      for (let chatIndex = 0; chatIndex < category.children.length; chatIndex++) {
-        if (category.children[chatIndex].index === chats.indexOf(chat)) {
-          selectedKey = `${categoryIndex}-${chatIndex}`;
-          break;
-        }
-      }
-      if (selectedKey) {
-        break;
-      }
-    }
-    return selectedKey;
+    return chat ? this.getChatItemKey(chat) : null;
   }
 
   onOpenChange = (keys) => {

--- a/web/src/ChatPage.js
+++ b/web/src/ChatPage.js
@@ -108,8 +108,16 @@ class ChatPage extends BaseListPage {
 
             const status = res.data;
             const isViewing = this.state.chat?.name === chat.name;
+            const generationFinished = chat.isGenerating && !status.isGenerating;
 
-            if (chat.isGenerating && !status.isGenerating && isViewing && status.isUnread) {
+            if (generationFinished && isViewing && this.state.messageLoading) {
+              this.setState({
+                messageLoading: false,
+              });
+              this.getMessages({...chat, ...status}, {skipPendingAnswer: true});
+            }
+
+            if (generationFinished && isViewing && status.isUnread) {
               this.markChatRead({...chat, ...status});
               return;
             }
@@ -377,6 +385,24 @@ class ChatPage extends BaseListPage {
     }
   };
 
+  refreshChatsAndSelect(chat) {
+    const field = "user";
+    const value = this.props.account.name;
+    const sortField = "", sortOrder = "";
+    const storeName = this.state.storeName;
+
+    ChatBackend.getChats(value, storeName, -1, -1, field, value, sortField, sortOrder)
+      .then((res) => {
+        if (res.status === "ok") {
+          const chats = res.data;
+          this.setState({
+            data: chats,
+          });
+          this.menu.current?.setSelectedKeyToChat(chats, chat.name);
+        }
+      });
+  }
+
   sendMessage(text, fileName, isHidden, isRegenerated, webSearchEnabled = false) {
     const newMessage = this.newMessage(text, fileName, isHidden, isRegenerated, webSearchEnabled);
     MessageBackend.addMessage(newMessage)
@@ -390,23 +416,7 @@ class ChatPage extends BaseListPage {
           });
           this.goToLinkSoft(this.generateChatUrl(chat.name, chat.store));
 
-          const field = "user";
-          const value = this.props.account.name;
-          const sortField = "", sortOrder = "";
-          const storeName = this.state.storeName;
-          ChatBackend.getChats(value, storeName, -1, -1, field, value, sortField, sortOrder)
-            .then((res) => {
-              if (res.status === "ok") {
-                const chats = res.data;
-                this.setState({
-                  data: chats,
-                });
-                if (this.menu && this.menu.current) {
-                  this.menu.current.setSelectedKeyToChat(chats, chat.name);
-                }
-              }
-            });
-
+          this.refreshChatsAndSelect(chat);
           this.getMessages(chat);
         } else {
           Setting.showMessage("error", `${i18next.t("general:Failed to add")}: ${res.msg}`);
@@ -417,7 +427,7 @@ class ChatPage extends BaseListPage {
       });
   }
 
-  getMessages(chat) {
+  getMessages(chat, options = {}) {
     this.setState({
       messageError: false,
     });
@@ -435,6 +445,13 @@ class ChatPage extends BaseListPage {
         if (res.data.length > 0) {
           const lastMessage = res.data[res.data.length - 1];
           if (lastMessage.author === "AI" && lastMessage.replyTo !== "" && lastMessage.text === "") {
+            if (options.skipPendingAnswer) {
+              this.setState({
+                messageLoading: false,
+                messageError: lastMessage.errorText !== "",
+              });
+              return;
+            }
             let text = "";
             let reasonText = "";
             this.setState({
@@ -788,6 +805,7 @@ class ChatPage extends BaseListPage {
 
   handleMessageEdit = (updatedChat) => {
     this.updateChatStatus(updatedChat.name, updatedChat);
+    this.refreshChatsAndSelect(updatedChat);
     this.getMessages(updatedChat);
   };
 


### PR DESCRIPTION
## Summary

Fix chat UI state getting stuck after an interrupted generation.

This PR makes the backend clear stale generating state when an answer job exits without producing message text or an error, and updates the frontend to recover the current chat view when chat status shows generation has already ended.

## Changes

- Clear stale chat `isGenerating` state when an interrupted answer job leaves an empty AI message.
- Stop the current message loading state and reload messages when polling detects generation has ended.
- Refresh and reselect the chat list after send/edit/regenerate so sidebar ordering stays in sync with backend state.
- Use stable chat identity keys in the sidebar instead of position-based keys to avoid selected/editing state moving to the wrong chat after list reorder.