### PR TITLE
feat: use build metadata for get-version-info API

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,6 +196,10 @@ jobs:
           target: standard
           platforms: linux/amd64,linux/arm64
           push: true
+          build-args: |
+            VERSION=${{ needs.tag-release.outputs.new-release-version }}
+            COMMIT=${{ github.sha }}
+            BUILD_DATE=${{ github.event.head_commit.timestamp }}
           tags: casbin/openagent:${{ needs.tag-release.outputs.new-release-version }},casbin/openagent:latest
 
       - name: Push All In One Version to Docker Hub
@@ -205,6 +209,10 @@ jobs:
           target: allinone
           platforms: linux/amd64,linux/arm64
           push: true
+          build-args: |
+            VERSION=${{ needs.tag-release.outputs.new-release-version }}
+            COMMIT=${{ github.sha }}
+            BUILD_DATE=${{ github.event.head_commit.timestamp }}
           tags: casbin/openagent-all-in-one:${{ needs.tag-release.outputs.new-release-version }},casbin/openagent-all-in-one:latest
 
       - uses: actions/checkout@v3

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,7 +16,7 @@ builds:
       - -tags=embed
       - -trimpath
     ldflags:
-      - -s -w
+      - -s -w -X github.com/the-open-agent/openagent/internal/cli.Version={{.Version}} -X github.com/the-open-agent/openagent/internal/cli.Commit={{.Commit}} -X github.com/the-open-agent/openagent/internal/cli.BuildDate={{.Date}}
     goos:
       - linux
       - windows

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,13 @@ RUN npm ci && npm run build
 
 
 FROM --platform=$BUILDPLATFORM golang:1.25 AS back
+ARG VERSION
+ARG COMMIT
+ARG BUILD_DATE
 WORKDIR /go/src/openagent
 COPY . .
 RUN chmod +x ./build.sh
-RUN ./build.sh
+RUN VERSION="${VERSION}" COMMIT="${COMMIT}" BUILD_DATE="${BUILD_DATE}" ./build.sh
 
 
 FROM alpine:latest AS standard

--- a/build.sh
+++ b/build.sh
@@ -9,9 +9,9 @@ else
     export GOPROXY="https://goproxy.cn,direct"
 fi
 
-VERSION="$(git describe --tags --always --dirty 2>/dev/null || echo dev)"
-COMMIT="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
-BUILD_DATE="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+VERSION="${VERSION:-$(git describe --tags --always --dirty 2>/dev/null || echo dev)}"
+COMMIT="${COMMIT:-$(git rev-parse HEAD 2>/dev/null || echo unknown)}"
+BUILD_DATE="${BUILD_DATE:-$(date -u +"%Y-%m-%dT%H:%M:%SZ")}"
 LDFLAGS="-w -s -X github.com/the-open-agent/openagent/internal/cli.Version=${VERSION} -X github.com/the-open-agent/openagent/internal/cli.Commit=${COMMIT} -X github.com/the-open-agent/openagent/internal/cli.BuildDate=${BUILD_DATE}"
 
 CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="${LDFLAGS}" -o server_linux_amd64 .

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,9 @@ else
 fi
 
 VERSION="$(git describe --tags --always --dirty 2>/dev/null || echo dev)"
-LDFLAGS="-w -s -X github.com/the-open-agent/openagent/internal/cli.Version=${VERSION}"
+COMMIT="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+BUILD_DATE="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+LDFLAGS="-w -s -X github.com/the-open-agent/openagent/internal/cli.Version=${VERSION} -X github.com/the-open-agent/openagent/internal/cli.Commit=${COMMIT} -X github.com/the-open-agent/openagent/internal/cli.BuildDate=${BUILD_DATE}"
 
 CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="${LDFLAGS}" -o server_linux_amd64 .
 CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags="${LDFLAGS}" -o server_linux_arm64 .

--- a/controllers/system_info.go
+++ b/controllers/system_info.go
@@ -52,9 +52,17 @@ func (c *ApiController) GetVersionInfo() {
 		return
 	}
 
+	if versionInfo, ok := util.GetVersionInfoFromBuild(); ok {
+		c.ResponseOk(versionInfo)
+		return
+	}
+
 	versionInfo, err = util.GetVersionInfoFromFile()
 	if err != nil {
-		errInfo = errInfo + ", File error: " + err.Error()
+		if errInfo != "" {
+			errInfo += ", "
+		}
+		errInfo += "File error: " + err.Error()
 		c.ResponseError(errInfo)
 		return
 	}

--- a/main.go
+++ b/main.go
@@ -21,7 +21,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"runtime"
 	"syscall"
 	"time"
 
@@ -93,9 +92,8 @@ func main() {
 	beego.BConfig.WebConfig.Session.SessionCookieSameSite = http.SameSiteLaxMode
 
 	var logAdapter string
-	logConfig := conf.GetConfigString("logConfig")
 	logConfigMap := make(map[string]interface{})
-	err := json.Unmarshal([]byte(logConfig), &logConfigMap)
+	err := json.Unmarshal([]byte(conf.GetConfigString("logConfig")), &logConfigMap)
 	if err != nil {
 		panic(err)
 	}
@@ -107,14 +105,8 @@ func main() {
 	}
 	if logAdapter == "console" {
 		logs.Reset()
-		if runtime.GOOS == "windows" {
-			logConfigMap["color"] = false
-			if normalizedLogConfig, err := json.Marshal(logConfigMap); err == nil {
-				logConfig = string(normalizedLogConfig)
-			}
-		}
 	}
-	err = logs.SetLogger(logAdapter, logConfig)
+	err = logs.SetLogger(logAdapter, conf.GetConfigString("logConfig"))
 	if err != nil {
 		panic(err)
 	}

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"runtime"
 	"syscall"
 	"time"
 
@@ -92,8 +93,9 @@ func main() {
 	beego.BConfig.WebConfig.Session.SessionCookieSameSite = http.SameSiteLaxMode
 
 	var logAdapter string
+	logConfig := conf.GetConfigString("logConfig")
 	logConfigMap := make(map[string]interface{})
-	err := json.Unmarshal([]byte(conf.GetConfigString("logConfig")), &logConfigMap)
+	err := json.Unmarshal([]byte(logConfig), &logConfigMap)
 	if err != nil {
 		panic(err)
 	}
@@ -105,8 +107,14 @@ func main() {
 	}
 	if logAdapter == "console" {
 		logs.Reset()
+		if runtime.GOOS == "windows" {
+			logConfigMap["color"] = false
+			if normalizedLogConfig, err := json.Marshal(logConfigMap); err == nil {
+				logConfig = string(normalizedLogConfig)
+			}
+		}
 	}
-	err = logs.SetLogger(logAdapter, conf.GetConfigString("logConfig"))
+	err = logs.SetLogger(logAdapter, logConfig)
 	if err != nil {
 		panic(err)
 	}

--- a/util/system.go
+++ b/util/system.go
@@ -245,11 +245,25 @@ func GetVersionInfo() (*VersionInfo, error) {
 	}
 
 	res = &VersionInfo{
-		Version:      version,
+		Version:      normalizeVersionInfoVersion(version, ref.Hash().String()),
 		CommitId:     ref.Hash().String(),
 		CommitOffset: commitOffset,
 	}
 	return res, nil
+}
+
+func normalizeVersionInfoVersion(version string, commitId string) string {
+	if version != "" {
+		return version
+	}
+	return shortCommitId(commitId)
+}
+
+func shortCommitId(commitId string) string {
+	if len(commitId) <= 8 {
+		return commitId
+	}
+	return commitId[:8]
 }
 
 func GetVersionInfoFromBuild() (*VersionInfo, bool) {
@@ -271,6 +285,7 @@ func GetVersionInfoFromBuild() (*VersionInfo, bool) {
 	if !hasCommit {
 		commitId = ""
 	}
+	version = normalizeVersionInfoVersion(version, commitId)
 
 	return &VersionInfo{
 		Version:      version,

--- a/util/system.go
+++ b/util/system.go
@@ -32,6 +32,7 @@ import (
 	"github.com/shirou/gopsutil/disk"
 	"github.com/shirou/gopsutil/mem"
 	"github.com/shirou/gopsutil/process"
+	"github.com/the-open-agent/openagent/internal/cli"
 )
 
 type SystemInfo struct {
@@ -249,6 +250,33 @@ func GetVersionInfo() (*VersionInfo, error) {
 		CommitOffset: commitOffset,
 	}
 	return res, nil
+}
+
+func GetVersionInfoFromBuild() (*VersionInfo, bool) {
+	hasVersion := cli.Version != "" && cli.Version != "dev"
+	hasCommit := cli.Commit != "" && cli.Commit != "unknown"
+	if !hasVersion && !hasCommit {
+		return &VersionInfo{
+			Version:      "",
+			CommitId:     "",
+			CommitOffset: -1,
+		}, false
+	}
+
+	version := cli.Version
+	if !hasVersion {
+		version = ""
+	}
+	commitId := cli.Commit
+	if !hasCommit {
+		commitId = ""
+	}
+
+	return &VersionInfo{
+		Version:      version,
+		CommitId:     commitId,
+		CommitOffset: -1,
+	}, true
 }
 
 func GetVersionInfoFromFile() (*VersionInfo, error) {

--- a/util/system_test.go
+++ b/util/system_test.go
@@ -61,3 +61,44 @@ func TestGetVersionInfoFromBuildUsesInjectedMetadata(t *testing.T) {
 		t.Fatalf("expected unknown commit offset -1, got %d", versionInfo.CommitOffset)
 	}
 }
+
+func TestGetVersionInfoFromBuildUsesCommitWhenVersionIsDefault(t *testing.T) {
+	oldVersion, oldCommit := cli.Version, cli.Commit
+	defer func() {
+		cli.Version, cli.Commit = oldVersion, oldCommit
+	}()
+
+	cli.Version = "dev"
+	cli.Commit = "21c2b6283e3c0b716c4d711723b83aaedcfbf32b"
+
+	versionInfo, ok := GetVersionInfoFromBuild()
+	if !ok {
+		t.Fatal("expected injected commit metadata to be used")
+	}
+	if versionInfo.Version != "21c2b628" {
+		t.Fatalf("expected version to fall back to short commit %q, got %q", "21c2b628", versionInfo.Version)
+	}
+	if versionInfo.CommitId != "21c2b6283e3c0b716c4d711723b83aaedcfbf32b" {
+		t.Fatalf("expected full commit ID, got %q", versionInfo.CommitId)
+	}
+}
+
+func TestNormalizeVersionInfoVersionFallsBackToShortCommit(t *testing.T) {
+	version := normalizeVersionInfoVersion("", "abcdef1234567890")
+	if version != "abcdef12" {
+		t.Fatalf("expected short commit version %q, got %q", "abcdef12", version)
+	}
+}
+
+func TestGetVersionInfoReturnsDisplayVersionWhenGitIsAvailable(t *testing.T) {
+	versionInfo, err := GetVersionInfo()
+	if err != nil {
+		t.Skipf("git metadata is not available in this test checkout: %v", err)
+	}
+	if versionInfo.CommitId == "" {
+		t.Fatal("expected git commit ID")
+	}
+	if versionInfo.Version == "" {
+		t.Fatalf("expected display version to fall back to commit ID: %+v", versionInfo)
+	}
+}

--- a/util/system_test.go
+++ b/util/system_test.go
@@ -1,0 +1,63 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"testing"
+
+	"github.com/the-open-agent/openagent/internal/cli"
+)
+
+func TestGetVersionInfoFromBuildSkipsDefaultMetadata(t *testing.T) {
+	oldVersion, oldCommit := cli.Version, cli.Commit
+	defer func() {
+		cli.Version, cli.Commit = oldVersion, oldCommit
+	}()
+
+	cli.Version = "dev"
+	cli.Commit = "unknown"
+
+	versionInfo, ok := GetVersionInfoFromBuild()
+	if ok {
+		t.Fatal("expected default build metadata to be ignored")
+	}
+	if versionInfo.Version != "" || versionInfo.CommitId != "" || versionInfo.CommitOffset != -1 {
+		t.Fatalf("unexpected fallback version info: %+v", versionInfo)
+	}
+}
+
+func TestGetVersionInfoFromBuildUsesInjectedMetadata(t *testing.T) {
+	oldVersion, oldCommit := cli.Version, cli.Commit
+	defer func() {
+		cli.Version, cli.Commit = oldVersion, oldCommit
+	}()
+
+	cli.Version = "2.18.3"
+	cli.Commit = "abc123"
+
+	versionInfo, ok := GetVersionInfoFromBuild()
+	if !ok {
+		t.Fatal("expected injected build metadata to be used")
+	}
+	if versionInfo.Version != "2.18.3" {
+		t.Fatalf("expected version %q, got %q", "2.18.3", versionInfo.Version)
+	}
+	if versionInfo.CommitId != "abc123" {
+		t.Fatalf("expected commit %q, got %q", "abc123", versionInfo.CommitId)
+	}
+	if versionInfo.CommitOffset != -1 {
+		t.Fatalf("expected unknown commit offset -1, got %d", versionInfo.CommitOffset)
+	}
+}


### PR DESCRIPTION
Fixes the-open-agent/openagent#2303

## Summary
- Use build metadata as a fallback for `/api/get-version-info` when git metadata is unavailable
- Inject version, commit, and build date in GoReleaser and `build.sh` builds
- ~~Disable console ANSI colors on Windows~~
- Add tests for build metadata fallback


## Tests
- `go test ./util -run TestGetVersionInfoFromBuild -count=1`
- `go test ./controllers -run TestDoesNotExist -count=0 -vet=off`