### PR TITLE
feat: Stream tool call arguments in chat UI

### DIFF
--- a/controllers/message_writer.go
+++ b/controllers/message_writer.go
@@ -55,6 +55,11 @@ func (w *RefinedWriter) Write(p []byte) (n int, err error) {
 		prefix := []byte("event: reason\ndata: ")
 		suffix := []byte("\n\n")
 		data = string(bytes.TrimSuffix(bytes.TrimPrefix(p, prefix), suffix))
+	} else if bytes.HasPrefix(p, []byte("event: tool-delta")) {
+		eventType = "tool-delta"
+		prefix := []byte("event: tool-delta\ndata: ")
+		suffix := []byte("\n\n")
+		data = string(bytes.TrimSuffix(bytes.TrimPrefix(p, prefix), suffix))
 	} else if bytes.HasPrefix(p, []byte("event: tool-start")) {
 		eventType = "tool-start"
 		prefix := []byte("event: tool-start\ndata: ")
@@ -77,9 +82,9 @@ func (w *RefinedWriter) Write(p []byte) (n int, err error) {
 		data = string(bytes.TrimSuffix(bytes.TrimPrefix(p, prefix), suffix))
 	}
 
-	// tool-start: flush immediately to frontend but do NOT buffer (no result yet)
-	if eventType == "tool-start" {
-		n, err := w.ResponseWriter.Write([]byte(fmt.Sprintf("event: tool-start\ndata: %s\n\n", data)))
+	// Tool progress events are UI-only and should not be saved in the final message.
+	if eventType == "tool-delta" || eventType == "tool-start" {
+		n, err := w.ResponseWriter.Write([]byte(fmt.Sprintf("event: %s\ndata: %s\n\n", eventType, data)))
 		if flusher, ok := w.ResponseWriter.(http.Flusher); ok {
 			flusher.Flush()
 		}

--- a/model/local.go
+++ b/model/local.go
@@ -345,6 +345,13 @@ func (p *LocalModelProvider) QueryText(question string, writer io.Writer, histor
 			}
 			if completion.Choices[0].Delta.ToolCalls != nil {
 				for _, toolCall := range completion.Choices[0].Delta.ToolCalls {
+					index := 0
+					if toolCall.Index != nil {
+						index = *toolCall.Index
+					}
+					if err = flushToolCallDelta(index, toolCall.ID, toolCall.Function.Name, toolCall.Function.Arguments, writer, lang); err != nil {
+						return nil, err
+					}
 					toolCalls, toolCallsMap = handleToolCallsParameters(toolCall, toolCalls, toolCallsMap)
 				}
 			}

--- a/model/mcp.go
+++ b/model/mcp.go
@@ -55,6 +55,30 @@ type ToolCall struct {
 	Content   string `json:"content"`
 }
 
+type ToolCallDelta struct {
+	Index          int    `json:"index"`
+	ID             string `json:"id,omitempty"`
+	Name           string `json:"name,omitempty"`
+	ArgumentsDelta string `json:"argumentsDelta,omitempty"`
+}
+
+func flushToolCallDelta(index int, id string, name string, argumentsDelta string, writer io.Writer, lang string) error {
+	if name == "" && argumentsDelta == "" {
+		return nil
+	}
+
+	payload, err := json.Marshal(ToolCallDelta{
+		Index:          index,
+		ID:             id,
+		Name:           name,
+		ArgumentsDelta: argumentsDelta,
+	})
+	if err != nil {
+		return err
+	}
+	return flushDataThink(string(payload), "tool-delta", writer, lang)
+}
+
 func reverseToolsToOpenAi(tools []*protocol.Tool) ([]openai.Tool, error) {
 	var openaiTools []openai.Tool
 	for _, tool := range tools {

--- a/model/openai.go
+++ b/model/openai.go
@@ -446,6 +446,19 @@ func (p *OpenAiModelProvider) QueryText(question string, writer io.Writer, histo
 				if err != nil {
 					return nil, err
 				}
+			case responses.ResponseOutputItemAddedEvent:
+				switch v := variant.Item.AsAny().(type) {
+				case responses.ResponseFunctionToolCall:
+					err = flushToolCallDelta(int(variant.OutputIndex), v.ID, v.Name, "", writer, lang)
+					if err != nil {
+						return nil, err
+					}
+				}
+			case responses.ResponseFunctionCallArgumentsDeltaEvent:
+				err = flushToolCallDelta(int(variant.OutputIndex), variant.ItemID, "", variant.Delta, writer, lang)
+				if err != nil {
+					return nil, err
+				}
 			case responses.ResponseOutputItemDoneEvent:
 				switch v := variant.Item.AsAny().(type) {
 				case responses.ResponseOutputItemImageGenerationCall:

--- a/web/src/ChatPage.js
+++ b/web/src/ChatPage.js
@@ -483,6 +483,19 @@ class ChatPage extends BaseListPage {
             }
             let text = "";
             let reasonText = "";
+            const toolCalls = [];
+            const toolDeltaPreviewLimit = 6000;
+            const flushToolDelta = () => {
+              if (!chat || (this.state.chat?.name !== chat.name)) {
+                return;
+              }
+
+              const currentMessage = res.data[res.data.length - 1];
+              const lastMessage2 = Setting.deepCopy(currentMessage);
+              lastMessage2.toolCalls = [...toolCalls];
+              res.data[res.data.length - 1] = lastMessage2;
+              this.setState({messages: [...res.data]});
+            };
             this.setState({
               messageLoading: true,
             });
@@ -560,16 +573,26 @@ class ChatPage extends BaseListPage {
               }
               const jsonData = JSON.parse(data);
 
-              const currentMessage = res.data[res.data.length - 1];
-              const toolCalls = currentMessage.toolCalls || [];
-
               if (!jsonData.content) {
-                // tool-start: add new entry with empty content (tool is executing)
-                toolCalls.push({
-                  name: jsonData.name,
-                  arguments: jsonData.arguments,
-                  content: "",
-                });
+                let found = false;
+                for (let i = toolCalls.length - 1; i >= 0; i--) {
+                  if (toolCalls[i].generatingArguments && !toolCalls[i].content && (!jsonData.name || toolCalls[i].name === jsonData.name || toolCalls[i].name === "tool")) {
+                    toolCalls[i] = {
+                      name: jsonData.name,
+                      arguments: jsonData.arguments,
+                      content: "",
+                    };
+                    found = true;
+                    break;
+                  }
+                }
+                if (!found) {
+                  toolCalls.push({
+                    name: jsonData.name,
+                    arguments: jsonData.arguments,
+                    content: "",
+                  });
+                }
               } else {
                 // tool-complete: find the last pending entry with same name and update it
                 let found = false;
@@ -593,6 +616,7 @@ class ChatPage extends BaseListPage {
                 }
               }
 
+              const currentMessage = res.data[res.data.length - 1];
               const lastMessage2 = Setting.deepCopy(currentMessage);
               lastMessage2.toolCalls = [...toolCalls];
               res.data[res.data.length - 1] = lastMessage2;
@@ -610,6 +634,9 @@ class ChatPage extends BaseListPage {
               const currentMessage = res.data[res.data.length - 1];
               const lastMessage2 = Setting.deepCopy(currentMessage);
               lastMessage2.searchResults = searchResults;
+              if (toolCalls.length > 0) {
+                lastMessage2.toolCalls = [...toolCalls];
+              }
               res.data[res.data.length - 1] = lastMessage2;
 
               this.setState({
@@ -624,6 +651,9 @@ class ChatPage extends BaseListPage {
               const currentMessage = res.data[res.data.length - 1];
               const lastMessage2 = Setting.deepCopy(currentMessage);
               lastMessage2.vectorScores = vectorScores;
+              if (toolCalls.length > 0) {
+                lastMessage2.toolCalls = [...toolCalls];
+              }
               res.data[res.data.length - 1] = lastMessage2;
 
               this.setState({
@@ -657,6 +687,7 @@ class ChatPage extends BaseListPage {
               if (!chat || (this.state.chat?.name !== chat.name)) {
                 return;
               }
+              flushToolDelta();
               const lastMessage2 = Setting.deepCopy(lastMessage);
               lastMessage2.text = text;
 
@@ -741,6 +772,41 @@ class ChatPage extends BaseListPage {
                 return;
               }
               this.updateChatDisplayName(update.displayName, {...chat, needTitle: update.needTitle ?? false});
+            }, (data) => {
+              if (!chat || (this.state.chat?.name !== chat.name)) {
+                return;
+              }
+              const jsonData = JSON.parse(data);
+              const index = jsonData.index ?? 0;
+              let found = false;
+
+              for (let i = toolCalls.length - 1; i >= 0; i--) {
+                if (toolCalls[i].generatingArguments && toolCalls[i].index === index) {
+                  const nextArguments = `${toolCalls[i].arguments || ""}${jsonData.argumentsDelta || ""}`;
+                  toolCalls[i] = {
+                    ...toolCalls[i],
+                    name: jsonData.name || toolCalls[i].name,
+                    arguments: nextArguments.length > toolDeltaPreviewLimit ? nextArguments.slice(nextArguments.length - toolDeltaPreviewLimit) : nextArguments,
+                  };
+                  found = true;
+                  break;
+                }
+              }
+              if (!found) {
+                toolCalls.push({
+                  index,
+                  name: jsonData.name || "tool",
+                  arguments: (jsonData.argumentsDelta || "").length > toolDeltaPreviewLimit ? (jsonData.argumentsDelta || "").slice((jsonData.argumentsDelta || "").length - toolDeltaPreviewLimit) : (jsonData.argumentsDelta || ""),
+                  content: "",
+                  generatingArguments: true,
+                });
+              }
+
+              const currentMessage = res.data[res.data.length - 1];
+              const lastMessage2 = Setting.deepCopy(currentMessage);
+              lastMessage2.toolCalls = [...toolCalls];
+              res.data[res.data.length - 1] = lastMessage2;
+              flushToolDelta();
             });
           } else {
             this.setState({

--- a/web/src/ChatPage.js
+++ b/web/src/ChatPage.js
@@ -29,6 +29,7 @@ import i18next from "i18next";
 import BaseListPage from "./BaseListPage";
 import {MessageCarrier} from "./chat/MessageCarrier";
 import {getFirstUserMessageText} from "./carrier/titleUtils";
+import {TOOL_DELTA_FLUSH_INTERVAL, applyToolDelta, applyToolEvent} from "./chat/toolCallStream";
 
 const chatStatusPollingInterval = 2000;
 
@@ -484,7 +485,7 @@ class ChatPage extends BaseListPage {
             let text = "";
             let reasonText = "";
             const toolCalls = [];
-            const toolDeltaPreviewLimit = 6000;
+            let toolDeltaFlushTimer = null;
             const flushToolDelta = () => {
               if (!chat || (this.state.chat?.name !== chat.name)) {
                 return;
@@ -495,6 +496,22 @@ class ChatPage extends BaseListPage {
               lastMessage2.toolCalls = [...toolCalls];
               res.data[res.data.length - 1] = lastMessage2;
               this.setState({messages: [...res.data]});
+            };
+            const scheduleToolDeltaFlush = () => {
+              if (toolDeltaFlushTimer !== null) {
+                return;
+              }
+              toolDeltaFlushTimer = window.setTimeout(() => {
+                toolDeltaFlushTimer = null;
+                flushToolDelta();
+              }, TOOL_DELTA_FLUSH_INTERVAL);
+            };
+            const flushToolDeltaNow = () => {
+              if (toolDeltaFlushTimer !== null) {
+                window.clearTimeout(toolDeltaFlushTimer);
+                toolDeltaFlushTimer = null;
+              }
+              flushToolDelta();
             };
             this.setState({
               messageLoading: true,
@@ -573,57 +590,8 @@ class ChatPage extends BaseListPage {
               }
               const jsonData = JSON.parse(data);
 
-              if (!jsonData.content) {
-                let found = false;
-                for (let i = toolCalls.length - 1; i >= 0; i--) {
-                  if (toolCalls[i].generatingArguments && !toolCalls[i].content && (!jsonData.name || toolCalls[i].name === jsonData.name || toolCalls[i].name === "tool")) {
-                    toolCalls[i] = {
-                      name: jsonData.name,
-                      arguments: jsonData.arguments,
-                      content: "",
-                    };
-                    found = true;
-                    break;
-                  }
-                }
-                if (!found) {
-                  toolCalls.push({
-                    name: jsonData.name,
-                    arguments: jsonData.arguments,
-                    content: "",
-                  });
-                }
-              } else {
-                // tool-complete: find the last pending entry with same name and update it
-                let found = false;
-                for (let i = toolCalls.length - 1; i >= 0; i--) {
-                  if (toolCalls[i].name === jsonData.name && !toolCalls[i].content) {
-                    toolCalls[i] = {
-                      name: jsonData.name,
-                      arguments: jsonData.arguments,
-                      content: jsonData.content,
-                    };
-                    found = true;
-                    break;
-                  }
-                }
-                if (!found) {
-                  toolCalls.push({
-                    name: jsonData.name,
-                    arguments: jsonData.arguments,
-                    content: jsonData.content,
-                  });
-                }
-              }
-
-              const currentMessage = res.data[res.data.length - 1];
-              const lastMessage2 = Setting.deepCopy(currentMessage);
-              lastMessage2.toolCalls = [...toolCalls];
-              res.data[res.data.length - 1] = lastMessage2;
-
-              this.setState({
-                messages: [...res.data],
-              });
+              applyToolEvent(toolCalls, jsonData);
+              flushToolDeltaNow();
             }, (data) => {
               // onSearch callback
               if (!chat || (this.state.chat?.name !== chat.name)) {
@@ -687,7 +655,7 @@ class ChatPage extends BaseListPage {
               if (!chat || (this.state.chat?.name !== chat.name)) {
                 return;
               }
-              flushToolDelta();
+              flushToolDeltaNow();
               const lastMessage2 = Setting.deepCopy(lastMessage);
               lastMessage2.text = text;
 
@@ -777,36 +745,8 @@ class ChatPage extends BaseListPage {
                 return;
               }
               const jsonData = JSON.parse(data);
-              const index = jsonData.index ?? 0;
-              let found = false;
-
-              for (let i = toolCalls.length - 1; i >= 0; i--) {
-                if (toolCalls[i].generatingArguments && toolCalls[i].index === index) {
-                  const nextArguments = `${toolCalls[i].arguments || ""}${jsonData.argumentsDelta || ""}`;
-                  toolCalls[i] = {
-                    ...toolCalls[i],
-                    name: jsonData.name || toolCalls[i].name,
-                    arguments: nextArguments.length > toolDeltaPreviewLimit ? nextArguments.slice(nextArguments.length - toolDeltaPreviewLimit) : nextArguments,
-                  };
-                  found = true;
-                  break;
-                }
-              }
-              if (!found) {
-                toolCalls.push({
-                  index,
-                  name: jsonData.name || "tool",
-                  arguments: (jsonData.argumentsDelta || "").length > toolDeltaPreviewLimit ? (jsonData.argumentsDelta || "").slice((jsonData.argumentsDelta || "").length - toolDeltaPreviewLimit) : (jsonData.argumentsDelta || ""),
-                  content: "",
-                  generatingArguments: true,
-                });
-              }
-
-              const currentMessage = res.data[res.data.length - 1];
-              const lastMessage2 = Setting.deepCopy(currentMessage);
-              lastMessage2.toolCalls = [...toolCalls];
-              res.data[res.data.length - 1] = lastMessage2;
-              flushToolDelta();
+              applyToolDelta(toolCalls, jsonData);
+              scheduleToolDeltaFlush();
             });
           } else {
             this.setState({

--- a/web/src/backend/MessageBackend.js
+++ b/web/src/backend/MessageBackend.js
@@ -46,7 +46,7 @@ export function getChatMessages(owner, chat) {
 
 const eventSourceMap = new Map();
 
-export function getMessageAnswer(owner, name, onMessage, onReason, onTool, onSearch, onVector, onError, onEnd, onInfo, onChat) {
+export function getMessageAnswer(owner, name, onMessage, onReason, onTool, onSearch, onVector, onError, onEnd, onInfo, onChat, onToolDelta) {
   if (eventSourceMap.has(`${owner}/${name}`)) {
     return;
   }
@@ -70,6 +70,12 @@ export function getMessageAnswer(owner, name, onMessage, onReason, onTool, onSea
   eventSource.addEventListener("tool", (e) => {
     onTool(e.data);
   });
+
+  if (onToolDelta) {
+    eventSource.addEventListener("tool-delta", (e) => {
+      onToolDelta(e.data);
+    });
+  }
 
   eventSource.addEventListener("search", (e) => {
     onSearch(e.data);

--- a/web/src/chat/MessageItem.js
+++ b/web/src/chat/MessageItem.js
@@ -236,9 +236,12 @@ const MessageItem = ({
     }
 
     if ((message.reasonText || message.toolCalls) && message.author === "AI") {
+      const hasToolCalls = message.toolCalls && message.toolCalls.length > 0;
+      const shouldRenderInlineReason = (!message.isReasoningPhase || hasToolCalls) && !hideThinking && message.reasonText;
+
       return (
         <div className="message-content">
-          {!hideThinking && (
+          {shouldRenderInlineReason && (
             <ReasoningSection
               reasonText={message.reasonText}
               isReasoningPhase={message.isReasoningPhase}
@@ -269,7 +272,7 @@ const MessageItem = ({
   };
 
   const renderReasoningBubble = () => {
-    if (message.isReasoningPhase && message.author === "AI" && message.reasonText) {
+    if (message.isReasoningPhase && message.author === "AI" && message.reasonText && (!message.toolCalls || message.toolCalls.length === 0)) {
       return (
         <div style={{marginBottom: "8px"}}>
           <Bubble
@@ -305,7 +308,7 @@ const MessageItem = ({
   };
 
   const renderMessageBubble = () => {
-    if (message.isReasoningPhase && message.author === "AI") {
+    if (message.isReasoningPhase && message.author === "AI" && (!message.toolCalls || message.toolCalls.length === 0) && !message.text) {
       return null;
     }
 

--- a/web/src/chat/ToolCallSection.js
+++ b/web/src/chat/ToolCallSection.js
@@ -17,10 +17,9 @@ import {Spin} from "antd";
 import {CheckCircleFilled, CodeOutlined, DownOutlined, LoadingOutlined} from "@ant-design/icons";
 import i18next from "i18next";
 import Editor from "../common/Editor";
+import {TOOL_DELTA_PREVIEW_LIMIT} from "./toolCallStream";
 
 /* ── Helpers ──────────────────────────────────────────────────── */
-
-const streamingPreviewLimit = 6000;
 
 function renderJsonContent(raw) {
   let text = raw;
@@ -44,7 +43,7 @@ function renderJsonContent(raw) {
 }
 
 function renderStreamingContent(raw, isDark) {
-  const text = raw.length > streamingPreviewLimit ? raw.slice(raw.length - streamingPreviewLimit) : raw;
+  const text = raw.length > TOOL_DELTA_PREVIEW_LIMIT ? raw.slice(raw.length - TOOL_DELTA_PREVIEW_LIMIT) : raw;
   return (
     <pre style={{
       margin: 0,

--- a/web/src/chat/ToolCallSection.js
+++ b/web/src/chat/ToolCallSection.js
@@ -20,6 +20,8 @@ import Editor from "../common/Editor";
 
 /* ── Helpers ──────────────────────────────────────────────────── */
 
+const streamingPreviewLimit = 6000;
+
 function renderJsonContent(raw) {
   let text = raw;
   try {
@@ -38,6 +40,29 @@ function renderJsonContent(raw) {
       lineNumbers={false}
       lineWrapping
     />
+  );
+}
+
+function renderStreamingContent(raw, isDark) {
+  const text = raw.length > streamingPreviewLimit ? raw.slice(raw.length - streamingPreviewLimit) : raw;
+  return (
+    <pre style={{
+      margin: 0,
+      maxHeight: "260px",
+      overflow: "auto",
+      whiteSpace: "pre-wrap",
+      wordBreak: "break-word",
+      fontFamily: "'JetBrains Mono', 'Fira Code', monospace",
+      fontSize: "12px",
+      lineHeight: 1.45,
+      padding: "10px",
+      borderRadius: "6px",
+      background: isDark ? "#11141d" : "#1f2430",
+      color: "#d8deef",
+      border: isDark ? "1px solid #252a3a" : "1px solid #2f3545",
+    }}>
+      {text}
+    </pre>
   );
 }
 
@@ -164,7 +189,7 @@ export const ToolCallCard = ({toolCall, isDark, themeColor, isLast}) => {
               }}>
                 {i18next.t("chat:Arguments")}
               </div>
-              {renderJsonContent(toolCall.arguments)}
+              {toolCall.content ? renderJsonContent(toolCall.arguments) : renderStreamingContent(toolCall.arguments, isDark)}
             </div>
           )}
           {toolCall.content ? (

--- a/web/src/chat/toolCallStream.js
+++ b/web/src/chat/toolCallStream.js
@@ -1,0 +1,108 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export const TOOL_DELTA_PREVIEW_LIMIT = 6000;
+export const TOOL_DELTA_FLUSH_INTERVAL = 80;
+
+export function trimToolArguments(argumentsText, limit = TOOL_DELTA_PREVIEW_LIMIT) {
+  if (!argumentsText || argumentsText.length <= limit) {
+    return argumentsText || "";
+  }
+  return argumentsText.slice(argumentsText.length - limit);
+}
+
+function isPendingDeltaForTool(toolCall, toolEvent) {
+  if (!toolCall.generatingArguments || toolCall.content) {
+    return false;
+  }
+  if (!toolEvent.name) {
+    return true;
+  }
+  return toolCall.name === toolEvent.name || toolCall.name === "tool";
+}
+
+export function applyToolDelta(toolCalls, jsonData, limit = TOOL_DELTA_PREVIEW_LIMIT) {
+  const index = jsonData.index ?? 0;
+  const argumentsDelta = jsonData.argumentsDelta || "";
+
+  for (let i = toolCalls.length - 1; i >= 0; i--) {
+    if (toolCalls[i].generatingArguments && toolCalls[i].index === index) {
+      const nextArguments = `${toolCalls[i].arguments || ""}${argumentsDelta}`;
+      toolCalls[i] = {
+        ...toolCalls[i],
+        id: jsonData.id || toolCalls[i].id,
+        name: jsonData.name || toolCalls[i].name,
+        arguments: trimToolArguments(nextArguments, limit),
+      };
+      return toolCalls[i];
+    }
+  }
+
+  const toolCall = {
+    index,
+    id: jsonData.id,
+    name: jsonData.name || "tool",
+    arguments: trimToolArguments(argumentsDelta, limit),
+    content: "",
+    generatingArguments: true,
+  };
+  toolCalls.push(toolCall);
+  return toolCall;
+}
+
+export function applyToolEvent(toolCalls, jsonData) {
+  if (!jsonData.content) {
+    for (let i = toolCalls.length - 1; i >= 0; i--) {
+      if (isPendingDeltaForTool(toolCalls[i], jsonData)) {
+        toolCalls[i] = {
+          ...toolCalls[i],
+          name: jsonData.name || toolCalls[i].name,
+          arguments: jsonData.arguments || toolCalls[i].arguments || "",
+          content: "",
+          generatingArguments: false,
+        };
+        return toolCalls[i];
+      }
+    }
+
+    const toolCall = {
+      name: jsonData.name,
+      arguments: jsonData.arguments || "",
+      content: "",
+    };
+    toolCalls.push(toolCall);
+    return toolCall;
+  }
+
+  for (let i = toolCalls.length - 1; i >= 0; i--) {
+    if (toolCalls[i].name === jsonData.name && !toolCalls[i].content) {
+      toolCalls[i] = {
+        ...toolCalls[i],
+        name: jsonData.name,
+        arguments: jsonData.arguments || toolCalls[i].arguments || "",
+        content: jsonData.content,
+        generatingArguments: false,
+      };
+      return toolCalls[i];
+    }
+  }
+
+  const toolCall = {
+    name: jsonData.name,
+    arguments: jsonData.arguments || "",
+    content: jsonData.content,
+  };
+  toolCalls.push(toolCall);
+  return toolCall;
+}

--- a/web/src/common/ChatWidget.js
+++ b/web/src/common/ChatWidget.js
@@ -22,6 +22,7 @@ import i18next from "i18next";
 import ChatBox from "../ChatBox";
 import {MessageCarrier} from "../chat/MessageCarrier";
 import {getFirstUserMessageText} from "../carrier/titleUtils";
+import {TOOL_DELTA_FLUSH_INTERVAL, applyToolDelta, applyToolEvent} from "../chat/toolCallStream";
 
 /**
  * ChatWidget - A complete chat component with header, model selector, and chat interface
@@ -428,7 +429,7 @@ class ChatWidget extends React.Component {
     const toolCalls = [];
     let searchResults = null;
     let vectorScores = null;
-    const toolDeltaPreviewLimit = 6000;
+    let toolDeltaFlushTimer = null;
     const flushToolDelta = () => {
       if (!chat || (this.state.currentChat?.name !== chat.name)) {
         return;
@@ -446,6 +447,22 @@ class ChatWidget extends React.Component {
       this.setState({
         messages: updatedMessages,
       });
+    };
+    const scheduleToolDeltaFlush = () => {
+      if (toolDeltaFlushTimer !== null) {
+        return;
+      }
+      toolDeltaFlushTimer = window.setTimeout(() => {
+        toolDeltaFlushTimer = null;
+        flushToolDelta();
+      }, TOOL_DELTA_FLUSH_INTERVAL);
+    };
+    const flushToolDeltaNow = () => {
+      if (toolDeltaFlushTimer !== null) {
+        window.clearTimeout(toolDeltaFlushTimer);
+        toolDeltaFlushTimer = null;
+      }
+      flushToolDelta();
     };
     this.setState({
       messageLoading: true,
@@ -542,61 +559,8 @@ class ChatWidget extends React.Component {
         }
         const jsonData = JSON.parse(data);
 
-        if (!jsonData.content) {
-          let found = false;
-          for (let i = toolCalls.length - 1; i >= 0; i--) {
-            if (toolCalls[i].generatingArguments && !toolCalls[i].content && (!jsonData.name || toolCalls[i].name === jsonData.name || toolCalls[i].name === "tool")) {
-              toolCalls[i] = {
-                name: jsonData.name,
-                arguments: jsonData.arguments,
-                content: "",
-              };
-              found = true;
-              break;
-            }
-          }
-          if (!found) {
-            toolCalls.push({
-              name: jsonData.name,
-              arguments: jsonData.arguments,
-              content: "",
-            });
-          }
-        } else {
-          // tool-complete: find the last pending entry with same name and update it
-          let found = false;
-          for (let i = toolCalls.length - 1; i >= 0; i--) {
-            if (toolCalls[i].name === jsonData.name && !toolCalls[i].content) {
-              toolCalls[i] = {
-                name: jsonData.name,
-                arguments: jsonData.arguments,
-                content: jsonData.content,
-              };
-              found = true;
-              break;
-            }
-          }
-          if (!found) {
-            toolCalls.push({
-              name: jsonData.name,
-              arguments: jsonData.arguments,
-              content: jsonData.content,
-            });
-          }
-        }
-
-        const updatedMessages = [...this.state.messages];
-        if (updatedMessages.length === 0) {
-          return;
-        }
-        const currentMessage = updatedMessages[updatedMessages.length - 1] || lastMessage;
-        const lastMessage2 = Setting.deepCopy(currentMessage);
-        lastMessage2.toolCalls = [...toolCalls];
-        updatedMessages[updatedMessages.length - 1] = lastMessage2;
-
-        this.setState({
-          messages: updatedMessages,
-        });
+        applyToolEvent(toolCalls, jsonData);
+        flushToolDeltaNow();
       },
       // onSearch
       (data) => {
@@ -662,7 +626,7 @@ class ChatWidget extends React.Component {
         if (!chat || (this.state.currentChat?.name !== chat.name)) {
           return;
         }
-        flushToolDelta();
+        flushToolDeltaNow();
 
         const lastMessage2 = Setting.deepCopy(lastMessage);
         lastMessage2.text = text;
@@ -729,31 +693,8 @@ class ChatWidget extends React.Component {
           return;
         }
         const jsonData = JSON.parse(data);
-        const index = jsonData.index ?? 0;
-        let found = false;
-
-        for (let i = toolCalls.length - 1; i >= 0; i--) {
-          if (toolCalls[i].generatingArguments && toolCalls[i].index === index) {
-            const nextArguments = `${toolCalls[i].arguments || ""}${jsonData.argumentsDelta || ""}`;
-            toolCalls[i] = {
-              ...toolCalls[i],
-              name: jsonData.name || toolCalls[i].name,
-              arguments: nextArguments.length > toolDeltaPreviewLimit ? nextArguments.slice(nextArguments.length - toolDeltaPreviewLimit) : nextArguments,
-            };
-            found = true;
-            break;
-          }
-        }
-        if (!found) {
-          toolCalls.push({
-            index,
-            name: jsonData.name || "tool",
-            arguments: (jsonData.argumentsDelta || "").length > toolDeltaPreviewLimit ? (jsonData.argumentsDelta || "").slice((jsonData.argumentsDelta || "").length - toolDeltaPreviewLimit) : (jsonData.argumentsDelta || ""),
-            content: "",
-            generatingArguments: true,
-          });
-        }
-        flushToolDelta();
+        applyToolDelta(toolCalls, jsonData);
+        scheduleToolDeltaFlush();
       }
     );
   }

--- a/web/src/common/ChatWidget.js
+++ b/web/src/common/ChatWidget.js
@@ -428,6 +428,25 @@ class ChatWidget extends React.Component {
     const toolCalls = [];
     let searchResults = null;
     let vectorScores = null;
+    const toolDeltaPreviewLimit = 6000;
+    const flushToolDelta = () => {
+      if (!chat || (this.state.currentChat?.name !== chat.name)) {
+        return;
+      }
+
+      const updatedMessages = [...this.state.messages];
+      if (updatedMessages.length === 0) {
+        return;
+      }
+      const currentMessage = updatedMessages[updatedMessages.length - 1] || lastMessage;
+      const lastMessage2 = Setting.deepCopy(currentMessage);
+      lastMessage2.toolCalls = [...toolCalls];
+      updatedMessages[updatedMessages.length - 1] = lastMessage2;
+
+      this.setState({
+        messages: updatedMessages,
+      });
+    };
     this.setState({
       messageLoading: true,
     });
@@ -505,6 +524,9 @@ class ChatWidget extends React.Component {
         lastMessage2.reasonText = reasonText;
         lastMessage2.isReasoningPhase = true;
         lastMessage2.text = "";
+        if (toolCalls.length > 0) {
+          lastMessage2.toolCalls = [...toolCalls];
+        }
 
         const updatedMessages = [...messages];
         updatedMessages[updatedMessages.length - 1] = lastMessage2;
@@ -521,12 +543,25 @@ class ChatWidget extends React.Component {
         const jsonData = JSON.parse(data);
 
         if (!jsonData.content) {
-          // tool-start: add new entry with empty content (tool is executing)
-          toolCalls.push({
-            name: jsonData.name,
-            arguments: jsonData.arguments,
-            content: "",
-          });
+          let found = false;
+          for (let i = toolCalls.length - 1; i >= 0; i--) {
+            if (toolCalls[i].generatingArguments && !toolCalls[i].content && (!jsonData.name || toolCalls[i].name === jsonData.name || toolCalls[i].name === "tool")) {
+              toolCalls[i] = {
+                name: jsonData.name,
+                arguments: jsonData.arguments,
+                content: "",
+              };
+              found = true;
+              break;
+            }
+          }
+          if (!found) {
+            toolCalls.push({
+              name: jsonData.name,
+              arguments: jsonData.arguments,
+              content: "",
+            });
+          }
         } else {
           // tool-complete: find the last pending entry with same name and update it
           let found = false;
@@ -550,10 +585,13 @@ class ChatWidget extends React.Component {
           }
         }
 
-        const lastMessage2 = Setting.deepCopy(lastMessage);
+        const updatedMessages = [...this.state.messages];
+        if (updatedMessages.length === 0) {
+          return;
+        }
+        const currentMessage = updatedMessages[updatedMessages.length - 1] || lastMessage;
+        const lastMessage2 = Setting.deepCopy(currentMessage);
         lastMessage2.toolCalls = [...toolCalls];
-
-        const updatedMessages = [...messages];
         updatedMessages[updatedMessages.length - 1] = lastMessage2;
 
         this.setState({
@@ -624,6 +662,7 @@ class ChatWidget extends React.Component {
         if (!chat || (this.state.currentChat?.name !== chat.name)) {
           return;
         }
+        flushToolDelta();
 
         const lastMessage2 = Setting.deepCopy(lastMessage);
         lastMessage2.text = text;
@@ -684,6 +723,37 @@ class ChatWidget extends React.Component {
           return;
         }
         this.updateChatDisplayName(update.displayName, {...chat, needTitle: update.needTitle ?? false});
+      },
+      (data) => {
+        if (!chat || (this.state.currentChat?.name !== chat.name)) {
+          return;
+        }
+        const jsonData = JSON.parse(data);
+        const index = jsonData.index ?? 0;
+        let found = false;
+
+        for (let i = toolCalls.length - 1; i >= 0; i--) {
+          if (toolCalls[i].generatingArguments && toolCalls[i].index === index) {
+            const nextArguments = `${toolCalls[i].arguments || ""}${jsonData.argumentsDelta || ""}`;
+            toolCalls[i] = {
+              ...toolCalls[i],
+              name: jsonData.name || toolCalls[i].name,
+              arguments: nextArguments.length > toolDeltaPreviewLimit ? nextArguments.slice(nextArguments.length - toolDeltaPreviewLimit) : nextArguments,
+            };
+            found = true;
+            break;
+          }
+        }
+        if (!found) {
+          toolCalls.push({
+            index,
+            name: jsonData.name || "tool",
+            arguments: (jsonData.argumentsDelta || "").length > toolDeltaPreviewLimit ? (jsonData.argumentsDelta || "").slice((jsonData.argumentsDelta || "").length - toolDeltaPreviewLimit) : (jsonData.argumentsDelta || ""),
+            content: "",
+            generatingArguments: true,
+          });
+        }
+        flushToolDelta();
       }
     );
   }


### PR DESCRIPTION
## Summary

Adds streaming display for tool call arguments in the chat UI for OpenAI Responses and OpenAI-compatible Chat Completions providers. Tool argument deltas are now surfaced through `tool-delta` events and merged into pending tool cards so users can see tool calls forming before execution, including long-running or large-argument tools like `local_file_write`.

## Changes

- Add frontend handling for `tool-delta` events across `ChatPage` and `ChatWidget`.
- Batch tool-delta UI updates with an 80ms flush interval to avoid excessive re-renders.
- Share tool call merge/truncation logic through a common helper.
- Keep reasoning and tool cards in a single AI bubble once tool calls appear.
- Reuse one shared preview limit for streamed tool arguments.
- Preserve immediate UI updates for `tool-start`, `tool-complete`, and stream end.