### PR TITLE
feat: add OpenCode model provider

### DIFF
--- a/model/opencode.go
+++ b/model/opencode.go
@@ -15,7 +15,9 @@
 package model
 
 import (
+	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -49,13 +51,10 @@ func NewOpenCodeProvider(serverUrl string, apiKey string) (*OpenCodeProvider, er
 func newOpenCodeHTTPClient() *http.Client {
 	if proxy.ProxyHttpClient != nil {
 		clonedClient := *proxy.ProxyHttpClient
-		clonedClient.Timeout = 300 * time.Second
 		return &clonedClient
 	}
 
-	return &http.Client{
-		Timeout: 300 * time.Second,
-	}
+	return &http.Client{}
 }
 
 func (p *OpenCodeProvider) GetPricing() string {
@@ -79,13 +78,21 @@ func (p *OpenCodeProvider) QueryText(question string, writer io.Writer, history 
 	if err != nil {
 		return nil, fmt.Errorf("OpenCode: failed to create session at %s: %v.\n\nMake sure 'opencode serve' is running. You can change the server URL in provider settings.", p.serverUrl, err)
 	}
+	defer p.deleteSession(sessionID)
 
 	var messageText strings.Builder
 	for _, msg := range history {
-		if msg.Author != "AI" {
-			messageText.WriteString(msg.Text)
-			messageText.WriteString("\n")
+		if msg.Text == "" {
+			continue
 		}
+		switch msg.Author {
+		case "AI":
+			messageText.WriteString("Assistant: ")
+		case "User":
+			messageText.WriteString("User: ")
+		}
+		messageText.WriteString(msg.Text)
+		messageText.WriteString("\n")
 	}
 	if len(knowledgeMessages) > 0 {
 		messageText.WriteString("\n--- Context ---\n")
@@ -97,44 +104,26 @@ func (p *OpenCodeProvider) QueryText(question string, writer io.Writer, history 
 	}
 	messageText.WriteString(question)
 
-	respParts, err := p.sendMessage(sessionID, prompt, messageText.String())
-	if err != nil {
+	// Open SSE stream first so it subscribes to events before any are published
+	type sseResult struct {
+		result *ModelResult
+		err    error
+	}
+	resultCh := make(chan sseResult, 1)
+	go func() {
+		r, e := p.readSSEStream(sessionID, question, writer, flusher)
+		resultCh <- sseResult{r, e}
+	}()
+
+	// Give SSE connection a moment to establish before triggering events
+	time.Sleep(100 * time.Millisecond)
+
+	if err := p.sendMessageAsync(sessionID, prompt, messageText.String()); err != nil {
 		return nil, err
 	}
 
-	var fullText strings.Builder
-	var promptTokens, completionTokens int
-
-	for _, part := range respParts {
-		switch part.Type {
-		case "text", "reasoning":
-			fullText.WriteString(part.Text)
-			fmt.Fprint(writer, part.Text)
-		case "step-finish":
-			if part.Tokens != nil {
-				promptTokens = part.Tokens.Prompt
-				completionTokens = part.Tokens.Completion
-			}
-		}
-	}
-	flusher.Flush()
-
-	if promptTokens == 0 {
-		promptTokens, _ = GetTokenSize("gpt-4", question)
-	}
-	if completionTokens == 0 {
-		completionTokens, _ = GetTokenSize("gpt-4", fullText.String())
-	}
-
-	totalTokens := promptTokens + completionTokens
-
-	return &ModelResult{
-		PromptTokenCount:   promptTokens,
-		ResponseTokenCount:  completionTokens,
-		TotalTokenCount:    totalTokens,
-		TotalPrice:         0,
-		Currency:           "USD",
-	}, nil
+	res := <-resultCh
+	return res.result, res.err
 }
 
 func (p *OpenCodeProvider) ListModels() ([]string, error) {
@@ -171,7 +160,24 @@ func (p *OpenCodeProvider) createSession() (string, error) {
 	return result.ID, nil
 }
 
-func (p *OpenCodeProvider) sendMessage(sessionID string, systemPrompt string, text string) ([]openCodeResponsePart, error) {
+func (p *OpenCodeProvider) deleteSession(sessionID string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "DELETE", p.serverUrl+"/session/"+sessionID, nil)
+	if err != nil {
+		return
+	}
+	p.setAuth(req)
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return
+	}
+	resp.Body.Close()
+}
+
+func (p *OpenCodeProvider) sendMessageAsync(sessionID string, systemPrompt string, text string) error {
 	reqBody := map[string]interface{}{
 		"parts": []map[string]string{
 			{"type": "text", "text": text},
@@ -183,12 +189,15 @@ func (p *OpenCodeProvider) sendMessage(sessionID string, systemPrompt string, te
 
 	bodyBytes, err := json.Marshal(reqBody)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	req, err := http.NewRequest("POST", p.serverUrl+"/session/"+sessionID+"/message", bytes.NewReader(bodyBytes))
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "POST", p.serverUrl+"/session/"+sessionID+"/prompt_async", bytes.NewReader(bodyBytes))
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	p.setAuth(req)
@@ -196,38 +205,200 @@ func (p *OpenCodeProvider) sendMessage(sessionID string, systemPrompt string, te
 
 	resp, err := p.client.Do(req)
 	if err != nil {
+		return fmt.Errorf("OpenCode: failed to send message: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("OpenCode: HTTP %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	return nil
+}
+
+func (p *OpenCodeProvider) readSSEStream(sessionID string, question string, writer io.Writer, flusher http.Flusher) (*ModelResult, error) {
+	req, err := http.NewRequest("GET", p.serverUrl+"/event", nil)
+	if err != nil {
 		return nil, err
+	}
+
+	p.setAuth(req)
+	req.Header.Set("Accept", "text/event-stream")
+	req.Header.Set("Cache-Control", "no-cache")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1200*time.Second)
+	defer cancel()
+	req = req.WithContext(ctx)
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("OpenCode: failed to connect to SSE stream: %v", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("OpenCode: HTTP %d: %s", resp.StatusCode, string(respBody))
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("OpenCode: SSE HTTP %d: %s", resp.StatusCode, string(body))
 	}
 
-	var result struct {
-		Info  json.RawMessage        `json:"info"`
-		Parts []openCodeResponsePart `json:"parts"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, err
+	var fullText strings.Builder
+	var promptTokens, completionTokens int
+	done := false
+	partTypes := make(map[string]string) // partID -> type ("reasoning" or "text")
+
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+
+		data := strings.TrimPrefix(line, "data: ")
+		if data == "" || data == "[DONE]" {
+			continue
+		}
+
+		event := p.parseSSEEvent(data)
+
+		if event.Properties == nil {
+			continue
+		}
+
+		switch event.Type {
+		case "message.part.updated":
+			part, _ := event.Properties["part"].(map[string]interface{})
+			if part == nil {
+				continue
+			}
+			partID, _ := part["id"].(string)
+			partType, _ := part["type"].(string)
+
+			// Track part type for routing deltas
+			if partID != "" && (partType == "reasoning" || partType == "text") {
+				partTypes[partID] = partType
+			}
+
+			// Extract token counts from step-finish
+			if partType == "step-finish" {
+				evtSessionID, _ := event.Properties["sessionID"].(string)
+				if evtSessionID == sessionID {
+					if tokens, ok := part["tokens"].(map[string]interface{}); ok {
+						if p, ok := tokens["input"].(float64); ok {
+							promptTokens = int(p)
+						}
+						if c, ok := tokens["output"].(float64); ok {
+							completionTokens = int(c)
+						}
+					}
+				}
+			}
+
+		case "message.part.delta":
+			evtSessionID, _ := event.Properties["sessionID"].(string)
+			if evtSessionID != sessionID {
+				continue
+			}
+			field, _ := event.Properties["field"].(string)
+			if field != "text" {
+				continue
+			}
+			delta, _ := event.Properties["delta"].(string)
+			if delta == "" {
+				continue
+			}
+
+			partID, _ := event.Properties["partID"].(string)
+			partType := partTypes[partID]
+
+			if partType == "reasoning" {
+				fmt.Fprintf(writer, "event: reason\ndata: %s\n\n", delta)
+			} else {
+				fullText.WriteString(delta)
+				fmt.Fprintf(writer, "event: message\ndata: %s\n\n", delta)
+			}
+			flusher.Flush()
+
+		case "session.status":
+			evtSessionID, _ := event.Properties["sessionID"].(string)
+			if evtSessionID != sessionID {
+				continue
+			}
+			if status, ok := event.Properties["status"].(map[string]interface{}); ok {
+				if st, _ := status["type"].(string); st == "idle" {
+					done = true
+				}
+			}
+
+		case "session.idle":
+			evtSessionID, _ := event.Properties["sessionID"].(string)
+			if evtSessionID == sessionID {
+				done = true
+			}
+		}
+
+		if done {
+			break
+		}
 	}
 
-	return result.Parts, nil
+	if err := scanner.Err(); err != nil {
+		if done {
+			// already completed, ignore scanner error (likely from closing connection)
+		} else if ctx.Err() == context.DeadlineExceeded {
+			return nil, fmt.Errorf("OpenCode: request timed out after 20 minutes")
+		} else {
+			return nil, fmt.Errorf("OpenCode: SSE stream error: %v", err)
+		}
+	}
+
+	if promptTokens == 0 {
+		promptTokens, _ = GetTokenSize("gpt-4", question)
+	}
+	if completionTokens == 0 {
+		completionTokens, _ = GetTokenSize("gpt-4", fullText.String())
+	}
+
+	totalTokens := promptTokens + completionTokens
+
+	return &ModelResult{
+		PromptTokenCount:   promptTokens,
+		ResponseTokenCount:  completionTokens,
+		TotalTokenCount:    totalTokens,
+		TotalPrice:         0,
+		Currency:           "USD",
+	}, nil
+}
+
+type sseEvent struct {
+	Type       string                 `json:"type"`
+	Properties map[string]interface{} `json:"properties"`
+}
+
+func (p *OpenCodeProvider) parseSSEEvent(data string) sseEvent {
+	var result sseEvent
+
+	// Try format A: { type, properties }
+	if err := json.Unmarshal([]byte(data), &result); err == nil && result.Type != "" {
+		return result
+	}
+
+	// Try format B: { directory, payload: { type, properties } }
+	var wrapped struct {
+		Payload json.RawMessage `json:"payload"`
+	}
+	if err := json.Unmarshal([]byte(data), &wrapped); err == nil && len(wrapped.Payload) > 0 {
+		json.Unmarshal(wrapped.Payload, &result)
+	}
+
+	return result
 }
 
 func (p *OpenCodeProvider) setAuth(req *http.Request) {
 	if p.apiKey != "" {
 		req.SetBasicAuth("opencode", p.apiKey)
 	}
-}
-
-type openCodeResponsePart struct {
-	Type   string `json:"type"`
-	Text   string `json:"text,omitempty"`
-	Tokens *struct {
-		Prompt     int `json:"prompt"`
-		Completion int `json:"completion"`
-		Total      int `json:"total"`
-	} `json:"tokens,omitempty"`
 }

--- a/model/opencode.go
+++ b/model/opencode.go
@@ -74,6 +74,14 @@ func (p *OpenCodeProvider) QueryText(question string, writer io.Writer, history 
 		return &ModelResult{}, nil
 	}
 
+	// NOTE: OpenCode is a self-contained agent that executes tools internally
+	// on the server side. It does not expose a "function calling" API where
+	// the LLM returns tool calls for the client to execute. This means
+	// OpenAgent's MCP tools cannot be mapped to OpenCode's execution model.
+	// When toolSession is non-nil, tools are silently unavailable and the
+	// LLM will produce a text-only response.
+	_ = toolSession
+
 	sessionID, err := p.createSession()
 	if err != nil {
 		return nil, fmt.Errorf("OpenCode: failed to create session at %s: %v.\n\nMake sure 'opencode serve' is running. You can change the server URL in provider settings.", p.serverUrl, err)
@@ -104,21 +112,27 @@ func (p *OpenCodeProvider) QueryText(question string, writer io.Writer, history 
 	}
 	messageText.WriteString(question)
 
-	// Open SSE stream first so it subscribes to events before any are published
+	// Shared context so SSE goroutine can be cancelled if sendMessageAsync fails
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	type sseResult struct {
 		result *ModelResult
 		err    error
 	}
 	resultCh := make(chan sseResult, 1)
+	readyCh := make(chan struct{})
 	go func() {
-		r, e := p.readSSEStream(sessionID, question, writer, flusher)
+		r, e := p.readSSEStream(ctx, sessionID, question, writer, flusher, readyCh)
 		resultCh <- sseResult{r, e}
 	}()
 
-	// Give SSE connection a moment to establish before triggering events
-	time.Sleep(100 * time.Millisecond)
+	// Wait for SSE connection to be established before sending prompt
+	<-readyCh
 
 	if err := p.sendMessageAsync(sessionID, prompt, messageText.String()); err != nil {
+		cancel()      // signal SSE goroutine to stop
+		<-resultCh    // wait for goroutine to clean up
 		return nil, err
 	}
 
@@ -131,7 +145,10 @@ func (p *OpenCodeProvider) ListModels() ([]string, error) {
 }
 
 func (p *OpenCodeProvider) createSession() (string, error) {
-	req, err := http.NewRequest("POST", p.serverUrl+"/session", bytes.NewReader([]byte("{}")))
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "POST", p.serverUrl+"/session", bytes.NewReader([]byte("{}")))
 	if err != nil {
 		return "", err
 	}
@@ -214,10 +231,15 @@ func (p *OpenCodeProvider) sendMessageAsync(sessionID string, systemPrompt strin
 		return fmt.Errorf("OpenCode: HTTP %d: %s", resp.StatusCode, string(respBody))
 	}
 
+	io.Copy(io.Discard, resp.Body)
 	return nil
 }
 
-func (p *OpenCodeProvider) readSSEStream(sessionID string, question string, writer io.Writer, flusher http.Flusher) (*ModelResult, error) {
+func (p *OpenCodeProvider) readSSEStream(ctx context.Context, sessionID string, question string, writer io.Writer, flusher http.Flusher, ready chan<- struct{}) (*ModelResult, error) {
+	// OpenCode only exposes global SSE endpoints (/event and /global/event).
+	// There is no session-scoped SSE endpoint, so we filter by sessionID
+	// client-side. This is the intended design — events include a sessionID
+	// field for this purpose.
 	req, err := http.NewRequest("GET", p.serverUrl+"/event", nil)
 	if err != nil {
 		return nil, err
@@ -227,15 +249,18 @@ func (p *OpenCodeProvider) readSSEStream(sessionID string, question string, writ
 	req.Header.Set("Accept", "text/event-stream")
 	req.Header.Set("Cache-Control", "no-cache")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1200*time.Second)
+	sseCtx, cancel := context.WithTimeout(ctx, 1200*time.Second)
 	defer cancel()
-	req = req.WithContext(ctx)
+	req = req.WithContext(sseCtx)
 
 	resp, err := p.client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("OpenCode: failed to connect to SSE stream: %v", err)
 	}
 	defer resp.Body.Close()
+
+	// Signal caller that SSE connection is established
+	close(ready)
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
@@ -348,7 +373,7 @@ func (p *OpenCodeProvider) readSSEStream(sessionID string, question string, writ
 	if err := scanner.Err(); err != nil {
 		if done {
 			// already completed, ignore scanner error (likely from closing connection)
-		} else if ctx.Err() == context.DeadlineExceeded {
+		} else if sseCtx.Err() == context.DeadlineExceeded {
 			return nil, fmt.Errorf("OpenCode: request timed out after 20 minutes")
 		} else {
 			return nil, fmt.Errorf("OpenCode: SSE stream error: %v", err)

--- a/model/opencode.go
+++ b/model/opencode.go
@@ -1,0 +1,233 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/the-open-agent/openagent/i18n"
+	"github.com/the-open-agent/openagent/proxy"
+)
+
+type OpenCodeProvider struct {
+	serverUrl string
+	apiKey    string
+	client    *http.Client
+}
+
+func NewOpenCodeProvider(serverUrl string, apiKey string) (*OpenCodeProvider, error) {
+	if serverUrl == "" {
+		serverUrl = "http://localhost:4096"
+	}
+	serverUrl = strings.TrimRight(serverUrl, "/")
+
+	return &OpenCodeProvider{
+		serverUrl: serverUrl,
+		apiKey:    apiKey,
+		client:    newOpenCodeHTTPClient(),
+	}, nil
+}
+
+func newOpenCodeHTTPClient() *http.Client {
+	if proxy.ProxyHttpClient != nil {
+		clonedClient := *proxy.ProxyHttpClient
+		clonedClient.Timeout = 300 * time.Second
+		return &clonedClient
+	}
+
+	return &http.Client{
+		Timeout: 300 * time.Second,
+	}
+}
+
+func (p *OpenCodeProvider) GetPricing() string {
+	return `OpenCode delegates to underlying LLM providers.
+Pricing depends on the provider and model configured in OpenCode.
+
+URL: https://opencode.ai`
+}
+
+func (p *OpenCodeProvider) QueryText(question string, writer io.Writer, history []*RawMessage, prompt string, knowledgeMessages []*RawMessage, toolSession *ToolSession, lang string) (*ModelResult, error) {
+	flusher, ok := writer.(http.Flusher)
+	if !ok {
+		return nil, fmt.Errorf(i18n.Translate(lang, "model:writer does not implement http.Flusher"))
+	}
+
+	if strings.HasPrefix(question, "$OpenAgentDryRun$") {
+		return &ModelResult{}, nil
+	}
+
+	sessionID, err := p.createSession()
+	if err != nil {
+		return nil, fmt.Errorf("OpenCode: failed to create session at %s: %v.\n\nMake sure 'opencode serve' is running. You can change the server URL in provider settings.", p.serverUrl, err)
+	}
+
+	var messageText strings.Builder
+	for _, msg := range history {
+		if msg.Author != "AI" {
+			messageText.WriteString(msg.Text)
+			messageText.WriteString("\n")
+		}
+	}
+	if len(knowledgeMessages) > 0 {
+		messageText.WriteString("\n--- Context ---\n")
+		for _, msg := range knowledgeMessages {
+			messageText.WriteString(msg.Text)
+			messageText.WriteString("\n")
+		}
+		messageText.WriteString("--- End Context ---\n\n")
+	}
+	messageText.WriteString(question)
+
+	respParts, err := p.sendMessage(sessionID, prompt, messageText.String())
+	if err != nil {
+		return nil, err
+	}
+
+	var fullText strings.Builder
+	var promptTokens, completionTokens int
+
+	for _, part := range respParts {
+		switch part.Type {
+		case "text", "reasoning":
+			fullText.WriteString(part.Text)
+			fmt.Fprint(writer, part.Text)
+		case "step-finish":
+			if part.Tokens != nil {
+				promptTokens = part.Tokens.Prompt
+				completionTokens = part.Tokens.Completion
+			}
+		}
+	}
+	flusher.Flush()
+
+	if promptTokens == 0 {
+		promptTokens, _ = GetTokenSize("gpt-4", question)
+	}
+	if completionTokens == 0 {
+		completionTokens, _ = GetTokenSize("gpt-4", fullText.String())
+	}
+
+	totalTokens := promptTokens + completionTokens
+
+	return &ModelResult{
+		PromptTokenCount:   promptTokens,
+		ResponseTokenCount:  completionTokens,
+		TotalTokenCount:    totalTokens,
+		TotalPrice:         0,
+		Currency:           "USD",
+	}, nil
+}
+
+func (p *OpenCodeProvider) ListModels() ([]string, error) {
+	return unsupportedListModels("OpenCode")
+}
+
+func (p *OpenCodeProvider) createSession() (string, error) {
+	req, err := http.NewRequest("POST", p.serverUrl+"/session", bytes.NewReader([]byte("{}")))
+	if err != nil {
+		return "", err
+	}
+
+	p.setAuth(req)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", err
+	}
+
+	return result.ID, nil
+}
+
+func (p *OpenCodeProvider) sendMessage(sessionID string, systemPrompt string, text string) ([]openCodeResponsePart, error) {
+	reqBody := map[string]interface{}{
+		"parts": []map[string]string{
+			{"type": "text", "text": text},
+		},
+	}
+	if systemPrompt != "" {
+		reqBody["system"] = systemPrompt
+	}
+
+	bodyBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", p.serverUrl+"/session/"+sessionID+"/message", bytes.NewReader(bodyBytes))
+	if err != nil {
+		return nil, err
+	}
+
+	p.setAuth(req)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("OpenCode: HTTP %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result struct {
+		Info  json.RawMessage        `json:"info"`
+		Parts []openCodeResponsePart `json:"parts"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+
+	return result.Parts, nil
+}
+
+func (p *OpenCodeProvider) setAuth(req *http.Request) {
+	if p.apiKey != "" {
+		req.SetBasicAuth("opencode", p.apiKey)
+	}
+}
+
+type openCodeResponsePart struct {
+	Type   string `json:"type"`
+	Text   string `json:"text,omitempty"`
+	Tokens *struct {
+		Prompt     int `json:"prompt"`
+		Completion int `json:"completion"`
+		Total      int `json:"total"`
+	} `json:"tokens,omitempty"`
+}

--- a/model/provider.go
+++ b/model/provider.go
@@ -173,6 +173,8 @@ func GetModelProvider(typ string, subType string, clientId string, clientSecret 
 		p, err = NewGitHubModelProvider(typ, subType, clientSecret, temperature, topP, frequencyPenalty, presencePenalty)
 	} else if typ == "Writer" {
 		p, err = NewWriterModelProvider(subType, clientSecret, temperature, topP)
+	} else if typ == "OpenCode" {
+		p, err = NewOpenCodeProvider(providerUrl, clientSecret)
 	} else {
 		return nil, nil
 	}

--- a/object/provider_util.go
+++ b/object/provider_util.go
@@ -47,7 +47,7 @@ func getModelProviderFromName(owner string, providerName string, lang string) (*
 	if provider.Category != "Model" {
 		return nil, nil, fmt.Errorf(i18n.Translate(lang, "object:The model provider: %s is expected to be \")Model\" category, got: \"%s\""), provider.GetId(), provider.Category)
 	}
-	if provider.ClientSecret == "" && provider.Type != "Ollama" {
+	if provider.ClientSecret == "" && provider.Type != "Ollama" && provider.Type != "OpenCode" {
 		return nil, nil, fmt.Errorf(i18n.Translate(lang, "object:The model provider: %s's client secret should not be empty"), provider.GetId())
 	}
 

--- a/web/src/ProviderEditPage.js
+++ b/web/src/ProviderEditPage.js
@@ -130,7 +130,7 @@ class ProviderEditPage extends React.Component {
   }
 
   modelCategoryShowsProviderUrlInput(type) {
-    return ["Local", "Ollama", "Azure", "Volcano Engine", "Tencent Cloud"].includes(type);
+    return ["Local", "Ollama", "Azure", "Volcano Engine", "Tencent Cloud", "OpenCode"].includes(type);
   }
 
   getRegionLabel(provider) {
@@ -436,6 +436,8 @@ class ProviderEditPage extends React.Component {
                     this.updateProviderField("subType", "gpt-4o");
                   } else if (value === "Writer") {
                     this.updateProviderField("subType", "palmyra-x5");
+                  } else if (value === "OpenCode") {
+                    this.updateProviderField("subType", "");
                   }
                 } else if (provider.category === "Embedding") {
                   if (value === "OpenAI") {
@@ -498,7 +500,7 @@ class ProviderEditPage extends React.Component {
                         virtual={false}
                         style={{flex: 1}}
                         value={provider.subType}
-                        disabled={isRemote}
+                        disabled={isRemote || provider.type === "OpenCode"}
                         onChange={(value) => {
                           this.updateProviderField("subType", value);
                         }}

--- a/web/src/ProviderSetting.js
+++ b/web/src/ProviderSetting.js
@@ -152,7 +152,11 @@ export function getOtherProviderInfo() {
       },
       "Writer": {
         logo: `${StaticBaseUrl}/img/social_writer.png`,
-        url: "https://writer.com/",
+        url: "https://writer.com",
+      },
+      "OpenCode": {
+        logo: `${StaticBaseUrl}/img/social_opencode.png`,
+        url: "https://opencode.ai",
       },
     },
     Embedding: {
@@ -600,6 +604,7 @@ export function getProviderTypeOptions(category) {
         {id: "Silicon Flow", name: "Silicon Flow"},
         {id: "GitHub", name: "GitHub"},
         {id: "Writer", name: "Writer"},
+        {id: "OpenCode", name: "OpenCode"},
       ]
     );
   } else if (category === "Embedding") {
@@ -1348,7 +1353,7 @@ export function getProviderAzureApiVersionOptions() {
 }
 
 export function getQuickSetupModelTypes() {
-  return ["OpenAI", "Claude", "Gemini", "DeepSeek", "Grok", "Ollama", "OpenRouter", "Mistral", "Azure", "OpenAI Compatible", "Alibaba Cloud", "Moonshot", "Silicon Flow", "Volcano Engine", "Baidu Cloud", "Amazon Bedrock"];
+  return ["OpenAI", "Claude", "Gemini", "DeepSeek", "Grok", "Ollama", "OpenRouter", "Mistral", "Azure", "OpenAI Compatible", "Alibaba Cloud", "Moonshot", "Silicon Flow", "Volcano Engine", "Baidu Cloud", "Amazon Bedrock", "OpenCode"];
 }
 
 export function getModelProviderMetadata(type) {
@@ -1369,6 +1374,7 @@ export function getModelProviderMetadata(type) {
     "Volcano Engine": {desc: "ByteDance AI platform", needsApiKey: true, needsUrl: false, needsClientId: false, needsRegion: false, defaultSubType: "doubao-seed-2-0-pro-260215"},
     "Baidu Cloud": {desc: "ERNIE Bot models", needsApiKey: true, needsUrl: false, needsClientId: false, needsRegion: false, defaultSubType: "ernie-5.0"},
     "Amazon Bedrock": {desc: "Claude, Llama on AWS", needsApiKey: true, needsUrl: false, needsClientId: true, needsRegion: true, defaultSubType: "claude"},
+    "OpenCode": {desc: "Delegate coding to OpenCode agent", needsApiKey: false, needsUrl: true, needsClientId: false, needsRegion: false, defaultSubType: "", urlPlaceholder: "http://localhost:4096", defaultUrl: "http://localhost:4096"},
   };
   return metadata[type] || {desc: "", needsApiKey: true, needsUrl: false, needsClientId: false, needsRegion: false, defaultSubType: ""};
 }


### PR DESCRIPTION
Closes #2328

Add OpenCode as a model provider so openagent can delegate coding
tasks to OpenCode via its HTTP server API.

### How it works

openagent chat request → OpenCodeProvider.QueryText()
  ↓
POST /session           → create OpenCode session
  ↓
POST /session/:id/message → send prompt + history + context
                              (system prompt via "system" field)
  ↓
parse response parts[]  → extract text/reasoning → stream to writer
                        → extract token stats from step-finish

### Changes

| File | Description |
|------|-------------|
| `model/opencode.go` (new) | Core provider communicating with OpenCode Server API |
| `model/provider.go` | Register `"OpenCode"` type in `GetModelProvider()` |
| `object/provider_util.go` | Allow empty `ClientSecret` for OpenCode (local server needs no auth by default) |
| `web/src/ProviderSetting.js` | Add logo, type option, quick setup, and metadata |
| `web/src/ProviderEditPage.js` | Show URL input, disable subType, clear it on type change |

### Behavior

- **Default URL**: `http://localhost:4096` (empty → auto default)
- **Model**: not specified (OpenCode uses its own configured default)
- **Auth**: optional — supports basic auth via `ClientSecret` when
  `OPENCODE_SERVER_PASSWORD` is set on the OpenCode server
- **SubType**: disabled in UI (OpenCode manages its own underlying model)

### Testing

1. Start `opencode serve --port 4096`
2. Start `go run main.go`
3. Add a Model provider with type "OpenCode" (URL + API key optional)
4. Send a coding request in chat — OpenCode processes and returns the result