### PR TITLE
fix: Fix vision image handling for storage URLs

### DIFF
--- a/model/image_url_util.go
+++ b/model/image_url_util.go
@@ -1,0 +1,240 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"encoding/base64"
+	"fmt"
+	"html"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/the-open-agent/openagent/proxy"
+)
+
+var (
+	imageBRRegexp       = regexp.MustCompile(`(?i)<br\s*/?>`)
+	imageTagRegexp      = regexp.MustCompile(`(?is)<img\b[^>]*>`)
+	imageSrcRegexp      = regexp.MustCompile(`(?is)<img\b[^>]*\bsrc\s*=\s*("[^"]*"|'[^']*'|[^'"\s>]+)[^>]*>`)
+	bareHTTPImageRegexp = regexp.MustCompile(`(?i)https?://[^\s"'<>]+\.(?:jpg|jpeg|png|gif|webp)(?:\?[^\s"'<>]*)?`)
+)
+
+func extractImageDataURLsFromMessage(message string) ([]string, string, error) {
+	imageSources, messageText := extractImageSourcesFromMessage(message)
+	res := make([]string, 0, len(imageSources))
+	for _, imageSource := range imageSources {
+		imageDataURL, err := imageSourceToDataURL(imageSource)
+		if err != nil {
+			return nil, "", err
+		}
+		res = append(res, imageDataURL)
+	}
+
+	return res, messageText, nil
+}
+
+func extractImageSourcesFromMessage(message string) ([]string, string) {
+	message = strings.ReplaceAll(message, "&nbsp;", " ")
+	message = imageBRRegexp.ReplaceAllString(message, " ")
+
+	res := []string{}
+	for _, match := range imageSrcRegexp.FindAllStringSubmatch(message, -1) {
+		if len(match) < 2 {
+			continue
+		}
+		res = append(res, cleanImageSource(match[1]))
+	}
+
+	message = imageTagRegexp.ReplaceAllString(message, "")
+
+	bareURLs := bareHTTPImageRegexp.FindAllString(message, -1)
+	for _, bareURL := range bareURLs {
+		res = append(res, cleanImageSource(bareURL))
+	}
+	message = bareHTTPImageRegexp.ReplaceAllString(message, "")
+
+	return res, message
+}
+
+func cleanImageSource(src string) string {
+	src = strings.TrimSpace(src)
+	if len(src) >= 2 {
+		first := src[0]
+		last := src[len(src)-1]
+		if (first == '"' && last == '"') || (first == '\'' && last == '\'') {
+			src = src[1 : len(src)-1]
+		}
+	}
+	return html.UnescapeString(strings.TrimSpace(src))
+}
+
+func imageSourceToDataURL(src string) (string, error) {
+	src = cleanImageSource(src)
+	lowerSrc := strings.ToLower(src)
+	if strings.HasPrefix(lowerSrc, "data:image/") {
+		if !strings.Contains(lowerSrc, ";base64,") {
+			return "", fmt.Errorf("image data URL is not base64 encoded")
+		}
+		return src, nil
+	}
+
+	if path, ok, err := storageURLToLocalPath(src); ok || err != nil {
+		if err != nil {
+			return "", err
+		}
+		return localImageFileToDataURL(path)
+	}
+
+	if strings.HasPrefix(lowerSrc, "http://") || strings.HasPrefix(lowerSrc, "https://") {
+		return httpImageToDataURL(src)
+	}
+
+	return "", fmt.Errorf("unsupported image source: %s", src)
+}
+
+func storageURLToLocalPath(src string) (string, bool, error) {
+	src = strings.TrimSpace(src)
+	if src == "" {
+		return "", false, nil
+	}
+
+	u, err := url.Parse(src)
+	if err != nil {
+		return "", false, err
+	}
+
+	escapedPath := u.EscapedPath()
+	if escapedPath == "" {
+		escapedPath = u.Path
+	}
+	if escapedPath == "" && u.Scheme == "" {
+		escapedPath = src
+		if index := strings.IndexAny(escapedPath, "?#"); index >= 0 {
+			escapedPath = escapedPath[:index]
+		}
+	}
+
+	path, err := url.PathUnescape(escapedPath)
+	if err != nil {
+		return "", false, err
+	}
+
+	var localPath string
+	switch {
+	case path == "/storage" || path == "storage":
+		return "", true, fmt.Errorf("storage image path is empty: %s", src)
+	case strings.HasPrefix(path, "/storage/"):
+		localPath = strings.TrimPrefix(path, "/storage")
+	case strings.HasPrefix(path, "storage/"):
+		localPath = strings.TrimPrefix(path, "storage")
+	default:
+		return "", false, nil
+	}
+
+	localPath = strings.Replace(localPath, "|", ":", 1)
+	if strings.HasPrefix(localPath, "/") && hasWindowsDrivePrefix(localPath[1:]) {
+		localPath = localPath[1:]
+	}
+
+	return localPath, true, nil
+}
+
+func hasWindowsDrivePrefix(path string) bool {
+	if len(path) < 3 {
+		return false
+	}
+	drive := path[0]
+	return ((drive >= 'a' && drive <= 'z') || (drive >= 'A' && drive <= 'Z')) &&
+		path[1] == ':' && (path[2] == '/' || path[2] == '\\')
+}
+
+func localImageFileToDataURL(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return imageBytesToDataURL(data, "", path)
+}
+
+func httpImageToDataURL(src string) (string, error) {
+	client := proxy.GetHttpClient(src)
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	resp, err := client.Get(src)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return "", fmt.Errorf("download image failed with status code %d: %s", resp.StatusCode, src)
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	sourcePath := src
+	if u, err := url.Parse(src); err == nil {
+		sourcePath = u.Path
+	}
+	return imageBytesToDataURL(data, resp.Header.Get("Content-Type"), sourcePath)
+}
+
+func imageBytesToDataURL(data []byte, contentType string, sourcePath string) (string, error) {
+	mimeType := imageMIMEFromContentType(contentType)
+	if mimeType == "" {
+		mimeType = imageMIMEFromPath(sourcePath)
+	}
+	if mimeType == "" && len(data) > 0 {
+		mimeType = imageMIMEFromContentType(http.DetectContentType(data))
+	}
+	if mimeType == "" {
+		return "", fmt.Errorf("cannot detect image MIME type: %s", sourcePath)
+	}
+
+	return fmt.Sprintf("data:%s;base64,%s", mimeType, base64.StdEncoding.EncodeToString(data)), nil
+}
+
+func imageMIMEFromContentType(contentType string) string {
+	contentType = strings.TrimSpace(contentType)
+	if contentType == "" {
+		return ""
+	}
+
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		mediaType = strings.Split(contentType, ";")[0]
+	}
+
+	mediaType = strings.ToLower(strings.TrimSpace(mediaType))
+	if strings.HasPrefix(mediaType, "image/") {
+		return mediaType
+	}
+	return ""
+}
+
+func imageMIMEFromPath(path string) string {
+	return imageMIMEFromContentType(mime.TypeByExtension(strings.ToLower(filepath.Ext(path))))
+}

--- a/model/image_url_util.go
+++ b/model/image_url_util.go
@@ -18,7 +18,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"html"
-	"io"
 	"mime"
 	"net/http"
 	"net/url"
@@ -26,8 +25,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-
-	"github.com/the-open-agent/openagent/proxy"
 )
 
 var (
@@ -37,15 +34,15 @@ var (
 	bareHTTPImageRegexp = regexp.MustCompile(`(?i)https?://[^\s"'<>]+\.(?:jpg|jpeg|png|gif|webp)(?:\?[^\s"'<>]*)?`)
 )
 
-func extractImageDataURLsFromMessage(message string) ([]string, string, error) {
+func extractImageRefsFromMessage(message string) ([]string, string, error) {
 	imageSources, messageText := extractImageSourcesFromMessage(message)
 	res := make([]string, 0, len(imageSources))
 	for _, imageSource := range imageSources {
-		imageDataURL, err := imageSourceToDataURL(imageSource)
+		imageRef, err := imageSourceToRef(imageSource)
 		if err != nil {
 			return nil, "", err
 		}
-		res = append(res, imageDataURL)
+		res = append(res, imageRef)
 	}
 
 	return res, messageText, nil
@@ -86,7 +83,7 @@ func cleanImageSource(src string) string {
 	return html.UnescapeString(strings.TrimSpace(src))
 }
 
-func imageSourceToDataURL(src string) (string, error) {
+func imageSourceToRef(src string) (string, error) {
 	src = cleanImageSource(src)
 	lowerSrc := strings.ToLower(src)
 	if strings.HasPrefix(lowerSrc, "data:image/") {
@@ -104,7 +101,7 @@ func imageSourceToDataURL(src string) (string, error) {
 	}
 
 	if strings.HasPrefix(lowerSrc, "http://") || strings.HasPrefix(lowerSrc, "https://") {
-		return httpImageToDataURL(src)
+		return src, nil
 	}
 
 	return "", fmt.Errorf("unsupported image source: %s", src)
@@ -172,34 +169,6 @@ func localImageFileToDataURL(path string) (string, error) {
 		return "", err
 	}
 	return imageBytesToDataURL(data, "", path)
-}
-
-func httpImageToDataURL(src string) (string, error) {
-	client := proxy.GetHttpClient(src)
-	if client == nil {
-		client = http.DefaultClient
-	}
-
-	resp, err := client.Get(src)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return "", fmt.Errorf("download image failed with status code %d: %s", resp.StatusCode, src)
-	}
-
-	data, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", err
-	}
-
-	sourcePath := src
-	if u, err := url.Parse(src); err == nil {
-		sourcePath = u.Path
-	}
-	return imageBytesToDataURL(data, resp.Header.Get("Content-Type"), sourcePath)
 }
 
 func imageBytesToDataURL(data []byte, contentType string, sourcePath string) (string, error) {

--- a/model/local_gptvision.go
+++ b/model/local_gptvision.go
@@ -64,7 +64,7 @@ func OpenaiRawMessagesToGptVisionMessages(messages []*RawMessage) ([]openai.Chat
 			role = openai.ChatMessageRoleUser
 		}
 
-		imageDataURLs, messageText, err := extractImageDataURLsFromMessage(message.Text)
+		imageRefs, messageText, err := extractImageRefsFromMessage(message.Text)
 		if err != nil {
 			return []openai.ChatCompletionMessage{}, err
 		}
@@ -93,11 +93,11 @@ func OpenaiRawMessagesToGptVisionMessages(messages []*RawMessage) ([]openai.Chat
 			}
 		}
 
-		for _, imageDataURL := range imageDataURLs {
+		for _, imageRef := range imageRefs {
 			item.MultiContent = append(item.MultiContent, openai.ChatMessagePart{
 				Type: openai.ChatMessagePartTypeImageURL,
 				ImageURL: &openai.ChatMessageImageURL{
-					URL:    imageDataURL,
+					URL:    imageRef,
 					Detail: openai.ImageURLDetailAuto,
 				},
 			})

--- a/model/local_gptvision.go
+++ b/model/local_gptvision.go
@@ -15,57 +15,8 @@
 package model
 
 import (
-	"encoding/base64"
-	"fmt"
-	"io"
-	"net/http"
-	"path/filepath"
-	"regexp"
-	"strings"
-
 	"github.com/sashabaranov/go-openai"
 )
-
-func extractImagesURL(message string) ([]string, string) {
-	message = strings.Replace(message, "&nbsp;", " ", -1)
-	br := regexp.MustCompile(`<br\s*/?>`)
-	message = br.ReplaceAllString(message, " ")
-
-	imgURL := regexp.MustCompile(`http[s]?://\S+\.(jpg|jpeg|png|gif|webp)`)
-	urls := imgURL.FindAllString(message, -1)
-	quote := regexp.MustCompile(`\"$`)
-	for i, url := range urls {
-		urls[i] = quote.ReplaceAllString(url, "")
-	}
-
-	message = imgURL.ReplaceAllString(message, "")
-
-	img := regexp.MustCompile(`<img[^>]+>`)
-	message = img.ReplaceAllString(message, "")
-	return urls, message
-}
-
-func getImageRefinedText(text string) (string, error) {
-	ext := filepath.Ext(text)
-	if ext != "" {
-		ext = ext[1:]
-	}
-
-	resp, err := http.Get(text)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	data, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", err
-	}
-
-	base64Data := base64.StdEncoding.EncodeToString(data)
-	res := fmt.Sprintf("data:image/%s;base64,%s", ext, base64Data)
-	return res, nil
-}
 
 func IsVisionModel(subType string) bool {
 	visionModels := []string{
@@ -113,7 +64,10 @@ func OpenaiRawMessagesToGptVisionMessages(messages []*RawMessage) ([]openai.Chat
 			role = openai.ChatMessageRoleUser
 		}
 
-		urls, messageText := extractImagesURL(message.Text)
+		imageDataURLs, messageText, err := extractImageDataURLsFromMessage(message.Text)
+		if err != nil {
+			return []openai.ChatCompletionMessage{}, err
+		}
 
 		item := openai.ChatCompletionMessage{
 			Role:             role,
@@ -139,16 +93,11 @@ func OpenaiRawMessagesToGptVisionMessages(messages []*RawMessage) ([]openai.Chat
 			}
 		}
 
-		for _, url := range urls {
-			imageText, err := getImageRefinedText(url)
-			if err != nil {
-				return []openai.ChatCompletionMessage{}, err
-			}
-
+		for _, imageDataURL := range imageDataURLs {
 			item.MultiContent = append(item.MultiContent, openai.ChatMessagePart{
 				Type: openai.ChatMessagePartTypeImageURL,
 				ImageURL: &openai.ChatMessageImageURL{
-					URL:    imageText,
+					URL:    imageDataURL,
 					Detail: openai.ImageURLDetailAuto,
 				},
 			})

--- a/model/openai.go
+++ b/model/openai.go
@@ -760,7 +760,10 @@ func openaiRawMessagesToGptVisionMessages(messages []*RawMessage) (responses.Res
 			role = responses.EasyInputMessageRoleUser
 		}
 
-		urls, messageText := extractImagesURL(message.Text)
+		imageDataURLs, messageText, err := extractImageDataURLsFromMessage(message.Text)
+		if err != nil {
+			return res, err
+		}
 
 		var itemContentList responses.ResponseInputMessageContentListParam
 		if len(messageText) > 0 {
@@ -773,14 +776,10 @@ func openaiRawMessagesToGptVisionMessages(messages []*RawMessage) (responses.Res
 				},
 			})
 		}
-		for _, url := range urls {
-			imageText, err := getImageRefinedText(url)
-			if err != nil {
-				return res, err
-			}
+		for _, imageDataURL := range imageDataURLs {
 			itemContentList = append(itemContentList, responses.ResponseInputContentUnionParam{
 				OfInputImage: &responses.ResponseInputImageParam{
-					ImageURL: param.NewOpt[string](imageText),
+					ImageURL: param.NewOpt[string](imageDataURL),
 				},
 			})
 		}

--- a/model/openai.go
+++ b/model/openai.go
@@ -760,7 +760,7 @@ func openaiRawMessagesToGptVisionMessages(messages []*RawMessage) (responses.Res
 			role = responses.EasyInputMessageRoleUser
 		}
 
-		imageDataURLs, messageText, err := extractImageDataURLsFromMessage(message.Text)
+		imageRefs, messageText, err := extractImageRefsFromMessage(message.Text)
 		if err != nil {
 			return res, err
 		}
@@ -776,10 +776,10 @@ func openaiRawMessagesToGptVisionMessages(messages []*RawMessage) (responses.Res
 				},
 			})
 		}
-		for _, imageDataURL := range imageDataURLs {
+		for _, imageRef := range imageRefs {
 			itemContentList = append(itemContentList, responses.ResponseInputContentUnionParam{
 				OfInputImage: &responses.ResponseInputImageParam{
-					ImageURL: param.NewOpt[string](imageDataURL),
+					ImageURL: param.NewOpt[string](imageRef),
 				},
 			})
 		}


### PR DESCRIPTION
## Summary
- Add a shared model-layer helper to extract image refs from message HTML.
- Convert only `/storage/...` image URLs to `data:image/...;base64,...` before vision model calls.