### PR TITLE
feat: run recorded web actions

### DIFF
--- a/controllers/browser_use_web_action.go
+++ b/controllers/browser_use_web_action.go
@@ -1,0 +1,245 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/the-open-agent/openagent/tool"
+)
+
+func (c *ApiController) requireBrowserUseWebActionAccess() bool {
+	if c.IsAdmin() || strings.TrimSpace(c.GetSessionUsername()) != "" {
+		return true
+	}
+	if err := tool.ValidateChromeExtensionRequest(c.Ctx.Request); err != nil {
+		c.ResponseError(err.Error())
+		return false
+	}
+	return true
+}
+
+func browserUseWebActionResponse(action tool.BrowserUseWebActionData) map[string]interface{} {
+	steps := []interface{}{}
+	response := map[string]interface{}{
+		"action_group": action.ActionGroup,
+		"name":         action.Name,
+		"url":          action.URL,
+		"description":  browserUseWebActionDescription(action.Action),
+		"action":       action.Action,
+		"script":       action.Script,
+		"updated_time": action.UpdatedTime,
+	}
+	if strings.TrimSpace(action.Script) != "" {
+		if err := json.Unmarshal([]byte(action.Script), &steps); err != nil {
+			response["steps_parse_error"] = err.Error()
+			return response
+		}
+	}
+	response["steps"] = steps
+	return response
+}
+
+func browserUseWebActionArgumentOwner(arguments map[string]interface{}) string {
+	owner, _ := arguments["owner"].(string)
+	return strings.TrimSpace(owner)
+}
+
+func (c *ApiController) browserUseWebActionOwner(arguments map[string]interface{}) (string, bool) {
+	requestedOwner := strings.TrimSpace(c.Input().Get("owner"))
+	if requestedOwner == "" {
+		requestedOwner = browserUseWebActionArgumentOwner(arguments)
+	}
+
+	if c.IsAdmin() {
+		if requestedOwner != "" {
+			return requestedOwner, true
+		}
+		return "admin", true
+	}
+
+	if username := strings.TrimSpace(c.GetSessionUsername()); username != "" {
+		if requestedOwner != "" && requestedOwner != username {
+			c.ResponseError("requested owner does not match the current user")
+			return "", false
+		}
+		return username, true
+	}
+
+	if err := tool.ValidateChromeExtensionRequest(c.Ctx.Request); err == nil {
+		owner := tool.ChromeExtensionOwner()
+		if requestedOwner != "" && requestedOwner != owner {
+			c.ResponseError("requested owner does not match the Chrome extension owner")
+			return "", false
+		}
+		return owner, true
+	}
+
+	c.ResponseError("browser web action owner is unavailable")
+	return "", false
+}
+
+func browserUseWebActionDescription(action string) string {
+	action = strings.TrimSpace(action)
+	if action == "" {
+		return ""
+	}
+	if index := strings.Index(action, "\n## Steps"); index >= 0 {
+		return strings.TrimSpace(action[:index])
+	}
+	if strings.HasPrefix(action, "## Steps") {
+		return ""
+	}
+	return action
+}
+
+func browserUseWebActionsResponse(actions []tool.BrowserUseWebActionData) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(actions))
+	for _, action := range actions {
+		result = append(result, browserUseWebActionResponse(action))
+	}
+	return result
+}
+
+// GetBrowserUseWebActions lists browser web actions, optionally filtered by URL.
+// @Title GetBrowserUseWebActions
+// @Tag Tool API
+// @Description list executable browser web actions
+// @Param action_group query string false "Action group"
+// @Param name query string false "Action name"
+// @Param url query string false "Current page URL for same-site matching"
+// @Success 200 {object} controllers.Response The Response object
+// @router /get-browser-use-web-actions [get]
+func (c *ApiController) GetBrowserUseWebActions() {
+	if !c.requireBrowserUseWebActionAccess() {
+		return
+	}
+	owner, ok := c.browserUseWebActionOwner(nil)
+	if !ok {
+		return
+	}
+
+	actions, err := tool.ListBrowserUseWebActions(owner, tool.BrowserUseWebActionFilter{
+		ActionGroup: c.Input().Get("action_group"),
+		Name:        c.Input().Get("name"),
+		URL:         c.Input().Get("url"),
+	})
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+
+	c.ResponseOk(browserUseWebActionsResponse(actions))
+}
+
+// GetBrowserUseWebAction gets one browser web action.
+// @Title GetBrowserUseWebAction
+// @Tag Tool API
+// @Description get an executable browser web action
+// @Param action_group query string false "Action group"
+// @Param name query string true "Action name"
+// @Success 200 {object} controllers.Response The Response object
+// @router /get-browser-use-web-action [get]
+func (c *ApiController) GetBrowserUseWebAction() {
+	if !c.requireBrowserUseWebActionAccess() {
+		return
+	}
+	owner, ok := c.browserUseWebActionOwner(nil)
+	if !ok {
+		return
+	}
+
+	action, err := tool.GetBrowserUseWebAction(owner, c.Input().Get("action_group"), c.Input().Get("name"))
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+
+	c.ResponseOk(browserUseWebActionResponse(action))
+}
+
+// SaveBrowserUseWebAction saves a Chrome-extension-recorded browser web action.
+// @Title SaveBrowserUseWebAction
+// @Tag Tool API
+// @Description save an executable browser web action recorded by the Chrome extension
+// @Param body body object true "Browser web action payload: {\"action_group\":\"site\",\"name\":\"action_name\",\"url\":\"https://example.com\",\"steps\":[...]}"
+// @Success 200 {object} controllers.Response The Response object
+// @router /save-browser-use-web-action [post]
+func (c *ApiController) SaveBrowserUseWebAction() {
+	if !c.requireBrowserUseWebActionAccess() {
+		return
+	}
+
+	arguments := map[string]interface{}{}
+	if err := json.Unmarshal(c.Ctx.Input.RequestBody, &arguments); err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+	owner, ok := c.browserUseWebActionOwner(arguments)
+	if !ok {
+		return
+	}
+
+	action, stepCount, err := tool.SaveBrowserUseWebAction(owner, arguments)
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+
+	c.ResponseOk(map[string]interface{}{
+		"action":    browserUseWebActionResponse(action),
+		"stepCount": stepCount,
+	})
+}
+
+// DeleteBrowserUseWebAction deletes one browser web action.
+// @Title DeleteBrowserUseWebAction
+// @Tag Tool API
+// @Description delete an executable browser web action
+// @Param body body object true "Browser web action identity: {\"action_group\":\"site\",\"name\":\"action_name\"}"
+// @Success 200 {object} controllers.Response The Response object
+// @router /delete-browser-use-web-action [post]
+func (c *ApiController) DeleteBrowserUseWebAction() {
+	if !c.requireBrowserUseWebActionAccess() {
+		return
+	}
+
+	arguments := map[string]interface{}{}
+	if err := json.Unmarshal(c.Ctx.Input.RequestBody, &arguments); err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+	owner, ok := c.browserUseWebActionOwner(arguments)
+	if !ok {
+		return
+	}
+
+	actionGroup, _ := arguments["action_group"].(string)
+	if strings.TrimSpace(actionGroup) == "" {
+		actionGroup, _ = arguments["actionGroup"].(string)
+	}
+	name, _ := arguments["name"].(string)
+	action, deleted, err := tool.DeleteBrowserUseWebAction(owner, actionGroup, name)
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+
+	c.ResponseOk(map[string]interface{}{
+		"deleted": deleted,
+		"action":  browserUseWebActionResponse(action),
+	})
+}

--- a/controllers/message_answer.go
+++ b/controllers/message_answer.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"strings"
 
@@ -61,6 +62,15 @@ func (c *ApiController) GetMessageAnswer() {
 
 	job := messageAnswerJobs.getOrStart(id, c.Ctx.Request.Host, c.GetAcceptLanguage(), signedIn)
 	streamMessageAnswerJob(c.Ctx.ResponseWriter, c.Ctx.Request, job)
+}
+
+func hasTool(tools []string, name string) bool {
+	for _, toolName := range tools {
+		if strings.TrimSpace(toolName) == name {
+			return true
+		}
+	}
+	return false
 }
 
 // CancelMessageAnswer
@@ -208,9 +218,10 @@ func generateMessageAnswer(id string, responseWriter http.ResponseWriter, host s
 		store.Tools = []string{chat.Tool}
 	}
 
+	prompt := store.Prompt
 	if len(store.Tools) > 0 {
-		store.Prompt += "\nYou are a helpful AI assistant with access to tools. When the user asks you to perform a task, you MUST use the available tools to complete it directly. Do not refuse or explain why you cannot — just use the tools and fulfill the request."
-		store.Prompt += "\n## Execution Bias\n" +
+		prompt += "\nYou are a helpful AI assistant with access to tools. When the user asks you to perform a task, you MUST use the available tools to complete it directly. Do not refuse or explain why you cannot — just use the tools and fulfill the request."
+		prompt += "\n## Execution Bias\n" +
 			"- Actionable request: act in this turn.\n" +
 			"- Continue until done or genuinely blocked; do not finish with a plan/promise when tools can move it forward.\n" +
 			"- Task completion: keep calling tools until the task is accomplished; do not describe next steps — execute them.\n" +
@@ -220,6 +231,14 @@ func generateMessageAnswer(id string, responseWriter http.ResponseWriter, host s
 			"- Mutable facts need live checks: use tools rather than memory.\n" +
 			"- Longer work: brief progress update, then keep going."
 	}
+	if hasTool(store.Tools, "browser_use") {
+		webActionCatalog, catalogErr := object.GetBrowserUseWebActionCatalog(store.Owner)
+		if catalogErr != nil {
+			log.Printf("failed to load browser web action catalog: %v", catalogErr)
+		} else if webActionCatalog != "" {
+			prompt += "\n\n" + webActionCatalog
+		}
+	}
 
 	if len(store.Skills) > 0 {
 		skillsContent, skillErr := object.GetSkillsCatalog(store.Owner, store.Skills)
@@ -228,7 +247,7 @@ func generateMessageAnswer(id string, responseWriter http.ResponseWriter, host s
 			return
 		}
 		if skillsContent != "" {
-			store.Prompt += "\n\n" + skillsContent
+			prompt += "\n\n" + skillsContent
 		}
 	}
 
@@ -359,7 +378,6 @@ func generateMessageAnswer(id string, responseWriter http.ResponseWriter, host s
 	// fmt.Printf("Refined Question: [%s]\n", realQuestion)
 	fmt.Printf("Answer: [")
 
-	prompt := store.Prompt
 	reviewQuestion := question
 	if !isReasonModel(modelProvider.SubType) {
 		if modelProvider.Type == "Alibaba Cloud" && webSearchEnabled {

--- a/controllers/message_answer.go
+++ b/controllers/message_answer.go
@@ -30,6 +30,7 @@ import (
 	"github.com/the-open-agent/openagent/mcp"
 	"github.com/the-open-agent/openagent/model"
 	"github.com/the-open-agent/openagent/object"
+	"github.com/the-open-agent/openagent/tool"
 	"github.com/the-open-agent/openagent/util"
 )
 
@@ -231,13 +232,14 @@ func generateMessageAnswer(id string, responseWriter http.ResponseWriter, host s
 			"- Mutable facts need live checks: use tools rather than memory.\n" +
 			"- Longer work: brief progress update, then keep going."
 	}
-	if hasTool(store.Tools, "browser_use") {
+	if hasTool(store.Tools, "browser_use") && store.BrowserUseWebActionPrompt {
 		webActionCatalog, catalogErr := object.GetBrowserUseWebActionCatalog(store.Owner)
 		if catalogErr != nil {
 			log.Printf("failed to load browser web action catalog: %v", catalogErr)
 		} else if webActionCatalog != "" {
 			prompt += "\n\n" + webActionCatalog
 		}
+		prompt += "\n\n" + tool.GetBrowserUseWebActionReflectionPrompt()
 	}
 
 	if len(store.Skills) > 0 {

--- a/object/adapter.go
+++ b/object/adapter.go
@@ -393,6 +393,11 @@ func (a *Adapter) createTable() {
 		panic(err)
 	}
 
+	err = a.engine.Sync2(new(BrowserUseWebAction))
+	if err != nil {
+		panic(err)
+	}
+
 	err = a.engine.Sync2(new(Snapshot))
 	if err != nil {
 		panic(err)

--- a/object/browser_use_web_action.go
+++ b/object/browser_use_web_action.go
@@ -1,0 +1,278 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package object
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/the-open-agent/openagent/tool"
+	"xorm.io/core"
+)
+
+var browserUseWebActionPlaceholderPattern = regexp.MustCompile(`\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}`)
+
+type BrowserUseWebAction struct {
+	Owner       string `xorm:"varchar(100) notnull pk" json:"owner"`
+	ActionGroup string `xorm:"varchar(100) notnull pk" json:"actionGroup"`
+	Name        string `xorm:"varchar(100) notnull pk" json:"name"`
+	URL         string `xorm:"varchar(500)" json:"url"`
+	CreatedTime string `xorm:"varchar(100)" json:"createdTime"`
+	UpdatedTime string `xorm:"varchar(100)" json:"updatedTime"`
+
+	Action string `xorm:"mediumtext" json:"action"`
+	Script string `xorm:"mediumtext" json:"script"`
+}
+
+func init() {
+	tool.SetBrowserUseWebActionStore(listBrowserUseWebActions, upsertBrowserUseWebAction, deleteBrowserUseWebAction, listBrowserUseWebActionsByActionGroups)
+}
+
+func browserUseWebMemoryOwner(owner string) string {
+	owner = strings.TrimSpace(owner)
+	if owner == "" {
+		return "admin"
+	}
+	return owner
+}
+
+func browserUseWebMemoryNow() string {
+	return time.Now().UTC().Format(time.RFC3339)
+}
+
+func listBrowserUseWebActions(owner string) ([]tool.BrowserUseWebActionData, error) {
+	owner = browserUseWebMemoryOwner(owner)
+
+	rows := []*BrowserUseWebAction{}
+	err := adapter.engine.Desc("updated_time").Find(&rows, &BrowserUseWebAction{Owner: owner})
+	if err != nil {
+		return nil, err
+	}
+
+	actions := make([]tool.BrowserUseWebActionData, 0, len(rows))
+	for _, row := range rows {
+		actions = append(actions, tool.BrowserUseWebActionData{
+			ActionGroup: row.ActionGroup,
+			Name:        row.Name,
+			URL:         row.URL,
+			Action:      row.Action,
+			Script:      row.Script,
+			UpdatedTime: row.UpdatedTime,
+		})
+	}
+	return actions, nil
+}
+
+func GetBrowserUseWebActionCatalog(owner string) (string, error) {
+	actions, err := listBrowserUseWebActions(owner)
+	if err != nil {
+		return "", err
+	}
+	if len(actions) == 0 {
+		return "", nil
+	}
+	sort.SliceStable(actions, func(i, j int) bool {
+		if actions[i].ActionGroup != actions[j].ActionGroup {
+			return actions[i].ActionGroup < actions[j].ActionGroup
+		}
+		return actions[i].Name < actions[j].Name
+	})
+
+	var builder strings.Builder
+	builder.WriteString("## Browser Web Action Catalog\n")
+	builder.WriteString("- Browser web actions are executable browser shortcuts, not skills.\n")
+	builder.WriteString("- Never call `load_skill` for a browser web action group or action name.\n")
+	builder.WriteString("- If the user's browser task matches one of these actions, call `browser_use_run_web_action` before manual navigation/clicking.\n")
+	builder.WriteString("- Use the listed `action_group`, `action_name`, and variables when running an action.\n")
+	builder.WriteString("- Always verify the resulting page state after running an action.\n\n")
+	for _, action := range actions {
+		name := strings.TrimSpace(action.Name)
+		group := strings.TrimSpace(action.ActionGroup)
+		if name == "" || group == "" {
+			continue
+		}
+		variables := browserUseWebActionVariableNames(action.Script)
+		builder.WriteString("- web_action:\n")
+		builder.WriteString(fmt.Sprintf("  action_group: %s\n", group))
+		builder.WriteString(fmt.Sprintf("  action_name: %s\n", name))
+		builder.WriteString("  run_with: browser_use_run_web_action\n")
+		if strings.TrimSpace(action.URL) != "" {
+			builder.WriteString(fmt.Sprintf("  url: %s\n", strings.TrimSpace(action.URL)))
+		}
+		if len(variables) > 0 {
+			builder.WriteString(fmt.Sprintf("  variables: %s\n", strings.Join(variables, ", ")))
+		}
+		if summary := firstBrowserUseWebActionLine(action.Action); summary != "" {
+			builder.WriteString(fmt.Sprintf("  summary: %s\n", summary))
+		}
+	}
+	return strings.TrimSpace(builder.String()), nil
+}
+
+func browserUseWebActionLoadSkillHint(owner string, actionGroup string) (string, error) {
+	actionGroup = strings.TrimSpace(actionGroup)
+	if actionGroup == "" {
+		return "", nil
+	}
+	actions, err := listBrowserUseWebActions(owner)
+	if err != nil {
+		return "", err
+	}
+
+	matches := make([]string, 0)
+	for _, action := range actions {
+		group := strings.TrimSpace(action.ActionGroup)
+		name := strings.TrimSpace(action.Name)
+		if actionGroup != group && actionGroup != name {
+			continue
+		}
+		matches = append(matches, fmt.Sprintf("%s / %s", group, name))
+	}
+	if len(matches) == 0 {
+		return "", nil
+	}
+	sort.Strings(matches)
+	return fmt.Sprintf(
+		"%q is a browser web action identifier, not a skill. Do not call load_skill for browser web actions. Use browser_use_run_web_action with one of: %s",
+		actionGroup,
+		strings.Join(matches, ", "),
+	), nil
+}
+
+func browserUseWebActionVariableNames(script string) []string {
+	matches := browserUseWebActionPlaceholderPattern.FindAllStringSubmatch(script, -1)
+	seen := map[string]bool{}
+	names := []string{}
+	for _, match := range matches {
+		if len(match) < 2 {
+			continue
+		}
+		name := strings.TrimSpace(match[1])
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func firstBrowserUseWebActionLine(action string) string {
+	for _, line := range strings.Split(strings.TrimSpace(action), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if len(line) > 180 {
+			line = line[:180] + "..."
+		}
+		return line
+	}
+	return ""
+}
+
+func listBrowserUseWebActionsByActionGroups(owner string, actionGroups []string) ([]tool.BrowserUseWebActionData, error) {
+	owner = browserUseWebMemoryOwner(owner)
+
+	names := make([]string, 0, len(actionGroups))
+	seen := map[string]bool{}
+	for _, actionGroup := range actionGroups {
+		name := strings.TrimSpace(actionGroup)
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		names = append(names, name)
+	}
+	if len(names) == 0 {
+		return []tool.BrowserUseWebActionData{}, nil
+	}
+
+	rows := []*BrowserUseWebAction{}
+	err := adapter.engine.Where("owner = ?", owner).In("action_group", names).Desc("updated_time").Find(&rows)
+	if err != nil {
+		return nil, err
+	}
+
+	actions := make([]tool.BrowserUseWebActionData, 0, len(rows))
+	for _, row := range rows {
+		actions = append(actions, tool.BrowserUseWebActionData{
+			ActionGroup: row.ActionGroup,
+			Name:        row.Name,
+			URL:         row.URL,
+			Action:      row.Action,
+			Script:      row.Script,
+			UpdatedTime: row.UpdatedTime,
+		})
+	}
+	return actions, nil
+}
+
+func upsertBrowserUseWebAction(owner string, action tool.BrowserUseWebActionData) (tool.BrowserUseWebActionData, error) {
+	owner = browserUseWebMemoryOwner(owner)
+	action.ActionGroup = strings.TrimSpace(action.ActionGroup)
+	action.Name = strings.TrimSpace(action.Name)
+	if action.ActionGroup == "" {
+		return tool.BrowserUseWebActionData{}, fmt.Errorf("action_group is required")
+	}
+	if action.Name == "" {
+		return tool.BrowserUseWebActionData{}, fmt.Errorf("name is required")
+	}
+
+	record := &BrowserUseWebAction{
+		Owner:       owner,
+		ActionGroup: action.ActionGroup,
+		Name:        action.Name,
+		URL:         strings.TrimSpace(action.URL),
+		UpdatedTime: action.UpdatedTime,
+		Action:      action.Action,
+		Script:      action.Script,
+	}
+
+	existing := &BrowserUseWebAction{}
+	existed, err := adapter.engine.ID(core.PK{owner, action.ActionGroup, action.Name}).Get(existing)
+	if err != nil {
+		return tool.BrowserUseWebActionData{}, err
+	}
+	if existed {
+		record.CreatedTime = existing.CreatedTime
+		if _, err = adapter.engine.ID(core.PK{owner, action.ActionGroup, action.Name}).AllCols().Update(record); err != nil {
+			return tool.BrowserUseWebActionData{}, err
+		}
+		return action, nil
+	}
+
+	record.CreatedTime = browserUseWebMemoryNow()
+	if _, err = adapter.engine.Insert(record); err != nil {
+		return tool.BrowserUseWebActionData{}, err
+	}
+	return action, nil
+}
+
+func deleteBrowserUseWebAction(owner, actionGroup, name string) (bool, error) {
+	owner = browserUseWebMemoryOwner(owner)
+	actionGroup = strings.TrimSpace(actionGroup)
+	name = strings.TrimSpace(name)
+
+	affected, err := adapter.engine.ID(core.PK{owner, actionGroup, name}).Delete(&BrowserUseWebAction{})
+	if err != nil {
+		return false, err
+	}
+	return affected != 0, nil
+}

--- a/object/skill.go
+++ b/object/skill.go
@@ -525,6 +525,13 @@ func (skillLoader) Load(owner string, allowedSkillNames []string, skillName stri
 			}
 		}
 		if !allowed {
+			hint, hintErr := browserUseWebActionLoadSkillHint(owner, skillName)
+			if hintErr != nil {
+				return "", hintErr
+			}
+			if hint != "" {
+				return "", fmt.Errorf("%s", hint)
+			}
 			return "", fmt.Errorf("skill is not enabled for this store: %s", skillName)
 		}
 	}

--- a/object/store.go
+++ b/object/store.go
@@ -61,45 +61,46 @@ type Store struct {
 	CreatedTime string `xorm:"varchar(100) index(idx_store_name_created)" json:"createdTime"`
 	DisplayName string `xorm:"varchar(100)" json:"displayName"`
 
-	StorageProvider        string            `xorm:"varchar(100)" json:"storageProvider"`
-	StorageSubpath         string            `xorm:"varchar(100)" json:"storageSubpath"`
-	ImageProvider          string            `xorm:"varchar(100)" json:"imageProvider"`
-	SplitProvider          string            `xorm:"varchar(100)" json:"splitProvider"`
-	SearchProvider         string            `xorm:"varchar(100)" json:"searchProvider"`
-	ModelProvider          string            `xorm:"varchar(100)" json:"modelProvider"`
-	EmbeddingProvider      string            `xorm:"varchar(100)" json:"embeddingProvider"`
-	TextToSpeechProvider   string            `xorm:"varchar(100)" json:"textToSpeechProvider"`
-	EnableTtsStreaming     bool              `xorm:"bool" json:"enableTtsStreaming"`
-	SpeechToTextProvider   string            `xorm:"varchar(100)" json:"speechToTextProvider"`
-	McpServer              string            `xorm:"varchar(100)" json:"mcpServer"`
-	Skills                 []string          `xorm:"mediumtext" json:"skills"`
-	Tools                  []string          `xorm:"mediumtext" json:"tools"`
-	VectorStoreId          string            `xorm:"varchar(100)" json:"vectorStoreId"`
-	MemoryLimit            int               `json:"memoryLimit"`
-	Frequency              int               `json:"frequency"`
-	LimitMinutes           int               `json:"limitMinutes"`
-	KnowledgeCount         int               `json:"knowledgeCount"`
-	SuggestionCount        int               `json:"suggestionCount"`
-	Welcome                string            `xorm:"varchar(100)" json:"welcome"`
-	WelcomeTitle           string            `xorm:"varchar(100)" json:"welcomeTitle"`
-	WelcomeText            string            `xorm:"varchar(100)" json:"welcomeText"`
-	Prompt                 string            `xorm:"mediumtext" json:"prompt"`
-	ExampleQuestions       []ExampleQuestion `xorm:"mediumtext" json:"exampleQuestions"`
-	Avatar                 string            `xorm:"varchar(200)" json:"avatar"`
-	Title                  string            `xorm:"varchar(100)" json:"title"`
-	VectorStores           []string          `xorm:"mediumtext" json:"vectorStores"`
-	ChildStores            []string          `xorm:"mediumtext" json:"childStores"`
-	ChildModelProviders    []string          `xorm:"mediumtext" json:"childModelProviders"`
-	ForbiddenWords         []string          `xorm:"text" json:"forbiddenWords"`
-	Owners                 []string          `xorm:"mediumtext" json:"owners"`
-	ShowAutoRead           bool              `json:"showAutoRead"`
-	DisableFileUpload      bool              `json:"disableFileUpload"`
-	HideThinking           bool              `json:"hideThinking"`
-	EnableExperienceReview bool              `json:"enableExperienceReview"`
-	EnableExtraOptions     bool              `json:"enableExtraOptions"`
-	IsDefault              bool              `json:"isDefault"`
-	State                  string            `xorm:"varchar(100)" json:"state"`
-	SharedBy               string            `xorm:"varchar(100)" json:"sharedBy"`
+	StorageProvider           string            `xorm:"varchar(100)" json:"storageProvider"`
+	StorageSubpath            string            `xorm:"varchar(100)" json:"storageSubpath"`
+	ImageProvider             string            `xorm:"varchar(100)" json:"imageProvider"`
+	SplitProvider             string            `xorm:"varchar(100)" json:"splitProvider"`
+	SearchProvider            string            `xorm:"varchar(100)" json:"searchProvider"`
+	ModelProvider             string            `xorm:"varchar(100)" json:"modelProvider"`
+	EmbeddingProvider         string            `xorm:"varchar(100)" json:"embeddingProvider"`
+	TextToSpeechProvider      string            `xorm:"varchar(100)" json:"textToSpeechProvider"`
+	EnableTtsStreaming        bool              `xorm:"bool" json:"enableTtsStreaming"`
+	SpeechToTextProvider      string            `xorm:"varchar(100)" json:"speechToTextProvider"`
+	McpServer                 string            `xorm:"varchar(100)" json:"mcpServer"`
+	Skills                    []string          `xorm:"mediumtext" json:"skills"`
+	Tools                     []string          `xorm:"mediumtext" json:"tools"`
+	VectorStoreId             string            `xorm:"varchar(100)" json:"vectorStoreId"`
+	MemoryLimit               int               `json:"memoryLimit"`
+	Frequency                 int               `json:"frequency"`
+	LimitMinutes              int               `json:"limitMinutes"`
+	KnowledgeCount            int               `json:"knowledgeCount"`
+	SuggestionCount           int               `json:"suggestionCount"`
+	Welcome                   string            `xorm:"varchar(100)" json:"welcome"`
+	WelcomeTitle              string            `xorm:"varchar(100)" json:"welcomeTitle"`
+	WelcomeText               string            `xorm:"varchar(100)" json:"welcomeText"`
+	Prompt                    string            `xorm:"mediumtext" json:"prompt"`
+	ExampleQuestions          []ExampleQuestion `xorm:"mediumtext" json:"exampleQuestions"`
+	Avatar                    string            `xorm:"varchar(200)" json:"avatar"`
+	Title                     string            `xorm:"varchar(100)" json:"title"`
+	VectorStores              []string          `xorm:"mediumtext" json:"vectorStores"`
+	ChildStores               []string          `xorm:"mediumtext" json:"childStores"`
+	ChildModelProviders       []string          `xorm:"mediumtext" json:"childModelProviders"`
+	ForbiddenWords            []string          `xorm:"text" json:"forbiddenWords"`
+	Owners                    []string          `xorm:"mediumtext" json:"owners"`
+	ShowAutoRead              bool              `json:"showAutoRead"`
+	DisableFileUpload         bool              `json:"disableFileUpload"`
+	HideThinking              bool              `json:"hideThinking"`
+	EnableExperienceReview    bool              `json:"enableExperienceReview"`
+	BrowserUseWebActionPrompt bool              `json:"browserUseWebActionPrompt"`
+	EnableExtraOptions        bool              `json:"enableExtraOptions"`
+	IsDefault                 bool              `json:"isDefault"`
+	State                     string            `xorm:"varchar(100)" json:"state"`
+	SharedBy                  string            `xorm:"varchar(100)" json:"sharedBy"`
 
 	Author      string `xorm:"varchar(100)" json:"author"`
 	Affiliation string `xorm:"varchar(100)" json:"affiliation"`

--- a/object/tool.go
+++ b/object/tool.go
@@ -184,6 +184,7 @@ func DeleteTool(t *Tool) (bool, error) {
 
 func getToolConfig(t *Tool) tool.Config {
 	return tool.Config{
+		Owner:        t.Owner,
 		Type:         t.Type,
 		SubType:      t.SubType,
 		ProviderUrl:  t.ProviderUrl,

--- a/routers/authz_filter.go
+++ b/routers/authz_filter.go
@@ -21,6 +21,7 @@ import (
 	"github.com/the-open-agent/openagent/authz"
 	"github.com/the-open-agent/openagent/conf"
 	"github.com/the-open-agent/openagent/controllers"
+	"github.com/the-open-agent/openagent/tool"
 	"github.com/the-open-agent/openagent/util"
 )
 
@@ -64,6 +65,14 @@ func permissionFilter(ctx *context.Context) {
 	}
 
 	user := GetSessionUser(ctx)
+	if isBrowserUseWebActionAPI(urlPath) && (method == "GET" || method == "POST") {
+		if err := tool.ValidateChromeExtensionRequest(ctx.Request); err == nil {
+			return
+		} else if !util.IsAdmin(user) {
+			responseError(ctx, err.Error())
+			return
+		}
+	}
 
 	var role string
 	switch {
@@ -77,5 +86,17 @@ func permissionFilter(ctx *context.Context) {
 
 	if !authz.IsAllowed(role, method, urlPath) {
 		responseError(ctx, "auth:this operation requires admin privilege")
+	}
+}
+
+func isBrowserUseWebActionAPI(urlPath string) bool {
+	switch urlPath {
+	case "/api/get-browser-use-web-actions",
+		"/api/get-browser-use-web-action",
+		"/api/save-browser-use-web-action",
+		"/api/delete-browser-use-web-action":
+		return true
+	default:
+		return false
 	}
 }

--- a/routers/cors_filter.go
+++ b/routers/cors_filter.go
@@ -63,6 +63,10 @@ func CorsFilter(ctx *context.Context) {
 	if origin == "" || origin == "null" {
 		return
 	}
+	if isBrowserUseWebActionAPI(ctx.Request.URL.Path) && strings.HasPrefix(origin, "chrome-extension://") {
+		setCorsHeaders(ctx, origin)
+		return
+	}
 
 	// Check if origin is allowed based on Casdoor application's RedirectUris
 	setCorsHeaders(ctx, origin)

--- a/routers/router.go
+++ b/routers/router.go
@@ -115,6 +115,10 @@ func initAPI() {
 	beego.Router("/api/add-tool", &controllers.ApiController{}, "POST:AddTool")
 	beego.Router("/api/delete-tool", &controllers.ApiController{}, "POST:DeleteTool")
 	beego.Router("/api/test-tool", &controllers.ApiController{}, "POST:TestTool")
+	beego.Router("/api/get-browser-use-web-actions", &controllers.ApiController{}, "GET:GetBrowserUseWebActions")
+	beego.Router("/api/get-browser-use-web-action", &controllers.ApiController{}, "GET:GetBrowserUseWebAction")
+	beego.Router("/api/save-browser-use-web-action", &controllers.ApiController{}, "POST:SaveBrowserUseWebAction")
+	beego.Router("/api/delete-browser-use-web-action", &controllers.ApiController{}, "POST:DeleteBrowserUseWebAction")
 
 	beego.Router("/api/get-global-files", &controllers.ApiController{}, "GET:GetGlobalFiles")
 	beego.Router("/api/get-files", &controllers.ApiController{}, "GET:GetFiles")

--- a/tool/browser_use.go
+++ b/tool/browser_use.go
@@ -1177,7 +1177,7 @@ type browserUseOpenBuiltin struct{ provider *BrowserUseTool }
 func (b *browserUseOpenBuiltin) GetName() string { return "browser_use_open" }
 
 func (b *browserUseOpenBuiltin) GetDescription() string {
-	return browserUseWithWebActionReflection("Open or reuse the managed visible browser and navigate the Browser Use controlled tab to a URL. In extension mode, OpenAgent UI tabs are protected and Browser Use uses a separate controlled tab. Use this for real browser tasks only; do not claim a page was opened unless this tool succeeds. The browser keeps tabs, cookies, and media state across related user requests. This tool returns a fresh snapshot plus current browser state; use the returned element indexes only until the next page-changing action.")
+	return browserUseDescription("Open or reuse the managed visible browser and navigate the Browser Use controlled tab to a URL. In extension mode, OpenAgent UI tabs are protected and Browser Use uses a separate controlled tab. Use this for real browser tasks only; do not claim a page was opened unless this tool succeeds. The browser keeps tabs, cookies, and media state across related user requests. This tool returns a fresh snapshot plus current browser state; use the returned element indexes only until the next page-changing action.")
 }
 
 func (b *browserUseOpenBuiltin) GetInputSchema() interface{} {
@@ -1244,7 +1244,7 @@ type browserUseSnapshotBuiltin struct{ provider *BrowserUseTool }
 func (b *browserUseSnapshotBuiltin) GetName() string { return "browser_use_snapshot" }
 
 func (b *browserUseSnapshotBuiltin) GetDescription() string {
-	return browserUseWithWebActionReflection("Read the Browser Use controlled tab in the existing managed browser and return visible text, indexed interactive elements, URL, title, controlled tab index, tab count, and media state. Treat this as the source of truth before acting. Use it at the start of a follow-up request and after every navigation, click, type, or key press before reusing element indexes.")
+	return browserUseDescription("Read the Browser Use controlled tab in the existing managed browser and return visible text, indexed interactive elements, URL, title, controlled tab index, tab count, and media state. Treat this as the source of truth before acting. Use it at the start of a follow-up request and after every navigation, click, type, or key press before reusing element indexes.")
 }
 
 func (b *browserUseSnapshotBuiltin) GetInputSchema() interface{} {
@@ -1272,7 +1272,7 @@ type browserUseClickBuiltin struct{ provider *BrowserUseTool }
 func (b *browserUseClickBuiltin) GetName() string { return "browser_use_click" }
 
 func (b *browserUseClickBuiltin) GetDescription() string {
-	return browserUseWithWebActionReflection("Click an indexed element from the latest browser_use_snapshot, or a CSS selector when no index is available. The click may navigate, open a new tab, or change the DOM, so old indexes must be considered stale afterward. This tool reports the current browser state after the click; call browser_use_snapshot before the next indexed action.")
+	return browserUseDescription("Click an indexed element from the latest browser_use_snapshot, or a CSS selector when no index is available. The click may navigate, open a new tab, or change the DOM, so old indexes must be considered stale afterward. This tool reports the current browser state after the click; call browser_use_snapshot before the next indexed action.")
 }
 
 func (b *browserUseClickBuiltin) GetInputSchema() interface{} {
@@ -1369,7 +1369,7 @@ type browserUseTypeBuiltin struct{ provider *BrowserUseTool }
 func (b *browserUseTypeBuiltin) GetName() string { return "browser_use_type" }
 
 func (b *browserUseTypeBuiltin) GetDescription() string {
-	return browserUseWithWebActionReflection("Type text into an indexed input-like element, select dropdown, or web code editor from the latest browser_use_snapshot, or a CSS selector when no index is available. For select elements, pass one of the option labels or values shown in the snapshot as text. Set clear=true to replace the focused field or editor content. This tool uses real focus, select-all, delete, and text insertion so it should be preferred over repeated key presses for multi-line text. Typing can open suggestions or change the DOM, so verify with browser_use_snapshot before relying on indexes or claiming the input was accepted.")
+	return browserUseDescription("Type text into an indexed input-like element, select dropdown, or web code editor from the latest browser_use_snapshot, or a CSS selector when no index is available. For select elements, pass one of the option labels or values shown in the snapshot as text. Set clear=true to replace the focused field or editor content. This tool uses real focus, select-all, delete, and text insertion so it should be preferred over repeated key presses for multi-line text. Typing can open suggestions or change the DOM, so verify with browser_use_snapshot before relying on indexes or claiming the input was accepted.")
 }
 
 func (b *browserUseTypeBuiltin) GetInputSchema() interface{} {
@@ -1502,7 +1502,7 @@ type browserUsePressBuiltin struct{ provider *BrowserUseTool }
 func (b *browserUsePressBuiltin) GetName() string { return "browser_use_press" }
 
 func (b *browserUsePressBuiltin) GetDescription() string {
-	return browserUseWithWebActionReflection("Press a keyboard key in the visible browser, such as Enter, Tab, Escape, ArrowDown, or Space. A key press can submit a form, navigate, open a new tab, or change focus, so old indexes may be stale afterward. This tool reports the current browser state; call browser_use_snapshot before the next indexed action.")
+	return browserUseDescription("Press a keyboard key in the visible browser, such as Enter, Tab, Escape, ArrowDown, or Space. A key press can submit a form, navigate, open a new tab, or change focus, so old indexes may be stale afterward. This tool reports the current browser state; call browser_use_snapshot before the next indexed action.")
 }
 
 func (b *browserUsePressBuiltin) GetInputSchema() interface{} {
@@ -1628,7 +1628,7 @@ type browserUsePlayMediaBuiltin struct{ provider *BrowserUseTool }
 func (b *browserUsePlayMediaBuiltin) GetName() string { return "browser_use_play_media" }
 
 func (b *browserUsePlayMediaBuiltin) GetDescription() string {
-	return browserUseWithWebActionReflection("Play and unmute visible audio or video elements on the Browser Use controlled tab. Use this after opening a page with music or video if playback is paused, muted, or silent. The result includes media playback state; do not tell the user audio is playing unless the returned state says a media element is playing.")
+	return browserUseDescription("Play and unmute visible audio or video elements on the Browser Use controlled tab. Use this after opening a page with music or video if playback is paused, muted, or silent. The result includes media playback state; do not tell the user audio is playing unless the returned state says a media element is playing.")
 }
 
 func (b *browserUsePlayMediaBuiltin) GetInputSchema() interface{} {
@@ -1657,7 +1657,7 @@ type browserUseTabsBuiltin struct{ provider *BrowserUseTool }
 func (b *browserUseTabsBuiltin) GetName() string { return "browser_use_tabs" }
 
 func (b *browserUseTabsBuiltin) GetDescription() string {
-	return browserUseWithWebActionReflection("List open browser tabs available to Browser Use, including active, controlled, and protected tab markers, titles, and URLs. Use this when a click opens a new tab, when the current page does not match what the user sees, or before switching tabs.")
+	return browserUseDescription("List open browser tabs available to Browser Use, including active, controlled, and protected tab markers, titles, and URLs. Use this when a click opens a new tab, when the current page does not match what the user sees, or before switching tabs.")
 }
 
 func (b *browserUseTabsBuiltin) GetInputSchema() interface{} {
@@ -1685,7 +1685,7 @@ type browserUseSwitchTabBuiltin struct{ provider *BrowserUseTool }
 func (b *browserUseSwitchTabBuiltin) GetName() string { return "browser_use_switch_tab" }
 
 func (b *browserUseSwitchTabBuiltin) GetDescription() string {
-	return browserUseWithWebActionReflection("Switch Browser Use to a tab returned by browser_use_tabs. The switch sets the selected tab as the controlled tab used by Browser Use tools; protected OpenAgent UI tabs cannot be controlled. This tool returns a fresh snapshot and browser state for the selected tab.")
+	return browserUseDescription("Switch Browser Use to a tab returned by browser_use_tabs. The switch sets the selected tab as the controlled tab used by Browser Use tools; protected OpenAgent UI tabs cannot be controlled. This tool returns a fresh snapshot and browser state for the selected tab.")
 }
 
 func (b *browserUseSwitchTabBuiltin) GetInputSchema() interface{} {
@@ -1742,7 +1742,7 @@ type browserUseCloseTabBuiltin struct{ provider *BrowserUseTool }
 func (b *browserUseCloseTabBuiltin) GetName() string { return "browser_use_close_tab" }
 
 func (b *browserUseCloseTabBuiltin) GetDescription() string {
-	return browserUseWithWebActionReflection("Close a browser tab returned by browser_use_tabs without closing the whole Browser Use session. Use browser_use_tabs first, then pass the tab index to close.")
+	return browserUseDescription("Close a browser tab returned by browser_use_tabs without closing the whole Browser Use session. Use browser_use_tabs first, then pass the tab index to close.")
 }
 
 func (b *browserUseCloseTabBuiltin) GetInputSchema() interface{} {
@@ -1818,7 +1818,7 @@ type browserUseCloseBuiltin struct{ provider *BrowserUseTool }
 func (b *browserUseCloseBuiltin) GetName() string { return "browser_use_close" }
 
 func (b *browserUseCloseBuiltin) GetDescription() string {
-	return browserUseWithWebActionReflection("Close the visible browser session owned by Browser Use. Only use this when the user explicitly asks to close or stop the browser; do not use it between related follow-up tasks because the browser is intended to keep context. The profile directory remains on disk so cookies and local storage can be reused next time.")
+	return browserUseDescription("Close the visible browser session owned by Browser Use. Only use this when the user explicitly asks to close or stop the browser; do not use it between related follow-up tasks because the browser is intended to keep context. The profile directory remains on disk so cookies and local storage can be reused next time.")
 }
 
 func (b *browserUseCloseBuiltin) GetInputSchema() interface{} {

--- a/tool/browser_use.go
+++ b/tool/browser_use.go
@@ -50,6 +50,8 @@ const (
 // It opens a visible, persistent Chromium browser for human-observable web tasks.
 type BrowserUseTool struct {
 	sessionKey  string
+	traceKey    string
+	owner       string
 	userDataDir string
 	enableProxy bool
 	mode        string
@@ -60,10 +62,16 @@ func NewBrowserUseTool(config Config) (*BrowserUseTool, error) {
 	if mode == "" {
 		mode = "User Chrome"
 	}
-	userDataDir := defaultBrowserUseDataDir()
+	userDataDir := strings.TrimSpace(config.UserDataDir)
+	if userDataDir == "" {
+		userDataDir = defaultBrowserUseDataDir()
+	}
+	owner := browserUseDefaultOwner(config.Owner)
 	sessionKey := strings.Join([]string{userDataDir, strconv.FormatBool(config.EnableProxy), mode}, "|")
 	return &BrowserUseTool{
 		sessionKey:  sessionKey,
+		traceKey:    strings.Join([]string{owner, sessionKey}, "|"),
+		owner:       owner,
 		userDataDir: userDataDir,
 		enableProxy: config.EnableProxy,
 		mode:        mode,
@@ -72,11 +80,16 @@ func NewBrowserUseTool(config Config) (*BrowserUseTool, error) {
 
 func (p *BrowserUseTool) BuiltinTools() []BuiltinTool {
 	if p.isChromeExtMode() {
-		return chromeConnectBuiltinTools()
+		return chromeConnectBuiltinTools(p)
 	}
 	return []BuiltinTool{
 		&browserUseOpenBuiltin{provider: p},
 		&browserUseSnapshotBuiltin{provider: p},
+		&browserUseListWebActionsBuiltin{provider: p},
+		&browserUseInspectWebActionTraceBuiltin{provider: p},
+		&browserUseSaveWebActionBuiltin{provider: p},
+		&browserUseRunWebActionBuiltin{provider: p},
+		&browserUseDeleteWebActionBuiltin{provider: p},
 		&browserUseClickBuiltin{provider: p},
 		&browserUseTypeBuiltin{provider: p},
 		&browserUsePressBuiltin{provider: p},
@@ -1151,7 +1164,8 @@ func browserUseSnapshot(provider *BrowserUseTool) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return browserUseFormatSnapshot(rawURL, title, visibleText, elements), nil
+	snapshot := browserUseFormatSnapshot(rawURL, title, visibleText, elements)
+	return snapshot, nil
 }
 
 // ---------------------------------------------------------------------------
@@ -1163,7 +1177,7 @@ type browserUseOpenBuiltin struct{ provider *BrowserUseTool }
 func (b *browserUseOpenBuiltin) GetName() string { return "browser_use_open" }
 
 func (b *browserUseOpenBuiltin) GetDescription() string {
-	return "Open or reuse the managed visible browser and navigate the Browser Use controlled tab to a URL. In extension mode, OpenAgent UI tabs are protected and Browser Use uses a separate controlled tab. Use this for real browser tasks only; do not claim a page was opened unless this tool succeeds. The browser keeps tabs, cookies, and media state across related user requests. This tool returns a fresh snapshot plus current browser state; use the returned element indexes only until the next page-changing action."
+	return browserUseWithWebActionReflection("Open or reuse the managed visible browser and navigate the Browser Use controlled tab to a URL. In extension mode, OpenAgent UI tabs are protected and Browser Use uses a separate controlled tab. Use this for real browser tasks only; do not claim a page was opened unless this tool succeeds. The browser keeps tabs, cookies, and media state across related user requests. This tool returns a fresh snapshot plus current browser state; use the returned element indexes only until the next page-changing action.")
 }
 
 func (b *browserUseOpenBuiltin) GetInputSchema() interface{} {
@@ -1187,9 +1201,33 @@ func (b *browserUseOpenBuiltin) Execute(ctx context.Context, arguments map[strin
 	}
 	rawURL = strings.TrimSpace(rawURL)
 
+	before := browserUseCurrentPageInfoSafe(b.provider)
 	if err := b.provider.run(chromedp.Navigate(rawURL), chromedp.WaitReady("body", chromedp.ByQuery)); err != nil {
+		browserUseRecordProviderWebActionTrace(b.provider, browserUseWebActionTraceStep{
+			Summary:     fmt.Sprintf("open %s", rawURL),
+			Kind:        "open",
+			Target:      rawURL,
+			URL:         rawURL,
+			URLBefore:   before.URL,
+			TitleBefore: before.Title,
+			Status:      "failed",
+			Error:       err.Error(),
+		})
 		return browserUseErrorWithState(b.provider, fmt.Sprintf("browser use open failed for %s: %s", rawURL, err.Error())), nil
 	}
+	after := browserUseCurrentPageInfoSafe(b.provider)
+	browserUseRecordProviderWebActionTrace(b.provider, browserUseWebActionTraceStep{
+		Summary:     fmt.Sprintf("open %s", rawURL),
+		Kind:        "open",
+		Target:      rawURL,
+		URL:         rawURL,
+		URLBefore:   before.URL,
+		URLAfter:    after.URL,
+		TitleBefore: before.Title,
+		TitleAfter:  after.Title,
+		Outcome:     browserUseTraceOutcome("open", before, after),
+		Status:      "success",
+	})
 	snapshot, err := browserUseSnapshot(b.provider)
 	if err != nil {
 		return browserUseErrorWithState(b.provider, fmt.Sprintf("browser use snapshot failed after opening %s: %s", rawURL, err.Error())), nil
@@ -1206,7 +1244,7 @@ type browserUseSnapshotBuiltin struct{ provider *BrowserUseTool }
 func (b *browserUseSnapshotBuiltin) GetName() string { return "browser_use_snapshot" }
 
 func (b *browserUseSnapshotBuiltin) GetDescription() string {
-	return "Read the Browser Use controlled tab in the existing managed browser and return visible text, indexed interactive elements, URL, title, controlled tab index, tab count, and media state. Treat this as the source of truth before acting. Use it at the start of a follow-up request and after every navigation, click, type, or key press before reusing element indexes. Do not invent page contents or completed browser actions that are not visible in this tool result."
+	return browserUseWithWebActionReflection("Read the Browser Use controlled tab in the existing managed browser and return visible text, indexed interactive elements, URL, title, controlled tab index, tab count, and media state. Treat this as the source of truth before acting. Use it at the start of a follow-up request and after every navigation, click, type, or key press before reusing element indexes.")
 }
 
 func (b *browserUseSnapshotBuiltin) GetInputSchema() interface{} {
@@ -1234,7 +1272,7 @@ type browserUseClickBuiltin struct{ provider *BrowserUseTool }
 func (b *browserUseClickBuiltin) GetName() string { return "browser_use_click" }
 
 func (b *browserUseClickBuiltin) GetDescription() string {
-	return "Click an indexed element from the latest browser_use_snapshot, or a CSS selector when no index is available. The click may navigate, open a new tab, or change the DOM, so old indexes must be considered stale afterward. This tool reports the current browser state after the click; call browser_use_snapshot before the next indexed action."
+	return browserUseWithWebActionReflection("Click an indexed element from the latest browser_use_snapshot, or a CSS selector when no index is available. The click may navigate, open a new tab, or change the DOM, so old indexes must be considered stale afterward. This tool reports the current browser state after the click; call browser_use_snapshot before the next indexed action.")
 }
 
 func (b *browserUseClickBuiltin) GetInputSchema() interface{} {
@@ -1259,6 +1297,8 @@ func (b *browserUseClickBuiltin) Execute(ctx context.Context, arguments map[stri
 	if err != nil {
 		return browserToolError(err.Error()), nil
 	}
+	targetSummary, traceSelector := browserUseTraceTarget(arguments)
+	beforePage := browserUseCurrentPageInfoSafe(b.provider)
 	switchedTab := false
 	err = b.provider.runSession(func(session *browserUseSession) error {
 		var previousURL string
@@ -1289,8 +1329,31 @@ func (b *browserUseClickBuiltin) Execute(ctx context.Context, arguments map[stri
 		return switchErr
 	})
 	if err != nil {
+		browserUseRecordProviderWebActionTrace(b.provider, browserUseWebActionTraceStep{
+			Summary:     fmt.Sprintf("click %s", targetSummary),
+			Kind:        "click",
+			Selector:    traceSelector,
+			Target:      targetSummary,
+			URLBefore:   beforePage.URL,
+			TitleBefore: beforePage.Title,
+			Status:      "failed",
+			Error:       err.Error(),
+		})
 		return browserUseErrorWithState(b.provider, fmt.Sprintf("browser use click failed for %s: %s", selector, err.Error())), nil
 	}
+	afterPage := browserUseCurrentPageInfoSafe(b.provider)
+	browserUseRecordProviderWebActionTrace(b.provider, browserUseWebActionTraceStep{
+		Summary:     fmt.Sprintf("click %s", targetSummary),
+		Kind:        "click",
+		Selector:    traceSelector,
+		Target:      targetSummary,
+		URLBefore:   beforePage.URL,
+		URLAfter:    afterPage.URL,
+		TitleBefore: beforePage.Title,
+		TitleAfter:  afterPage.Title,
+		Outcome:     browserUseTraceOutcome("click", beforePage, afterPage),
+		Status:      "success",
+	})
 	if switchedTab {
 		return browserUseTextWithState(b.provider, "Clicked and switched to the new tab. Call browser_use_snapshot before the next indexed action."), nil
 	}
@@ -1306,7 +1369,7 @@ type browserUseTypeBuiltin struct{ provider *BrowserUseTool }
 func (b *browserUseTypeBuiltin) GetName() string { return "browser_use_type" }
 
 func (b *browserUseTypeBuiltin) GetDescription() string {
-	return "Type text into an indexed input-like element, select dropdown, or web code editor from the latest browser_use_snapshot, or a CSS selector when no index is available. For select elements, pass one of the option labels or values shown in the snapshot as text. Set clear=true to replace the focused field or editor content. This tool uses real focus, select-all, delete, and text insertion so it should be preferred over repeated key presses for multi-line text. Typing can open suggestions or change the DOM, so verify with browser_use_snapshot before relying on indexes or claiming the input was accepted."
+	return browserUseWithWebActionReflection("Type text into an indexed input-like element, select dropdown, or web code editor from the latest browser_use_snapshot, or a CSS selector when no index is available. For select elements, pass one of the option labels or values shown in the snapshot as text. Set clear=true to replace the focused field or editor content. This tool uses real focus, select-all, delete, and text insertion so it should be preferred over repeated key presses for multi-line text. Typing can open suggestions or change the DOM, so verify with browser_use_snapshot before relying on indexes or claiming the input was accepted.")
 }
 
 func (b *browserUseTypeBuiltin) GetInputSchema() interface{} {
@@ -1349,8 +1412,45 @@ func (b *browserUseTypeBuiltin) Execute(ctx context.Context, arguments map[strin
 	if value, ok := arguments["clear"].(bool); ok {
 		clear = value
 	}
+	targetSummary, traceSelector := browserUseTraceTarget(arguments)
+	beforePage := browserUseCurrentPageInfoSafe(b.provider)
 
-	actions := []chromedp.Action{
+	if err = b.provider.run(browserUseTypeActions(selector, text, clear)...); err != nil {
+		browserUseRecordProviderWebActionTrace(b.provider, browserUseWebActionTraceStep{
+			Summary:     fmt.Sprintf("type into %s", targetSummary),
+			Kind:        "type",
+			Selector:    traceSelector,
+			Target:      targetSummary,
+			Text:        text,
+			Clear:       &clear,
+			URLBefore:   beforePage.URL,
+			TitleBefore: beforePage.Title,
+			Status:      "failed",
+			Error:       err.Error(),
+		})
+		return browserUseErrorWithState(b.provider, fmt.Sprintf("browser use type failed for %s: %s", selector, err.Error())), nil
+	}
+	afterPage := browserUseCurrentPageInfoSafe(b.provider)
+	browserUseRecordProviderWebActionTrace(b.provider, browserUseWebActionTraceStep{
+		Summary:     fmt.Sprintf("type into %s", targetSummary),
+		Kind:        "type",
+		Selector:    traceSelector,
+		Target:      targetSummary,
+		Text:        text,
+		Clear:       &clear,
+		URLBefore:   beforePage.URL,
+		URLAfter:    afterPage.URL,
+		TitleBefore: beforePage.Title,
+		TitleAfter:  afterPage.Title,
+		Outcome:     browserUseTraceOutcome("type", beforePage, afterPage),
+		Status:      "success",
+	})
+	return browserUseTextWithState(b.provider, "Typed. Call browser_use_snapshot before the next indexed action or before claiming the page accepted the input."), nil
+}
+
+func browserUseTypeActions(selector, text string, clear bool) []chromedp.Action {
+	return []chromedp.Action{
+		chromedp.WaitReady(selector, chromedp.ByQuery),
 		chromedp.ScrollIntoView(selector, chromedp.ByQuery),
 		chromedp.Click(selector, chromedp.ByQuery),
 		chromedp.Sleep(100 * time.Millisecond),
@@ -1391,11 +1491,6 @@ func (b *browserUseTypeBuiltin) Execute(ctx context.Context, arguments map[strin
 		}),
 		chromedp.Sleep(300 * time.Millisecond),
 	}
-
-	if err = b.provider.run(actions...); err != nil {
-		return browserUseErrorWithState(b.provider, fmt.Sprintf("browser use type failed for %s: %s", selector, err.Error())), nil
-	}
-	return browserUseTextWithState(b.provider, "Typed. Call browser_use_snapshot before the next indexed action or before claiming the page accepted the input."), nil
 }
 
 // ---------------------------------------------------------------------------
@@ -1407,7 +1502,7 @@ type browserUsePressBuiltin struct{ provider *BrowserUseTool }
 func (b *browserUsePressBuiltin) GetName() string { return "browser_use_press" }
 
 func (b *browserUsePressBuiltin) GetDescription() string {
-	return "Press a keyboard key in the visible browser, such as Enter, Tab, Escape, ArrowDown, or Space. A key press can submit a form, navigate, open a new tab, or change focus, so old indexes may be stale afterward. This tool reports the current browser state; call browser_use_snapshot before the next indexed action."
+	return browserUseWithWebActionReflection("Press a keyboard key in the visible browser, such as Enter, Tab, Escape, ArrowDown, or Space. A key press can submit a form, navigate, open a new tab, or change focus, so old indexes may be stale afterward. This tool reports the current browser state; call browser_use_snapshot before the next indexed action.")
 }
 
 func (b *browserUsePressBuiltin) GetInputSchema() interface{} {
@@ -1431,6 +1526,7 @@ func (b *browserUsePressBuiltin) Execute(ctx context.Context, arguments map[stri
 	}
 	key = browserUseKey(strings.TrimSpace(key))
 
+	beforePage := browserUseCurrentPageInfoSafe(b.provider)
 	switchedTab := false
 	err := b.provider.runSession(func(session *browserUseSession) error {
 		var previousURL string
@@ -1457,8 +1553,31 @@ func (b *browserUsePressBuiltin) Execute(ctx context.Context, arguments map[stri
 		return switchErr
 	})
 	if err != nil {
+		browserUseRecordProviderWebActionTrace(b.provider, browserUseWebActionTraceStep{
+			Summary:     fmt.Sprintf("press %s", key),
+			Kind:        "press",
+			Target:      key,
+			Key:         key,
+			URLBefore:   beforePage.URL,
+			TitleBefore: beforePage.Title,
+			Status:      "failed",
+			Error:       err.Error(),
+		})
 		return browserUseErrorWithState(b.provider, fmt.Sprintf("browser use press failed for %s: %s", key, err.Error())), nil
 	}
+	afterPage := browserUseCurrentPageInfoSafe(b.provider)
+	browserUseRecordProviderWebActionTrace(b.provider, browserUseWebActionTraceStep{
+		Summary:     fmt.Sprintf("press %s", key),
+		Kind:        "press",
+		Target:      key,
+		Key:         key,
+		URLBefore:   beforePage.URL,
+		URLAfter:    afterPage.URL,
+		TitleBefore: beforePage.Title,
+		TitleAfter:  afterPage.Title,
+		Outcome:     browserUseTraceOutcome("press", beforePage, afterPage),
+		Status:      "success",
+	})
 	if switchedTab {
 		return browserUseTextWithState(b.provider, "Key pressed and switched to the new tab. Call browser_use_snapshot before the next indexed action."), nil
 	}
@@ -1509,7 +1628,7 @@ type browserUsePlayMediaBuiltin struct{ provider *BrowserUseTool }
 func (b *browserUsePlayMediaBuiltin) GetName() string { return "browser_use_play_media" }
 
 func (b *browserUsePlayMediaBuiltin) GetDescription() string {
-	return "Play and unmute visible audio or video elements on the Browser Use controlled tab. Use this after opening a page with music or video if playback is paused, muted, or silent. The result includes media playback state; do not tell the user audio is playing unless the returned state says a media element is playing."
+	return browserUseWithWebActionReflection("Play and unmute visible audio or video elements on the Browser Use controlled tab. Use this after opening a page with music or video if playback is paused, muted, or silent. The result includes media playback state; do not tell the user audio is playing unless the returned state says a media element is playing.")
 }
 
 func (b *browserUsePlayMediaBuiltin) GetInputSchema() interface{} {
@@ -1538,7 +1657,7 @@ type browserUseTabsBuiltin struct{ provider *BrowserUseTool }
 func (b *browserUseTabsBuiltin) GetName() string { return "browser_use_tabs" }
 
 func (b *browserUseTabsBuiltin) GetDescription() string {
-	return "List open browser tabs available to Browser Use, including active, controlled, and protected tab markers, titles, and URLs. Use this when a click opens a new tab, when the current page does not match what the user sees, or before switching tabs."
+	return browserUseWithWebActionReflection("List open browser tabs available to Browser Use, including active, controlled, and protected tab markers, titles, and URLs. Use this when a click opens a new tab, when the current page does not match what the user sees, or before switching tabs.")
 }
 
 func (b *browserUseTabsBuiltin) GetInputSchema() interface{} {
@@ -1566,7 +1685,7 @@ type browserUseSwitchTabBuiltin struct{ provider *BrowserUseTool }
 func (b *browserUseSwitchTabBuiltin) GetName() string { return "browser_use_switch_tab" }
 
 func (b *browserUseSwitchTabBuiltin) GetDescription() string {
-	return "Switch Browser Use to a tab returned by browser_use_tabs. The switch sets the selected tab as the controlled tab used by Browser Use tools; protected OpenAgent UI tabs cannot be controlled. This tool returns a fresh snapshot and browser state for the selected tab."
+	return browserUseWithWebActionReflection("Switch Browser Use to a tab returned by browser_use_tabs. The switch sets the selected tab as the controlled tab used by Browser Use tools; protected OpenAgent UI tabs cannot be controlled. This tool returns a fresh snapshot and browser state for the selected tab.")
 }
 
 func (b *browserUseSwitchTabBuiltin) GetInputSchema() interface{} {
@@ -1623,7 +1742,7 @@ type browserUseCloseTabBuiltin struct{ provider *BrowserUseTool }
 func (b *browserUseCloseTabBuiltin) GetName() string { return "browser_use_close_tab" }
 
 func (b *browserUseCloseTabBuiltin) GetDescription() string {
-	return "Close a browser tab returned by browser_use_tabs without closing the whole Browser Use session. Use browser_use_tabs first, then pass the tab index to close."
+	return browserUseWithWebActionReflection("Close a browser tab returned by browser_use_tabs without closing the whole Browser Use session. Use browser_use_tabs first, then pass the tab index to close.")
 }
 
 func (b *browserUseCloseTabBuiltin) GetInputSchema() interface{} {
@@ -1699,7 +1818,7 @@ type browserUseCloseBuiltin struct{ provider *BrowserUseTool }
 func (b *browserUseCloseBuiltin) GetName() string { return "browser_use_close" }
 
 func (b *browserUseCloseBuiltin) GetDescription() string {
-	return "Close the visible browser session owned by Browser Use. Only use this when the user explicitly asks to close or stop the browser; do not use it between related follow-up tasks because the browser is intended to keep context. The profile directory remains on disk so cookies and local storage can be reused next time."
+	return browserUseWithWebActionReflection("Close the visible browser session owned by Browser Use. Only use this when the user explicitly asks to close or stop the browser; do not use it between related follow-up tasks because the browser is intended to keep context. The profile directory remains on disk so cookies and local storage can be reused next time.")
 }
 
 func (b *browserUseCloseBuiltin) GetInputSchema() interface{} {

--- a/tool/browser_use_chrome_ext.go
+++ b/tool/browser_use_chrome_ext.go
@@ -17,6 +17,7 @@ package tool
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -31,6 +32,11 @@ import (
 	"github.com/ThinkInAIXYZ/go-mcp/protocol"
 	"github.com/chromedp/cdproto/target"
 	"github.com/gorilla/websocket"
+)
+
+var (
+	ErrChromeExtensionForbidden    = errors.New("browser extension request forbidden")
+	ErrChromeExtensionUnauthorized = errors.New("browser extension request unauthorized")
 )
 
 const (
@@ -120,16 +126,37 @@ func HandleChromeConnectWebSocket(w http.ResponseWriter, r *http.Request) {
 	globalBrowserUseChromeExtBridge.handleWebSocket(w, r)
 }
 
-func (b *browserUseChromeExtBridge) handleWebSocket(w http.ResponseWriter, r *http.Request) {
+func ValidateChromeExtensionRequest(r *http.Request) error {
 	if !browserUseIsLocalRequest(r) {
-		http.Error(w, "browser extension bridge only accepts localhost connections", http.StatusForbidden)
-		return
+		return fmt.Errorf("%w: browser extension bridge only accepts localhost connections", ErrChromeExtensionForbidden)
+	}
+	if origin := strings.TrimSpace(r.Header.Get("Origin")); origin != "" && !browserUseIsChromeExtensionOrigin(origin) {
+		return fmt.Errorf("%w: browser extension bridge only accepts chrome-extension origins", ErrChromeExtensionForbidden)
 	}
 	if expectedToken := strings.TrimSpace(os.Getenv("OPENAGENT_CHROME_EXTENSION_TOKEN")); expectedToken != "" {
 		if r.URL.Query().Get("token") != expectedToken {
-			http.Error(w, "invalid browser extension bridge token", http.StatusUnauthorized)
-			return
+			return fmt.Errorf("%w: invalid browser extension bridge token", ErrChromeExtensionUnauthorized)
 		}
+	}
+	return nil
+}
+
+func ChromeExtensionOwner() string {
+	owner := strings.TrimSpace(os.Getenv("OPENAGENT_CHROME_EXTENSION_OWNER"))
+	if owner == "" {
+		return "admin"
+	}
+	return owner
+}
+
+func (b *browserUseChromeExtBridge) handleWebSocket(w http.ResponseWriter, r *http.Request) {
+	if err := ValidateChromeExtensionRequest(r); err != nil {
+		status := http.StatusForbidden
+		if errors.Is(err, ErrChromeExtensionUnauthorized) {
+			status = http.StatusUnauthorized
+		}
+		http.Error(w, err.Error(), status)
+		return
 	}
 
 	upgrader := websocket.Upgrader{
@@ -375,7 +402,7 @@ func browserUseChromeExtOpen(ctx context.Context, rawURL string) error {
 	return browserUseChromeExtCall(ctx, "open", map[string]interface{}{"url": rawURL}, nil)
 }
 
-func browserUseChromeExtSnapshot(ctx context.Context) (string, error) {
+func browserUseChromeExtSnapshot(provider *BrowserUseTool, ctx context.Context) (string, error) {
 	var snapshot browserUseChromeExtSnapshotResult
 	if err := browserUseChromeExtCall(ctx, "snapshot", map[string]interface{}{}, &snapshot); err != nil {
 		return "", err
@@ -386,7 +413,8 @@ func browserUseChromeExtSnapshot(ctx context.Context) (string, error) {
 	if snapshot.Title == "" {
 		snapshot.Title = snapshot.Tab.Title
 	}
-	return browserUseFormatSnapshot(snapshot.URL, snapshot.Title, snapshot.VisibleText, snapshot.Elements), nil
+	formatted := browserUseFormatSnapshot(snapshot.URL, snapshot.Title, snapshot.VisibleText, snapshot.Elements)
+	return formatted, nil
 }
 
 func browserUseChromeExtCurrentState(ctx context.Context) (string, error) {
@@ -543,26 +571,31 @@ func chromeConnectErrorWithState(text string) *protocol.CallToolResult {
 	return browserToolError(fmt.Sprintf("%s\n\n%s", text, state))
 }
 
-func chromeConnectBuiltinTools() []BuiltinTool {
+func chromeConnectBuiltinTools(provider *BrowserUseTool) []BuiltinTool {
 	return []BuiltinTool{
-		&chromeConnectOpenBuiltin{},
-		&chromeConnectSnapshotBuiltin{},
-		&chromeConnectClickBuiltin{},
-		&chromeConnectTypeBuiltin{},
-		&chromeConnectPressBuiltin{},
+		&chromeConnectOpenBuiltin{provider: provider},
+		&chromeConnectSnapshotBuiltin{provider: provider},
+		&chromeConnectListWebActionsBuiltin{provider: provider},
+		&chromeConnectInspectWebActionTraceBuiltin{provider: provider},
+		&chromeConnectSaveWebActionBuiltin{provider: provider},
+		&chromeConnectRunWebActionBuiltin{provider: provider},
+		&chromeConnectDeleteWebActionBuiltin{provider: provider},
+		&chromeConnectClickBuiltin{provider: provider},
+		&chromeConnectTypeBuiltin{provider: provider},
+		&chromeConnectPressBuiltin{provider: provider},
 		&chromeConnectPlayMediaBuiltin{},
 		&chromeConnectTabsBuiltin{},
-		&chromeConnectSwitchTabBuiltin{},
+		&chromeConnectSwitchTabBuiltin{provider: provider},
 		&chromeConnectCloseTabBuiltin{},
 		&chromeConnectCloseBuiltin{},
 	}
 }
 
-type chromeConnectOpenBuiltin struct{}
+type chromeConnectOpenBuiltin struct{ provider *BrowserUseTool }
 
 func (b *chromeConnectOpenBuiltin) GetName() string { return "browser_use_open" }
 func (b *chromeConnectOpenBuiltin) GetDescription() string {
-	return "Navigate the Browser Use controlled tab in your existing Chrome browser to a URL via the OpenAgent Chrome extension. OpenAgent UI tabs are protected and Browser Use operates a separate controlled tab. Use this for real browser tasks only; do not claim a page was opened unless this tool succeeds. Returns a fresh snapshot plus current browser state."
+	return browserUseWithWebActionReflection("Navigate the Browser Use controlled tab in your existing Chrome browser to a URL via the OpenAgent Chrome extension. OpenAgent UI tabs are protected and Browser Use operates a separate controlled tab. Use this for real browser tasks only; do not claim a page was opened unless this tool succeeds. Returns a fresh snapshot plus current browser state.")
 }
 
 func (b *chromeConnectOpenBuiltin) GetInputSchema() interface{} {
@@ -585,21 +618,45 @@ func (b *chromeConnectOpenBuiltin) Execute(ctx context.Context, arguments map[st
 		return browserToolError("missing required parameter: url"), nil
 	}
 	rawURL = strings.TrimSpace(rawURL)
+	before := browserUseChromeExtCurrentPageInfoSafe(ctx)
 	if err := browserUseChromeExtOpen(ctx, rawURL); err != nil {
+		browserUseRecordProviderWebActionTrace(b.provider, browserUseWebActionTraceStep{
+			Summary:     fmt.Sprintf("open %s", rawURL),
+			Kind:        "open",
+			Target:      rawURL,
+			URL:         rawURL,
+			URLBefore:   before.URL,
+			TitleBefore: before.Title,
+			Status:      "failed",
+			Error:       err.Error(),
+		})
 		return chromeConnectErrorWithState(fmt.Sprintf("browser use open failed for %s: %s", rawURL, err.Error())), nil
 	}
-	snapshot, err := browserUseChromeExtSnapshot(ctx)
+	after := browserUseChromeExtCurrentPageInfoSafe(ctx)
+	browserUseRecordProviderWebActionTrace(b.provider, browserUseWebActionTraceStep{
+		Summary:     fmt.Sprintf("open %s", rawURL),
+		Kind:        "open",
+		Target:      rawURL,
+		URL:         rawURL,
+		URLBefore:   before.URL,
+		URLAfter:    after.URL,
+		TitleBefore: before.Title,
+		TitleAfter:  after.Title,
+		Outcome:     browserUseTraceOutcome("open", before, after),
+		Status:      "success",
+	})
+	snapshot, err := browserUseChromeExtSnapshot(b.provider, ctx)
 	if err != nil {
 		return chromeConnectErrorWithState(fmt.Sprintf("browser use snapshot failed after opening %s: %s", rawURL, err.Error())), nil
 	}
 	return chromeConnectTextWithState(snapshot), nil
 }
 
-type chromeConnectSnapshotBuiltin struct{}
+type chromeConnectSnapshotBuiltin struct{ provider *BrowserUseTool }
 
 func (b *chromeConnectSnapshotBuiltin) GetName() string { return "browser_use_snapshot" }
 func (b *chromeConnectSnapshotBuiltin) GetDescription() string {
-	return "Read the Browser Use controlled tab in your existing Chrome browser via the OpenAgent Chrome extension and return visible text, indexed interactive elements, URL, title, controlled tab index, tab count, and media state. Treat this as the source of truth before acting. Use it at the start of a follow-up request and after every navigation, click, type, or key press before reusing element indexes."
+	return browserUseWithWebActionReflection("Read the Browser Use controlled tab in your existing Chrome browser via the OpenAgent Chrome extension and return visible text, indexed interactive elements, URL, title, controlled tab index, tab count, and media state. Treat this as the source of truth before acting. Use it at the start of a follow-up request and after every navigation, click, type, or key press before reusing element indexes.")
 }
 
 func (b *chromeConnectSnapshotBuiltin) GetInputSchema() interface{} {
@@ -611,18 +668,18 @@ func (b *chromeConnectSnapshotBuiltin) GetInputSchema() interface{} {
 }
 
 func (b *chromeConnectSnapshotBuiltin) Execute(ctx context.Context, arguments map[string]interface{}) (*protocol.CallToolResult, error) {
-	snapshot, err := browserUseChromeExtSnapshot(ctx)
+	snapshot, err := browserUseChromeExtSnapshot(b.provider, ctx)
 	if err != nil {
 		return chromeConnectErrorWithState(fmt.Sprintf("browser use snapshot failed: %s", err.Error())), nil
 	}
 	return chromeConnectTextWithState(snapshot), nil
 }
 
-type chromeConnectClickBuiltin struct{}
+type chromeConnectClickBuiltin struct{ provider *BrowserUseTool }
 
 func (b *chromeConnectClickBuiltin) GetName() string { return "browser_use_click" }
 func (b *chromeConnectClickBuiltin) GetDescription() string {
-	return "Click an indexed element from the latest browser_use_snapshot, or a CSS selector when no index is available. The click may navigate, open a new tab, or change the DOM, so old indexes must be considered stale afterward. Call browser_use_snapshot before the next indexed action."
+	return browserUseWithWebActionReflection("Click an indexed element from the latest browser_use_snapshot, or a CSS selector when no index is available. The click may navigate, open a new tab, or change the DOM, so old indexes must be considered stale afterward. Call browser_use_snapshot before the next indexed action.")
 }
 
 func (b *chromeConnectClickBuiltin) GetInputSchema() interface{} {
@@ -643,17 +700,42 @@ func (b *chromeConnectClickBuiltin) GetInputSchema() interface{} {
 }
 
 func (b *chromeConnectClickBuiltin) Execute(ctx context.Context, arguments map[string]interface{}) (*protocol.CallToolResult, error) {
+	targetSummary, traceSelector := browserUseTraceTarget(arguments)
+	before := browserUseChromeExtCurrentPageInfoSafe(ctx)
 	if err := browserUseChromeExtClick(ctx, arguments); err != nil {
+		browserUseRecordProviderWebActionTrace(b.provider, browserUseWebActionTraceStep{
+			Summary:     fmt.Sprintf("click %s", targetSummary),
+			Kind:        "click",
+			Selector:    traceSelector,
+			Target:      targetSummary,
+			URLBefore:   before.URL,
+			TitleBefore: before.Title,
+			Status:      "failed",
+			Error:       err.Error(),
+		})
 		return chromeConnectErrorWithState(fmt.Sprintf("browser use click failed: %s", err.Error())), nil
 	}
+	after := browserUseChromeExtCurrentPageInfoSafe(ctx)
+	browserUseRecordProviderWebActionTrace(b.provider, browserUseWebActionTraceStep{
+		Summary:     fmt.Sprintf("click %s", targetSummary),
+		Kind:        "click",
+		Selector:    traceSelector,
+		Target:      targetSummary,
+		URLBefore:   before.URL,
+		URLAfter:    after.URL,
+		TitleBefore: before.Title,
+		TitleAfter:  after.Title,
+		Outcome:     browserUseTraceOutcome("click", before, after),
+		Status:      "success",
+	})
 	return chromeConnectTextWithState("Clicked. Call browser_use_snapshot before the next indexed action."), nil
 }
 
-type chromeConnectTypeBuiltin struct{}
+type chromeConnectTypeBuiltin struct{ provider *BrowserUseTool }
 
 func (b *chromeConnectTypeBuiltin) GetName() string { return "browser_use_type" }
 func (b *chromeConnectTypeBuiltin) GetDescription() string {
-	return "Type text into an indexed input-like element or a CSS selector from the latest browser_use_snapshot. Set clear=true to replace the current field content. Verify with browser_use_snapshot before relying on indexes or claiming the input was accepted."
+	return browserUseWithWebActionReflection("Type text into an indexed input-like element or a CSS selector from the latest browser_use_snapshot. Set clear=true to replace the current field content. Verify with browser_use_snapshot before relying on indexes or claiming the input was accepted.")
 }
 
 func (b *chromeConnectTypeBuiltin) GetInputSchema() interface{} {
@@ -684,17 +766,51 @@ func (b *chromeConnectTypeBuiltin) GetInputSchema() interface{} {
 }
 
 func (b *chromeConnectTypeBuiltin) Execute(ctx context.Context, arguments map[string]interface{}) (*protocol.CallToolResult, error) {
+	targetSummary, traceSelector := browserUseTraceTarget(arguments)
+	text, _ := arguments["text"].(string)
+	clear := true
+	if value, ok := arguments["clear"].(bool); ok {
+		clear = value
+	}
+	before := browserUseChromeExtCurrentPageInfoSafe(ctx)
 	if err := browserUseChromeExtType(ctx, arguments); err != nil {
+		browserUseRecordProviderWebActionTrace(b.provider, browserUseWebActionTraceStep{
+			Summary:     fmt.Sprintf("type into %s", targetSummary),
+			Kind:        "type",
+			Selector:    traceSelector,
+			Target:      targetSummary,
+			Text:        text,
+			Clear:       &clear,
+			URLBefore:   before.URL,
+			TitleBefore: before.Title,
+			Status:      "failed",
+			Error:       err.Error(),
+		})
 		return chromeConnectErrorWithState(fmt.Sprintf("browser use type failed: %s", err.Error())), nil
 	}
+	after := browserUseChromeExtCurrentPageInfoSafe(ctx)
+	browserUseRecordProviderWebActionTrace(b.provider, browserUseWebActionTraceStep{
+		Summary:     fmt.Sprintf("type into %s", targetSummary),
+		Kind:        "type",
+		Selector:    traceSelector,
+		Target:      targetSummary,
+		Text:        text,
+		Clear:       &clear,
+		URLBefore:   before.URL,
+		URLAfter:    after.URL,
+		TitleBefore: before.Title,
+		TitleAfter:  after.Title,
+		Outcome:     browserUseTraceOutcome("type", before, after),
+		Status:      "success",
+	})
 	return chromeConnectTextWithState("Typed. Call browser_use_snapshot before the next indexed action or before claiming the page accepted the input."), nil
 }
 
-type chromeConnectPressBuiltin struct{}
+type chromeConnectPressBuiltin struct{ provider *BrowserUseTool }
 
 func (b *chromeConnectPressBuiltin) GetName() string { return "browser_use_press" }
 func (b *chromeConnectPressBuiltin) GetDescription() string {
-	return "Press a keyboard key in the controlled Chrome tab, such as Enter, Tab, Escape, ArrowDown, or Space. A key press can submit a form, navigate, or change focus; call browser_use_snapshot before the next indexed action."
+	return browserUseWithWebActionReflection("Press a keyboard key in the controlled Chrome tab, such as Enter, Tab, Escape, ArrowDown, or Space. A key press can submit a form, navigate, or change focus; call browser_use_snapshot before the next indexed action.")
 }
 
 func (b *chromeConnectPressBuiltin) GetInputSchema() interface{} {
@@ -716,9 +832,34 @@ func (b *chromeConnectPressBuiltin) Execute(ctx context.Context, arguments map[s
 	if !ok || strings.TrimSpace(key) == "" {
 		return browserToolError("missing required parameter: key"), nil
 	}
-	if err := browserUseChromeExtPress(ctx, strings.TrimSpace(key)); err != nil {
+	key = strings.TrimSpace(key)
+	before := browserUseChromeExtCurrentPageInfoSafe(ctx)
+	if err := browserUseChromeExtPress(ctx, key); err != nil {
+		browserUseRecordProviderWebActionTrace(b.provider, browserUseWebActionTraceStep{
+			Summary:     fmt.Sprintf("press %s", key),
+			Kind:        "press",
+			Target:      key,
+			Key:         key,
+			URLBefore:   before.URL,
+			TitleBefore: before.Title,
+			Status:      "failed",
+			Error:       err.Error(),
+		})
 		return chromeConnectErrorWithState(fmt.Sprintf("browser use press failed for %s: %s", key, err.Error())), nil
 	}
+	after := browserUseChromeExtCurrentPageInfoSafe(ctx)
+	browserUseRecordProviderWebActionTrace(b.provider, browserUseWebActionTraceStep{
+		Summary:     fmt.Sprintf("press %s", key),
+		Kind:        "press",
+		Target:      key,
+		Key:         key,
+		URLBefore:   before.URL,
+		URLAfter:    after.URL,
+		TitleBefore: before.Title,
+		TitleAfter:  after.Title,
+		Outcome:     browserUseTraceOutcome("press", before, after),
+		Status:      "success",
+	})
 	return chromeConnectTextWithState("Key pressed. Call browser_use_snapshot before the next indexed action."), nil
 }
 
@@ -726,7 +867,7 @@ type chromeConnectPlayMediaBuiltin struct{}
 
 func (b *chromeConnectPlayMediaBuiltin) GetName() string { return "browser_use_play_media" }
 func (b *chromeConnectPlayMediaBuiltin) GetDescription() string {
-	return "Play and unmute visible audio or video elements on the Browser Use controlled tab via the OpenAgent Chrome extension. Use this after opening a page with media if playback is paused or muted."
+	return browserUseWithWebActionReflection("Play and unmute visible audio or video elements on the Browser Use controlled tab via the OpenAgent Chrome extension. Use this after opening a page with media if playback is paused or muted.")
 }
 
 func (b *chromeConnectPlayMediaBuiltin) GetInputSchema() interface{} {
@@ -749,7 +890,7 @@ type chromeConnectTabsBuiltin struct{}
 
 func (b *chromeConnectTabsBuiltin) GetName() string { return "browser_use_tabs" }
 func (b *chromeConnectTabsBuiltin) GetDescription() string {
-	return "List open Chrome tabs available via the OpenAgent Chrome extension, including active, controlled, and protected tab markers, titles, and URLs. Use this before switching tabs or when the current page does not match what the user sees."
+	return browserUseWithWebActionReflection("List open Chrome tabs available via the OpenAgent Chrome extension, including active, controlled, and protected tab markers, titles, and URLs. Use this before switching tabs or when the current page does not match what the user sees.")
 }
 
 func (b *chromeConnectTabsBuiltin) GetInputSchema() interface{} {
@@ -768,11 +909,11 @@ func (b *chromeConnectTabsBuiltin) Execute(ctx context.Context, arguments map[st
 	return chromeConnectTextWithState(browserUseFormatTabs(tabs)), nil
 }
 
-type chromeConnectSwitchTabBuiltin struct{}
+type chromeConnectSwitchTabBuiltin struct{ provider *BrowserUseTool }
 
 func (b *chromeConnectSwitchTabBuiltin) GetName() string { return "browser_use_switch_tab" }
 func (b *chromeConnectSwitchTabBuiltin) GetDescription() string {
-	return "Switch Browser Use to a tab returned by browser_use_tabs via the OpenAgent Chrome extension. Protected OpenAgent UI tabs cannot be controlled. Returns a fresh snapshot and browser state for the selected tab."
+	return browserUseWithWebActionReflection("Switch Browser Use to a tab returned by browser_use_tabs via the OpenAgent Chrome extension. Protected OpenAgent UI tabs cannot be controlled. Returns a fresh snapshot and browser state for the selected tab.")
 }
 
 func (b *chromeConnectSwitchTabBuiltin) GetInputSchema() interface{} {
@@ -801,7 +942,7 @@ func (b *chromeConnectSwitchTabBuiltin) Execute(ctx context.Context, arguments m
 	if err = browserUseChromeExtSwitchTab(ctx, index); err != nil {
 		return chromeConnectErrorWithState(fmt.Sprintf("browser use switch tab failed: %s", err.Error())), nil
 	}
-	snapshot, err := browserUseChromeExtSnapshot(ctx)
+	snapshot, err := browserUseChromeExtSnapshot(b.provider, ctx)
 	if err != nil {
 		return chromeConnectErrorWithState(fmt.Sprintf("browser use snapshot failed after switching tabs: %s", err.Error())), nil
 	}
@@ -812,7 +953,7 @@ type chromeConnectCloseTabBuiltin struct{}
 
 func (b *chromeConnectCloseTabBuiltin) GetName() string { return "browser_use_close_tab" }
 func (b *chromeConnectCloseTabBuiltin) GetDescription() string {
-	return "Close a Chrome tab returned by browser_use_tabs via the OpenAgent Chrome extension. Use browser_use_tabs first, then pass the tab index to close."
+	return browserUseWithWebActionReflection("Close a Chrome tab returned by browser_use_tabs via the OpenAgent Chrome extension. Use browser_use_tabs first, then pass the tab index to close.")
 }
 
 func (b *chromeConnectCloseTabBuiltin) GetInputSchema() interface{} {
@@ -848,7 +989,7 @@ type chromeConnectCloseBuiltin struct{}
 
 func (b *chromeConnectCloseBuiltin) GetName() string { return "browser_use_close" }
 func (b *chromeConnectCloseBuiltin) GetDescription() string {
-	return "Disconnect the OpenAgent Chrome extension bridge. Only use this when the user explicitly asks to stop browser use; do not use it between related follow-up tasks. Chrome tabs are left open."
+	return browserUseWithWebActionReflection("Disconnect the OpenAgent Chrome extension bridge. Only use this when the user explicitly asks to stop browser use; do not use it between related follow-up tasks. Chrome tabs are left open.")
 }
 
 func (b *chromeConnectCloseBuiltin) GetInputSchema() interface{} {

--- a/tool/browser_use_chrome_ext.go
+++ b/tool/browser_use_chrome_ext.go
@@ -595,7 +595,7 @@ type chromeConnectOpenBuiltin struct{ provider *BrowserUseTool }
 
 func (b *chromeConnectOpenBuiltin) GetName() string { return "browser_use_open" }
 func (b *chromeConnectOpenBuiltin) GetDescription() string {
-	return browserUseWithWebActionReflection("Navigate the Browser Use controlled tab in your existing Chrome browser to a URL via the OpenAgent Chrome extension. OpenAgent UI tabs are protected and Browser Use operates a separate controlled tab. Use this for real browser tasks only; do not claim a page was opened unless this tool succeeds. Returns a fresh snapshot plus current browser state.")
+	return browserUseDescription("Navigate the Browser Use controlled tab in your existing Chrome browser to a URL via the OpenAgent Chrome extension. OpenAgent UI tabs are protected and Browser Use operates a separate controlled tab. Use this for real browser tasks only; do not claim a page was opened unless this tool succeeds. Returns a fresh snapshot plus current browser state.")
 }
 
 func (b *chromeConnectOpenBuiltin) GetInputSchema() interface{} {
@@ -656,7 +656,7 @@ type chromeConnectSnapshotBuiltin struct{ provider *BrowserUseTool }
 
 func (b *chromeConnectSnapshotBuiltin) GetName() string { return "browser_use_snapshot" }
 func (b *chromeConnectSnapshotBuiltin) GetDescription() string {
-	return browserUseWithWebActionReflection("Read the Browser Use controlled tab in your existing Chrome browser via the OpenAgent Chrome extension and return visible text, indexed interactive elements, URL, title, controlled tab index, tab count, and media state. Treat this as the source of truth before acting. Use it at the start of a follow-up request and after every navigation, click, type, or key press before reusing element indexes.")
+	return browserUseDescription("Read the Browser Use controlled tab in your existing Chrome browser via the OpenAgent Chrome extension and return visible text, indexed interactive elements, URL, title, controlled tab index, tab count, and media state. Treat this as the source of truth before acting. Use it at the start of a follow-up request and after every navigation, click, type, or key press before reusing element indexes.")
 }
 
 func (b *chromeConnectSnapshotBuiltin) GetInputSchema() interface{} {
@@ -679,7 +679,7 @@ type chromeConnectClickBuiltin struct{ provider *BrowserUseTool }
 
 func (b *chromeConnectClickBuiltin) GetName() string { return "browser_use_click" }
 func (b *chromeConnectClickBuiltin) GetDescription() string {
-	return browserUseWithWebActionReflection("Click an indexed element from the latest browser_use_snapshot, or a CSS selector when no index is available. The click may navigate, open a new tab, or change the DOM, so old indexes must be considered stale afterward. Call browser_use_snapshot before the next indexed action.")
+	return browserUseDescription("Click an indexed element from the latest browser_use_snapshot, or a CSS selector when no index is available. The click may navigate, open a new tab, or change the DOM, so old indexes must be considered stale afterward. Call browser_use_snapshot before the next indexed action.")
 }
 
 func (b *chromeConnectClickBuiltin) GetInputSchema() interface{} {
@@ -735,7 +735,7 @@ type chromeConnectTypeBuiltin struct{ provider *BrowserUseTool }
 
 func (b *chromeConnectTypeBuiltin) GetName() string { return "browser_use_type" }
 func (b *chromeConnectTypeBuiltin) GetDescription() string {
-	return browserUseWithWebActionReflection("Type text into an indexed input-like element or a CSS selector from the latest browser_use_snapshot. Set clear=true to replace the current field content. Verify with browser_use_snapshot before relying on indexes or claiming the input was accepted.")
+	return browserUseDescription("Type text into an indexed input-like element or a CSS selector from the latest browser_use_snapshot. Set clear=true to replace the current field content. Verify with browser_use_snapshot before relying on indexes or claiming the input was accepted.")
 }
 
 func (b *chromeConnectTypeBuiltin) GetInputSchema() interface{} {
@@ -810,7 +810,7 @@ type chromeConnectPressBuiltin struct{ provider *BrowserUseTool }
 
 func (b *chromeConnectPressBuiltin) GetName() string { return "browser_use_press" }
 func (b *chromeConnectPressBuiltin) GetDescription() string {
-	return browserUseWithWebActionReflection("Press a keyboard key in the controlled Chrome tab, such as Enter, Tab, Escape, ArrowDown, or Space. A key press can submit a form, navigate, or change focus; call browser_use_snapshot before the next indexed action.")
+	return browserUseDescription("Press a keyboard key in the controlled Chrome tab, such as Enter, Tab, Escape, ArrowDown, or Space. A key press can submit a form, navigate, or change focus; call browser_use_snapshot before the next indexed action.")
 }
 
 func (b *chromeConnectPressBuiltin) GetInputSchema() interface{} {
@@ -867,7 +867,7 @@ type chromeConnectPlayMediaBuiltin struct{}
 
 func (b *chromeConnectPlayMediaBuiltin) GetName() string { return "browser_use_play_media" }
 func (b *chromeConnectPlayMediaBuiltin) GetDescription() string {
-	return browserUseWithWebActionReflection("Play and unmute visible audio or video elements on the Browser Use controlled tab via the OpenAgent Chrome extension. Use this after opening a page with media if playback is paused or muted.")
+	return browserUseDescription("Play and unmute visible audio or video elements on the Browser Use controlled tab via the OpenAgent Chrome extension. Use this after opening a page with media if playback is paused or muted.")
 }
 
 func (b *chromeConnectPlayMediaBuiltin) GetInputSchema() interface{} {
@@ -890,7 +890,7 @@ type chromeConnectTabsBuiltin struct{}
 
 func (b *chromeConnectTabsBuiltin) GetName() string { return "browser_use_tabs" }
 func (b *chromeConnectTabsBuiltin) GetDescription() string {
-	return browserUseWithWebActionReflection("List open Chrome tabs available via the OpenAgent Chrome extension, including active, controlled, and protected tab markers, titles, and URLs. Use this before switching tabs or when the current page does not match what the user sees.")
+	return browserUseDescription("List open Chrome tabs available via the OpenAgent Chrome extension, including active, controlled, and protected tab markers, titles, and URLs. Use this before switching tabs or when the current page does not match what the user sees.")
 }
 
 func (b *chromeConnectTabsBuiltin) GetInputSchema() interface{} {
@@ -913,7 +913,7 @@ type chromeConnectSwitchTabBuiltin struct{ provider *BrowserUseTool }
 
 func (b *chromeConnectSwitchTabBuiltin) GetName() string { return "browser_use_switch_tab" }
 func (b *chromeConnectSwitchTabBuiltin) GetDescription() string {
-	return browserUseWithWebActionReflection("Switch Browser Use to a tab returned by browser_use_tabs via the OpenAgent Chrome extension. Protected OpenAgent UI tabs cannot be controlled. Returns a fresh snapshot and browser state for the selected tab.")
+	return browserUseDescription("Switch Browser Use to a tab returned by browser_use_tabs via the OpenAgent Chrome extension. Protected OpenAgent UI tabs cannot be controlled. Returns a fresh snapshot and browser state for the selected tab.")
 }
 
 func (b *chromeConnectSwitchTabBuiltin) GetInputSchema() interface{} {
@@ -953,7 +953,7 @@ type chromeConnectCloseTabBuiltin struct{}
 
 func (b *chromeConnectCloseTabBuiltin) GetName() string { return "browser_use_close_tab" }
 func (b *chromeConnectCloseTabBuiltin) GetDescription() string {
-	return browserUseWithWebActionReflection("Close a Chrome tab returned by browser_use_tabs via the OpenAgent Chrome extension. Use browser_use_tabs first, then pass the tab index to close.")
+	return browserUseDescription("Close a Chrome tab returned by browser_use_tabs via the OpenAgent Chrome extension. Use browser_use_tabs first, then pass the tab index to close.")
 }
 
 func (b *chromeConnectCloseTabBuiltin) GetInputSchema() interface{} {
@@ -989,7 +989,7 @@ type chromeConnectCloseBuiltin struct{}
 
 func (b *chromeConnectCloseBuiltin) GetName() string { return "browser_use_close" }
 func (b *chromeConnectCloseBuiltin) GetDescription() string {
-	return browserUseWithWebActionReflection("Disconnect the OpenAgent Chrome extension bridge. Only use this when the user explicitly asks to stop browser use; do not use it between related follow-up tasks. Chrome tabs are left open.")
+	return browserUseDescription("Disconnect the OpenAgent Chrome extension bridge. Only use this when the user explicitly asks to stop browser use; do not use it between related follow-up tasks. Chrome tabs are left open.")
 }
 
 func (b *chromeConnectCloseBuiltin) GetInputSchema() interface{} {

--- a/tool/browser_use_web_action.go
+++ b/tool/browser_use_web_action.go
@@ -137,8 +137,12 @@ const browserUseWebActionReflectionPrompt = "After using this browser_use tool, 
 
 var browserUseWebActionPlaceholderPattern = regexp.MustCompile(`\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}`)
 
-func browserUseWithWebActionReflection(description string) string {
-	return strings.TrimSpace(description) + " " + browserUseWebActionReflectionPrompt
+func browserUseDescription(description string) string {
+	return strings.TrimSpace(description)
+}
+
+func GetBrowserUseWebActionReflectionPrompt() string {
+	return browserUseWebActionReflectionPrompt
 }
 
 func browserUseDefaultOwner(owner string) string {
@@ -1322,7 +1326,7 @@ type browserUseListWebActionsBuiltin struct{ provider *BrowserUseTool }
 func (b *browserUseListWebActionsBuiltin) GetName() string { return "browser_use_list_web_actions" }
 
 func (b *browserUseListWebActionsBuiltin) GetDescription() string {
-	return browserUseWithWebActionReflection("List executable Browser Web Actions, including required variables inferred from {{placeholders}} in the saved action script.")
+	return browserUseDescription("List executable Browser Web Actions, including required variables inferred from {{placeholders}} in the saved action script.")
 }
 
 func (b *browserUseListWebActionsBuiltin) GetInputSchema() interface{} {
@@ -1351,7 +1355,7 @@ func (b *browserUseInspectWebActionTraceBuiltin) GetName() string {
 }
 
 func (b *browserUseInspectWebActionTraceBuiltin) GetDescription() string {
-	return browserUseWithWebActionReflection("Inspect recent Browser Use trace steps so the model can review prior attempts before authoring an explicit parameterized Browser Web Action steps array.")
+	return browserUseDescription("Inspect recent Browser Use trace steps so the model can review prior attempts before authoring an explicit parameterized Browser Web Action steps array.")
 }
 
 func (b *browserUseInspectWebActionTraceBuiltin) GetInputSchema() interface{} {
@@ -1373,7 +1377,7 @@ type browserUseSaveWebActionBuiltin struct{ provider *BrowserUseTool }
 func (b *browserUseSaveWebActionBuiltin) GetName() string { return "browser_use_save_web_action" }
 
 func (b *browserUseSaveWebActionBuiltin) GetDescription() string {
-	return browserUseWithWebActionReflection("Save an executable Browser Web Action under an action group. Provide an explicit parameterized steps array using open, click, type, and press steps; do not reference trace step ids.")
+	return browserUseDescription("Save an executable Browser Web Action under an action group. Provide an explicit parameterized steps array using open, click, type, and press steps; do not reference trace step ids.")
 }
 
 func (b *browserUseSaveWebActionBuiltin) GetInputSchema() interface{} {
@@ -1393,7 +1397,7 @@ type browserUseRunWebActionBuiltin struct{ provider *BrowserUseTool }
 func (b *browserUseRunWebActionBuiltin) GetName() string { return "browser_use_run_web_action" }
 
 func (b *browserUseRunWebActionBuiltin) GetDescription() string {
-	return browserUseWithWebActionReflection("Run a saved executable Browser Web Action. Use variables to fill {{placeholder}} values captured in the action script.")
+	return browserUseDescription("Run a saved executable Browser Web Action. Use variables to fill {{placeholder}} values captured in the action script.")
 }
 
 func (b *browserUseRunWebActionBuiltin) GetInputSchema() interface{} {
@@ -1422,7 +1426,7 @@ type browserUseDeleteWebActionBuiltin struct{ provider *BrowserUseTool }
 func (b *browserUseDeleteWebActionBuiltin) GetName() string { return "browser_use_delete_web_action" }
 
 func (b *browserUseDeleteWebActionBuiltin) GetDescription() string {
-	return browserUseWithWebActionReflection("Delete a saved executable Browser Web Action. Pass action_group when multiple action groups have an action with the same name.")
+	return browserUseDescription("Delete a saved executable Browser Web Action. Pass action_group when multiple action groups have an action with the same name.")
 }
 
 func (b *browserUseDeleteWebActionBuiltin) GetInputSchema() interface{} {
@@ -1442,7 +1446,7 @@ type chromeConnectListWebActionsBuiltin struct{ provider *BrowserUseTool }
 func (b *chromeConnectListWebActionsBuiltin) GetName() string { return "browser_use_list_web_actions" }
 
 func (b *chromeConnectListWebActionsBuiltin) GetDescription() string {
-	return browserUseWithWebActionReflection("List executable Browser Web Actions, including required variables inferred from {{placeholders}} in the saved action script.")
+	return browserUseDescription("List executable Browser Web Actions, including required variables inferred from {{placeholders}} in the saved action script.")
 }
 
 func (b *chromeConnectListWebActionsBuiltin) GetInputSchema() interface{} {
@@ -1471,7 +1475,7 @@ func (b *chromeConnectInspectWebActionTraceBuiltin) GetName() string {
 }
 
 func (b *chromeConnectInspectWebActionTraceBuiltin) GetDescription() string {
-	return browserUseWithWebActionReflection("Inspect recent Browser Use trace steps so the model can review prior attempts before authoring an explicit parameterized Browser Web Action steps array.")
+	return browserUseDescription("Inspect recent Browser Use trace steps so the model can review prior attempts before authoring an explicit parameterized Browser Web Action steps array.")
 }
 
 func (b *chromeConnectInspectWebActionTraceBuiltin) GetInputSchema() interface{} {
@@ -1493,7 +1497,7 @@ type chromeConnectSaveWebActionBuiltin struct{ provider *BrowserUseTool }
 func (b *chromeConnectSaveWebActionBuiltin) GetName() string { return "browser_use_save_web_action" }
 
 func (b *chromeConnectSaveWebActionBuiltin) GetDescription() string {
-	return browserUseWithWebActionReflection("Save an executable Browser Web Action under an action group. Provide an explicit parameterized steps array using open, click, type, and press steps; do not reference trace step ids.")
+	return browserUseDescription("Save an executable Browser Web Action under an action group. Provide an explicit parameterized steps array using open, click, type, and press steps; do not reference trace step ids.")
 }
 
 func (b *chromeConnectSaveWebActionBuiltin) GetInputSchema() interface{} {
@@ -1513,7 +1517,7 @@ type chromeConnectRunWebActionBuiltin struct{ provider *BrowserUseTool }
 func (b *chromeConnectRunWebActionBuiltin) GetName() string { return "browser_use_run_web_action" }
 
 func (b *chromeConnectRunWebActionBuiltin) GetDescription() string {
-	return browserUseWithWebActionReflection("Run a saved executable Browser Web Action via the OpenAgent Chrome extension.")
+	return browserUseDescription("Run a saved executable Browser Web Action via the OpenAgent Chrome extension.")
 }
 
 func (b *chromeConnectRunWebActionBuiltin) GetInputSchema() interface{} {
@@ -1544,7 +1548,7 @@ func (b *chromeConnectDeleteWebActionBuiltin) GetName() string {
 }
 
 func (b *chromeConnectDeleteWebActionBuiltin) GetDescription() string {
-	return browserUseWithWebActionReflection("Delete a saved executable Browser Web Action. Pass action_group when multiple action groups have an action with the same name.")
+	return browserUseDescription("Delete a saved executable Browser Web Action. Pass action_group when multiple action groups have an action with the same name.")
 }
 
 func (b *chromeConnectDeleteWebActionBuiltin) GetInputSchema() interface{} {

--- a/tool/browser_use_web_action.go
+++ b/tool/browser_use_web_action.go
@@ -1,0 +1,1560 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tool
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ThinkInAIXYZ/go-mcp/protocol"
+	"github.com/chromedp/cdproto/page"
+	"github.com/chromedp/chromedp"
+	"golang.org/x/net/publicsuffix"
+)
+
+type browserUsePageInfo struct {
+	URL   string
+	Title string
+}
+
+type browserUseWebAction struct {
+	ActionGroup string `json:"action_group"`
+	Name        string `json:"name"`
+	URL         string `json:"url"`
+	Action      string `json:"action"`
+	Script      string `json:"script"`
+	UpdatedTime string `json:"updatedTime"`
+}
+
+type BrowserUseWebActionData = browserUseWebAction
+
+type BrowserUseWebActionFilter struct {
+	ActionGroup string
+	Name        string
+	URL         string
+}
+
+var browserUseWebActionStoreMu sync.RWMutex
+
+var browserUseListWebActionsFunc func(owner string) ([]BrowserUseWebActionData, error)
+
+var browserUseListWebActionsByActionGroupsFunc func(owner string, actionGroups []string) ([]BrowserUseWebActionData, error)
+
+var browserUseUpsertWebActionFunc func(owner string, action BrowserUseWebActionData) (BrowserUseWebActionData, error)
+
+var browserUseDeleteWebActionFunc func(owner, actionGroup, name string) (bool, error)
+
+func SetBrowserUseWebActionStore(
+	list func(owner string) ([]BrowserUseWebActionData, error),
+	upsert func(owner string, action BrowserUseWebActionData) (BrowserUseWebActionData, error),
+	deleteAction func(owner, actionGroup, name string) (bool, error),
+	listByActionGroups ...func(owner string, actionGroups []string) ([]BrowserUseWebActionData, error),
+) {
+	browserUseWebActionStoreMu.Lock()
+	defer browserUseWebActionStoreMu.Unlock()
+
+	browserUseListWebActionsFunc = list
+	browserUseUpsertWebActionFunc = upsert
+	browserUseDeleteWebActionFunc = deleteAction
+	browserUseListWebActionsByActionGroupsFunc = nil
+	if len(listByActionGroups) > 0 {
+		browserUseListWebActionsByActionGroupsFunc = listByActionGroups[0]
+	}
+}
+
+type browserUseWebActionTraceStep struct {
+	ID          string `json:"step_id"`
+	Sequence    int64  `json:"sequence"`
+	Time        string `json:"time"`
+	Summary     string `json:"summary"`
+	Kind        string `json:"kind"`
+	Selector    string `json:"selector,omitempty"`
+	Target      string `json:"target,omitempty"`
+	URL         string `json:"url,omitempty"`
+	Text        string `json:"text,omitempty"`
+	Clear       *bool  `json:"clear,omitempty"`
+	Key         string `json:"key,omitempty"`
+	URLBefore   string `json:"url_before,omitempty"`
+	URLAfter    string `json:"url_after,omitempty"`
+	TitleBefore string `json:"title_before,omitempty"`
+	TitleAfter  string `json:"title_after,omitempty"`
+	Outcome     string `json:"outcome,omitempty"`
+	Status      string `json:"status"`
+	Error       string `json:"error,omitempty"`
+}
+
+type browserUseWebActionScriptStep struct {
+	Kind           string   `json:"kind"`
+	Selector       string   `json:"selector,omitempty"`
+	SourceSelector string   `json:"sourceSelector,omitempty"`
+	TargetSelector string   `json:"targetSelector,omitempty"`
+	URL            string   `json:"url,omitempty"`
+	Text           string   `json:"text,omitempty"`
+	Clear          *bool    `json:"clear,omitempty"`
+	Key            string   `json:"key,omitempty"`
+	X              *float64 `json:"x,omitempty"`
+	Y              *float64 `json:"y,omitempty"`
+	Button         string   `json:"button,omitempty"`
+	DoubleClick    bool     `json:"doubleClick,omitempty"`
+	CtrlKey        bool     `json:"ctrlKey,omitempty"`
+	ShiftKey       bool     `json:"shiftKey,omitempty"`
+	AltKey         bool     `json:"altKey,omitempty"`
+	MetaKey        bool     `json:"metaKey,omitempty"`
+	Summary        string   `json:"summary,omitempty"`
+}
+
+type browserUseWebActionTraceState struct {
+	NextSequence int64
+	Steps        []browserUseWebActionTraceStep
+}
+
+var browserUseWebActionTraceMu sync.Mutex
+
+var browserUseWebActionTraces = map[string]*browserUseWebActionTraceState{}
+
+const browserUseWebActionTraceLimit = 200
+
+const browserUseWebActionReflectionPrompt = "After using this browser_use tool, reflect whether a successful repeatable workflow should be saved or updated as a browser web action. Use browser_use_inspect_web_action_trace for review, then browser_use_save_web_action with an explicit parameterized steps array. The user does not need to explicitly ask for this; skip only one-off, uncertain, or failed workflows."
+
+var browserUseWebActionPlaceholderPattern = regexp.MustCompile(`\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}`)
+
+func browserUseWithWebActionReflection(description string) string {
+	return strings.TrimSpace(description) + " " + browserUseWebActionReflectionPrompt
+}
+
+func browserUseDefaultOwner(owner string) string {
+	owner = strings.TrimSpace(owner)
+	if owner == "" {
+		owner = "admin"
+	}
+	return owner
+}
+
+func browserUseRecordWebActionTrace(traceKey string, step browserUseWebActionTraceStep) browserUseWebActionTraceStep {
+	traceKey = browserUseDefaultOwner(traceKey)
+	browserUseWebActionTraceMu.Lock()
+	defer browserUseWebActionTraceMu.Unlock()
+
+	state := browserUseWebActionTraces[traceKey]
+	if state == nil {
+		state = &browserUseWebActionTraceState{}
+		browserUseWebActionTraces[traceKey] = state
+	}
+	state.NextSequence++
+	step.Sequence = state.NextSequence
+	step.ID = fmt.Sprintf("bua_%06d", step.Sequence)
+	if strings.TrimSpace(step.Time) == "" {
+		step.Time = time.Now().UTC().Format(time.RFC3339)
+	}
+	if strings.TrimSpace(step.Status) == "" {
+		step.Status = "success"
+	}
+	state.Steps = append(state.Steps, step)
+	if len(state.Steps) > browserUseWebActionTraceLimit {
+		state.Steps = state.Steps[len(state.Steps)-browserUseWebActionTraceLimit:]
+	}
+	return step
+}
+
+func browserUseTraceSteps(owner string) []browserUseWebActionTraceStep {
+	owner = browserUseDefaultOwner(owner)
+	browserUseWebActionTraceMu.Lock()
+	defer browserUseWebActionTraceMu.Unlock()
+
+	state := browserUseWebActionTraces[owner]
+	if state == nil {
+		return []browserUseWebActionTraceStep{}
+	}
+	steps := make([]browserUseWebActionTraceStep, len(state.Steps))
+	copy(steps, state.Steps)
+	return steps
+}
+
+func browserUseValidateWebActionScriptStep(actionName string, index int, step browserUseWebActionScriptStep) error {
+	kind := browserUseNormalizeWebActionStepKind(step.Kind)
+	switch kind {
+	case "open":
+		if strings.TrimSpace(step.URL) == "" {
+			return fmt.Errorf("web action %q has invalid steps: step %d is an open step but has no url; save it again with an explicit parameterized steps array", actionName, index+1)
+		}
+	case "click":
+		if strings.TrimSpace(step.Selector) == "" && (step.X == nil || step.Y == nil) {
+			return fmt.Errorf("web action %q has invalid steps: step %d is a click step but has no selector or viewport x/y coordinates; save it again with an explicit parameterized steps array", actionName, index+1)
+		}
+	case "type":
+		if strings.TrimSpace(step.Selector) == "" && (step.X == nil || step.Y == nil) {
+			return fmt.Errorf("web action %q has invalid steps: step %d is a type step but has no selector or viewport x/y coordinates; save it again with an explicit parameterized steps array", actionName, index+1)
+		}
+	case "press":
+		if strings.TrimSpace(step.Key) == "" {
+			return fmt.Errorf("web action %q has invalid steps: step %d is a press step but has no key; save it again with an explicit parameterized steps array", actionName, index+1)
+		}
+	case "drag_and_drop":
+		if strings.TrimSpace(step.SourceSelector) == "" || strings.TrimSpace(step.TargetSelector) == "" {
+			return fmt.Errorf("web action %q has invalid steps: step %d is a drag_and_drop step but has no sourceSelector or targetSelector; save it again with an explicit parameterized steps array", actionName, index+1)
+		}
+	case "":
+		return fmt.Errorf("web action %q is not executable: step %d is missing its action kind. Save it again with explicit parameterized steps, for example [{\"kind\":\"open\",\"url\":\"https://example.com/search?q={{query}}\"}, {\"kind\":\"click\",\"selector\":\"button[type=submit]\"}]", actionName, index+1)
+	default:
+		return fmt.Errorf("web action %q uses unsupported executable step kind %q at step %d. Supported kinds are open, click, type, press, and drag_and_drop. Save it again with explicit parameterized steps", actionName, kind, index+1)
+	}
+	return nil
+}
+
+func browserUseValidateWebActionScript(actionName string, steps []browserUseWebActionScriptStep) error {
+	if len(steps) == 0 {
+		return fmt.Errorf("web action %q is not executable because it has no steps. Save it again with an explicit parameterized steps array", actionName)
+	}
+	for i, step := range steps {
+		if err := browserUseValidateWebActionScriptStep(actionName, i, step); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func browserUseNormalizeWebActionStepKind(kind string) string {
+	switch strings.TrimSpace(kind) {
+	case "navigate":
+		return "open"
+	case "dblclick":
+		return "click"
+	default:
+		return strings.TrimSpace(kind)
+	}
+}
+
+func browserUseNormalizeWebActionScriptStep(step browserUseWebActionScriptStep) browserUseWebActionScriptStep {
+	originalKind := strings.TrimSpace(step.Kind)
+	step.Kind = browserUseNormalizeWebActionStepKind(originalKind)
+	if originalKind == "dblclick" {
+		step.DoubleClick = true
+	}
+	step.Selector = strings.TrimSpace(step.Selector)
+	step.SourceSelector = strings.TrimSpace(step.SourceSelector)
+	step.TargetSelector = strings.TrimSpace(step.TargetSelector)
+	step.URL = strings.TrimSpace(step.URL)
+	step.Key = strings.TrimSpace(step.Key)
+	step.Button = strings.TrimSpace(step.Button)
+	step.Summary = strings.TrimSpace(step.Summary)
+	return step
+}
+
+func browserUseNormalizeWebActionScriptSteps(steps []browserUseWebActionScriptStep) []browserUseWebActionScriptStep {
+	normalized := make([]browserUseWebActionScriptStep, 0, len(steps))
+	for _, step := range steps {
+		normalized = append(normalized, browserUseNormalizeWebActionScriptStep(step))
+	}
+	return normalized
+}
+
+func browserUseTraceSummary(step browserUseWebActionTraceStep) string {
+	parts := []string{fmt.Sprintf("%s: %s", step.ID, strings.TrimSpace(step.Summary))}
+	if step.Kind != "" {
+		parts = append(parts, "kind: "+step.Kind)
+	}
+	if step.Target != "" {
+		parts = append(parts, "target: "+step.Target)
+	} else if step.Selector != "" {
+		parts = append(parts, "selector: "+step.Selector)
+	}
+	if step.URLBefore != "" || step.URLAfter != "" {
+		parts = append(parts, fmt.Sprintf("transition: %s -> %s", step.URLBefore, step.URLAfter))
+	}
+	if step.TitleBefore != "" || step.TitleAfter != "" {
+		parts = append(parts, fmt.Sprintf("title: %s -> %s", step.TitleBefore, step.TitleAfter))
+	}
+	if step.Outcome != "" {
+		parts = append(parts, "outcome: "+step.Outcome)
+	}
+	if step.Error != "" {
+		parts = append(parts, "error: "+step.Error)
+	}
+	return strings.Join(parts, " | ")
+}
+
+func browserUseWebActionVariableNames(action browserUseWebAction) []string {
+	matches := browserUseWebActionPlaceholderPattern.FindAllStringSubmatch(action.Script+"\n"+action.URL, -1)
+	seen := map[string]bool{}
+	names := []string{}
+	for _, match := range matches {
+		if len(match) < 2 {
+			continue
+		}
+		name := strings.TrimSpace(match[1])
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func browserUseMissingWebActionVariables(action browserUseWebAction, variables map[string]string) []string {
+	missing := []string{}
+	for _, name := range browserUseWebActionVariableNames(action) {
+		if _, ok := variables[name]; !ok {
+			missing = append(missing, name)
+		}
+	}
+	return missing
+}
+
+func browserUseValidateWebActionVariables(action browserUseWebAction, variables map[string]string) error {
+	missing := browserUseMissingWebActionVariables(action, variables)
+	if len(missing) == 0 {
+		return nil
+	}
+	return fmt.Errorf("web action %q requires variables: %s. Pass them as {\"variables\":{%s}} when calling browser_use_run_web_action", action.Name, strings.Join(missing, ", "), browserUseFormatVariableExample(missing))
+}
+
+func browserUseFormatVariableExample(names []string) string {
+	parts := make([]string, 0, len(names))
+	for _, name := range names {
+		parts = append(parts, fmt.Sprintf("%q:%q", name, "value"))
+	}
+	return strings.Join(parts, ",")
+}
+
+func browserUsePageChanged(before, after browserUsePageInfo) bool {
+	return strings.TrimSpace(before.URL) != strings.TrimSpace(after.URL) ||
+		strings.TrimSpace(before.Title) != strings.TrimSpace(after.Title)
+}
+
+func browserUseTraceOutcome(kind string, before, after browserUsePageInfo) string {
+	if browserUsePageChanged(before, after) {
+		return "page changed"
+	}
+	switch strings.TrimSpace(kind) {
+	case "open":
+		return "navigation completed without an observed URL/title change"
+	case "click":
+		return "click completed; no URL/title change observed"
+	case "type":
+		return "text input completed; no URL/title change observed"
+	case "press":
+		return "key press completed; no URL/title change observed"
+	default:
+		return "completed; no URL/title change observed"
+	}
+}
+
+func browserUseTraceTarget(arguments map[string]interface{}) (string, string) {
+	if rawIndex, ok := arguments["index"]; ok {
+		if index, err := browserUsePositiveInt(rawIndex, "index"); err == nil {
+			return fmt.Sprintf("index=%d", index), fmt.Sprintf(`[data-openagent-browser-use-ref="%d"]`, index)
+		}
+	}
+	if selector, ok := arguments["selector"].(string); ok && strings.TrimSpace(selector) != "" {
+		selector = strings.TrimSpace(selector)
+		return fmt.Sprintf("selector=%s", selector), selector
+	}
+	return "target=unknown", ""
+}
+
+func browserUseWebActionOwner(provider *BrowserUseTool) string {
+	if provider == nil {
+		return ""
+	}
+	return strings.TrimSpace(provider.owner)
+}
+
+func browserUseTraceKey(provider *BrowserUseTool) string {
+	if provider == nil {
+		return browserUseWebActionOwner(provider)
+	}
+	if strings.TrimSpace(provider.traceKey) != "" {
+		return strings.TrimSpace(provider.traceKey)
+	}
+	return browserUseWebActionOwner(provider)
+}
+
+func browserUseRecordProviderWebActionTrace(provider *BrowserUseTool, step browserUseWebActionTraceStep) browserUseWebActionTraceStep {
+	return browserUseRecordWebActionTrace(browserUseTraceKey(provider), step)
+}
+
+func browserUseCurrentPageInfo(provider *BrowserUseTool) (browserUsePageInfo, error) {
+	page := browserUsePageInfo{}
+	err := provider.run(
+		chromedp.Title(&page.Title),
+		chromedp.Location(&page.URL),
+	)
+	return page, err
+}
+
+func browserUseCurrentPageInfoSafe(provider *BrowserUseTool) browserUsePageInfo {
+	if provider == nil {
+		return browserUsePageInfo{}
+	}
+	page, err := browserUseCurrentPageInfo(provider)
+	if err != nil {
+		return browserUsePageInfo{}
+	}
+	return page
+}
+
+func browserUseChromeExtCurrentPageInfo(ctx context.Context) (browserUsePageInfo, error) {
+	state := browserUseChromeExtState{}
+	if err := browserUseChromeExtCall(ctx, "state", map[string]interface{}{}, &state); err != nil {
+		return browserUsePageInfo{}, err
+	}
+	return browserUsePageInfo{
+		URL:   strings.TrimSpace(state.Tab.URL),
+		Title: strings.TrimSpace(state.Tab.Title),
+	}, nil
+}
+
+func browserUseChromeExtCurrentPageInfoSafe(ctx context.Context) browserUsePageInfo {
+	page, err := browserUseChromeExtCurrentPageInfo(ctx)
+	if err != nil {
+		return browserUsePageInfo{}
+	}
+	return page
+}
+
+func browserUseLoadWebActions(owner string) ([]browserUseWebAction, error) {
+	browserUseWebActionStoreMu.RLock()
+	list := browserUseListWebActionsFunc
+	browserUseWebActionStoreMu.RUnlock()
+
+	if list == nil {
+		return []browserUseWebAction{}, nil
+	}
+	actions, err := list(strings.TrimSpace(owner))
+	if err != nil {
+		return nil, err
+	}
+	browserUseNormalizeWebActions(actions)
+	return actions, nil
+}
+
+func browserUseNormalizeWebActions(actions []browserUseWebAction) {
+	for i := range actions {
+		actions[i].ActionGroup = strings.TrimSpace(actions[i].ActionGroup)
+		actions[i].Name = strings.TrimSpace(actions[i].Name)
+		actions[i].Action = strings.TrimSpace(actions[i].Action)
+		actions[i].Script = strings.TrimSpace(actions[i].Script)
+		actions[i].UpdatedTime = strings.TrimSpace(actions[i].UpdatedTime)
+	}
+}
+
+func browserUseLoadWebActionsByActionGroups(owner string, actionGroups []string) ([]browserUseWebAction, error) {
+	seen := map[string]bool{}
+	names := []string{}
+	for _, actionGroup := range actionGroups {
+		name := strings.TrimSpace(actionGroup)
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		names = append(names, name)
+	}
+	if len(names) == 0 {
+		return []browserUseWebAction{}, nil
+	}
+	browserUseWebActionStoreMu.RLock()
+	listByActionGroups := browserUseListWebActionsByActionGroupsFunc
+	browserUseWebActionStoreMu.RUnlock()
+
+	if listByActionGroups != nil {
+		actions, err := listByActionGroups(strings.TrimSpace(owner), names)
+		if err != nil {
+			return nil, err
+		}
+		browserUseNormalizeWebActions(actions)
+		return actions, nil
+	}
+	actions, err := browserUseLoadWebActions(owner)
+	if err != nil {
+		return nil, err
+	}
+	filtered := []browserUseWebAction{}
+	for _, action := range actions {
+		if seen[action.ActionGroup] {
+			filtered = append(filtered, action)
+		}
+	}
+	return filtered, nil
+}
+
+func browserUseFormatWebActions(actions []browserUseWebAction) string {
+	if len(actions) == 0 {
+		return "No browser web actions matched."
+	}
+	sort.SliceStable(actions, func(i, j int) bool {
+		if actions[i].ActionGroup != actions[j].ActionGroup {
+			return actions[i].ActionGroup < actions[j].ActionGroup
+		}
+		return actions[i].Name < actions[j].Name
+	})
+	var builder strings.Builder
+	builder.WriteString("Browser Web Actions:\n")
+	for _, action := range actions {
+		builder.WriteString(fmt.Sprintf("\n- %s / %s\n", action.ActionGroup, action.Name))
+		variables := browserUseWebActionVariableNames(action)
+		if len(variables) > 0 {
+			builder.WriteString(fmt.Sprintf("  required variables: %s\n", strings.Join(variables, ", ")))
+		} else {
+			builder.WriteString("  required variables: none\n")
+		}
+		if strings.TrimSpace(action.URL) != "" {
+			builder.WriteString(fmt.Sprintf("  start url: %s\n", strings.TrimSpace(action.URL)))
+		}
+		if strings.TrimSpace(action.Action) != "" {
+			for _, line := range strings.Split(strings.TrimSpace(action.Action), "\n") {
+				if strings.TrimSpace(line) != "" {
+					builder.WriteString("  ")
+					builder.WriteString(strings.TrimSpace(line))
+					builder.WriteString("\n")
+				}
+			}
+		}
+	}
+	return strings.TrimSpace(builder.String())
+}
+
+func browserUseListWebActionsText(owner string, arguments map[string]interface{}, defaultURL string) (string, error) {
+	actions, err := ListBrowserUseWebActions(owner, BrowserUseWebActionFilter{
+		ActionGroup: browserUseActionGroupArgument(arguments),
+		URL:         defaultURL,
+	})
+	if err != nil {
+		return "", err
+	}
+	return browserUseFormatWebActions(actions), nil
+}
+
+func ListBrowserUseWebActions(owner string, filter BrowserUseWebActionFilter) ([]BrowserUseWebActionData, error) {
+	actions, err := browserUseLoadWebActions(owner)
+	if err != nil {
+		return nil, err
+	}
+
+	filter.ActionGroup = strings.TrimSpace(filter.ActionGroup)
+	filter.Name = strings.TrimSpace(filter.Name)
+	filter.URL = strings.TrimSpace(filter.URL)
+
+	filtered := make([]BrowserUseWebActionData, 0, len(actions))
+	for _, action := range actions {
+		if filter.ActionGroup != "" && action.ActionGroup != filter.ActionGroup {
+			continue
+		}
+		if filter.Name != "" && action.Name != filter.Name {
+			continue
+		}
+		if filter.URL != "" && !browserUseWebActionMatchesURL(action.URL, filter.URL) {
+			continue
+		}
+		filtered = append(filtered, action)
+	}
+	sort.SliceStable(filtered, func(i, j int) bool {
+		if filtered[i].ActionGroup != filtered[j].ActionGroup {
+			return filtered[i].ActionGroup < filtered[j].ActionGroup
+		}
+		return filtered[i].Name < filtered[j].Name
+	})
+	return filtered, nil
+}
+
+func GetBrowserUseWebAction(owner, actionGroup, name string) (BrowserUseWebActionData, error) {
+	return browserUseResolveWebAction(owner, actionGroup, name)
+}
+
+func DeleteBrowserUseWebAction(owner, actionGroup, name string) (BrowserUseWebActionData, bool, error) {
+	browserUseWebActionStoreMu.RLock()
+	deleteAction := browserUseDeleteWebActionFunc
+	browserUseWebActionStoreMu.RUnlock()
+
+	if deleteAction == nil {
+		return BrowserUseWebActionData{}, false, fmt.Errorf("browser use web action storage is not configured")
+	}
+	action, err := browserUseResolveWebAction(owner, actionGroup, name)
+	if err != nil {
+		return BrowserUseWebActionData{}, false, err
+	}
+	deleted, err := deleteAction(strings.TrimSpace(owner), action.ActionGroup, action.Name)
+	if err != nil {
+		return BrowserUseWebActionData{}, false, err
+	}
+	if !deleted {
+		return BrowserUseWebActionData{}, false, fmt.Errorf("web action %q under action group %q was not found", action.Name, action.ActionGroup)
+	}
+	return action, true, nil
+}
+
+func browserUseWebActionMatchesURL(actionURL, currentURL string) bool {
+	actionURL = strings.TrimSpace(actionURL)
+	currentURL = strings.TrimSpace(currentURL)
+	if actionURL == "" || currentURL == "" {
+		return false
+	}
+
+	actionParsed, err := url.Parse(actionURL)
+	if err != nil || actionParsed.Hostname() == "" {
+		return false
+	}
+	currentParsed, err := url.Parse(currentURL)
+	if err != nil || currentParsed.Hostname() == "" {
+		return false
+	}
+
+	actionHost := strings.ToLower(strings.TrimPrefix(actionParsed.Hostname(), "www."))
+	currentHost := strings.ToLower(strings.TrimPrefix(currentParsed.Hostname(), "www."))
+	if actionHost == currentHost || strings.HasSuffix(currentHost, "."+actionHost) || strings.HasSuffix(actionHost, "."+currentHost) {
+		return true
+	}
+
+	actionDomain, actionErr := publicsuffix.EffectiveTLDPlusOne(actionHost)
+	currentDomain, currentErr := publicsuffix.EffectiveTLDPlusOne(currentHost)
+	return actionErr == nil && currentErr == nil && actionDomain == currentDomain
+}
+
+func browserUseActionStepsFromArguments(arguments map[string]interface{}) ([]browserUseWebActionScriptStep, error) {
+	rawSteps, ok := arguments["steps"]
+	if !ok {
+		rawScript, hasScript := arguments["script"]
+		if !hasScript {
+			return nil, fmt.Errorf("steps is required; provide an explicit parameterized action sequence such as [{\"kind\":\"open\",\"url\":\"https://example.com/search?q={{query}}\"}, {\"kind\":\"click\",\"selector\":\"button[type=submit]\"}]")
+		}
+		if script, ok := rawScript.(string); ok {
+			var steps []browserUseWebActionScriptStep
+			if err := json.Unmarshal([]byte(script), &steps); err != nil {
+				return nil, fmt.Errorf("script must be a JSON array of action step objects: %w", err)
+			}
+			return browserUseNormalizeWebActionScriptSteps(steps), nil
+		}
+		rawSteps = rawScript
+	}
+	bytes, err := json.Marshal(rawSteps)
+	if err != nil {
+		return nil, fmt.Errorf("steps must be a JSON array of action step objects: %w", err)
+	}
+	var steps []browserUseWebActionScriptStep
+	if err = json.Unmarshal(bytes, &steps); err != nil {
+		return nil, fmt.Errorf("steps must be a JSON array of action step objects: %w", err)
+	}
+	return browserUseNormalizeWebActionScriptSteps(steps), nil
+}
+
+func browserUseNormalizeWebActionArguments(arguments map[string]interface{}) map[string]interface{} {
+	normalized := map[string]interface{}{}
+	for key, value := range arguments {
+		normalized[key] = value
+	}
+	if _, ok := normalized["action_group"]; !ok {
+		if value, ok := normalized["actionGroup"]; ok {
+			normalized["action_group"] = value
+		}
+	}
+	return normalized
+}
+
+func browserUseActionGroupArgument(arguments map[string]interface{}) string {
+	arguments = browserUseNormalizeWebActionArguments(arguments)
+	actionGroup, _ := arguments["action_group"].(string)
+	return strings.TrimSpace(actionGroup)
+}
+
+func browserUseDescribeWebActionStep(step browserUseWebActionScriptStep) string {
+	switch browserUseNormalizeWebActionStepKind(step.Kind) {
+	case "open":
+		return fmt.Sprintf("open %s", strings.TrimSpace(step.URL))
+	case "click":
+		if step.DoubleClick {
+			return fmt.Sprintf("double click %s", browserUseDescribeWebActionTarget(step))
+		}
+		return fmt.Sprintf("click %s", browserUseDescribeWebActionTarget(step))
+	case "type":
+		return fmt.Sprintf("type into %s", browserUseDescribeWebActionTarget(step))
+	case "press":
+		return fmt.Sprintf("press %s", strings.TrimSpace(step.Key))
+	case "drag_and_drop":
+		return fmt.Sprintf("drag %s to %s", strings.TrimSpace(step.SourceSelector), strings.TrimSpace(step.TargetSelector))
+	default:
+		return strings.TrimSpace(step.Summary)
+	}
+}
+
+func browserUseDescribeWebActionTarget(step browserUseWebActionScriptStep) string {
+	if strings.TrimSpace(step.Selector) != "" {
+		return strings.TrimSpace(step.Selector)
+	}
+	if step.X != nil && step.Y != nil {
+		return fmt.Sprintf("viewport position %.0f,%.0f", *step.X, *step.Y)
+	}
+	return "target"
+}
+
+func SaveBrowserUseWebAction(owner string, arguments map[string]interface{}) (BrowserUseWebActionData, int, error) {
+	arguments = browserUseNormalizeWebActionArguments(arguments)
+	browserUseWebActionStoreMu.RLock()
+	upsert := browserUseUpsertWebActionFunc
+	browserUseWebActionStoreMu.RUnlock()
+
+	if upsert == nil {
+		return BrowserUseWebActionData{}, 0, fmt.Errorf("browser use web action storage is not configured")
+	}
+	actionGroup := browserUseActionGroupArgument(arguments)
+	name, _ := arguments["name"].(string)
+	description, _ := arguments["description"].(string)
+	actionText, _ := arguments["action"].(string)
+	startURL, _ := arguments["url"].(string)
+	if strings.TrimSpace(actionGroup) == "" {
+		return BrowserUseWebActionData{}, 0, fmt.Errorf("action_group is required")
+	}
+	if strings.TrimSpace(name) == "" {
+		return BrowserUseWebActionData{}, 0, fmt.Errorf("name is required")
+	}
+
+	scriptSteps, err := browserUseActionStepsFromArguments(arguments)
+	if err != nil {
+		return BrowserUseWebActionData{}, 0, err
+	}
+	startURL = browserUseWebActionStartURL(startURL, scriptSteps)
+	if strings.TrimSpace(actionText) == "" {
+		var builder strings.Builder
+		if strings.TrimSpace(description) != "" {
+			builder.WriteString(strings.TrimSpace(description))
+			builder.WriteString("\n\n")
+		}
+		builder.WriteString("## Steps\n")
+		for i, step := range scriptSteps {
+			builder.WriteString(fmt.Sprintf("%d. %s\n", i+1, browserUseDescribeWebActionStep(step)))
+		}
+		actionText = strings.TrimSpace(builder.String())
+	}
+	if err := browserUseValidateWebActionScript(strings.TrimSpace(name), scriptSteps); err != nil {
+		return BrowserUseWebActionData{}, 0, err
+	}
+	scriptBytes, err := json.Marshal(scriptSteps)
+	if err != nil {
+		return BrowserUseWebActionData{}, 0, err
+	}
+	action := browserUseWebAction{
+		ActionGroup: strings.TrimSpace(actionGroup),
+		Name:        strings.TrimSpace(name),
+		URL:         strings.TrimSpace(startURL),
+		Action:      strings.TrimSpace(actionText),
+		Script:      string(scriptBytes),
+		UpdatedTime: time.Now().UTC().Format(time.RFC3339),
+	}
+	saved, err := upsert(strings.TrimSpace(owner), action)
+	if err != nil {
+		return BrowserUseWebActionData{}, 0, err
+	}
+	return saved, len(scriptSteps), nil
+}
+
+func browserUseWebActionStartURL(rawURL string, steps []browserUseWebActionScriptStep) string {
+	rawURL = strings.TrimSpace(rawURL)
+	if rawURL != "" {
+		return rawURL
+	}
+	for _, step := range steps {
+		if strings.TrimSpace(step.URL) != "" {
+			return strings.TrimSpace(step.URL)
+		}
+	}
+	return ""
+}
+
+func browserUseSaveWebActionText(owner string, arguments map[string]interface{}) (string, error) {
+	saved, stepCount, err := SaveBrowserUseWebAction(owner, arguments)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("Saved executable browser web action %q under action group %q with %d step(s).", saved.Name, saved.ActionGroup, stepCount), nil
+}
+
+func browserUseInspectWebActionTraceText(owner string, limit int) string {
+	steps := browserUseTraceSteps(owner)
+	if len(steps) == 0 {
+		return "No browser web action trace steps recorded yet."
+	}
+	if limit <= 0 || limit > len(steps) {
+		limit = len(steps)
+	}
+	steps = steps[len(steps)-limit:]
+	var builder strings.Builder
+	builder.WriteString("Browser web action trace:\n")
+	for _, step := range steps {
+		builder.WriteString("- ")
+		builder.WriteString(browserUseTraceSummary(step))
+		builder.WriteString("\n")
+	}
+	builder.WriteString("\nUse this trace only to review what happened. To save an action, write an explicit parameterized `steps` array for `browser_use_save_web_action`; do not pass trace step ids.")
+	return strings.TrimSpace(builder.String())
+}
+
+func browserUseResolveWebAction(owner, actionGroup, name string) (browserUseWebAction, error) {
+	actions, err := browserUseLoadWebActions(owner)
+	if err != nil {
+		return browserUseWebAction{}, err
+	}
+	actionGroup = strings.TrimSpace(actionGroup)
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return browserUseWebAction{}, fmt.Errorf("name is required")
+	}
+	matches := []browserUseWebAction{}
+	for _, action := range actions {
+		if action.Name != name {
+			continue
+		}
+		if actionGroup != "" && action.ActionGroup != actionGroup {
+			continue
+		}
+		matches = append(matches, action)
+	}
+	if len(matches) == 0 {
+		if actionGroup != "" {
+			return browserUseWebAction{}, fmt.Errorf("web action %q under action group %q was not found", name, actionGroup)
+		}
+		return browserUseWebAction{}, fmt.Errorf("web action %q was not found", name)
+	}
+	if len(matches) > 1 {
+		actionGroups := make([]string, 0, len(matches))
+		for _, action := range matches {
+			actionGroups = append(actionGroups, action.ActionGroup)
+		}
+		sort.Strings(actionGroups)
+		return browserUseWebAction{}, fmt.Errorf("web action %q exists under multiple action groups (%s); pass action_group to disambiguate", name, strings.Join(actionGroups, ", "))
+	}
+	return matches[0], nil
+}
+
+func browserUseDeleteWebActionText(owner string, arguments map[string]interface{}) (string, error) {
+	name, _ := arguments["name"].(string)
+	actionGroup := browserUseActionGroupArgument(arguments)
+	action, _, err := DeleteBrowserUseWebAction(owner, actionGroup, name)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("Deleted browser web action %q under action group %q.", action.Name, action.ActionGroup), nil
+}
+
+func browserUseVariables(arguments map[string]interface{}) map[string]string {
+	variables := map[string]string{}
+	rawVariables, ok := arguments["variables"].(map[string]interface{})
+	if !ok {
+		return variables
+	}
+	for key, value := range rawVariables {
+		if text, ok := value.(string); ok {
+			variables[strings.TrimSpace(key)] = text
+		}
+	}
+	return variables
+}
+
+func browserUseApplyVariables(text string, variables map[string]string) string {
+	return browserUseWebActionPlaceholderPattern.ReplaceAllStringFunc(text, func(match string) string {
+		parts := browserUseWebActionPlaceholderPattern.FindStringSubmatch(match)
+		if len(parts) < 2 {
+			return match
+		}
+		key := strings.TrimSpace(parts[1])
+		if value, ok := variables[key]; ok {
+			return value
+		}
+		return match
+	})
+}
+
+func browserUseDecodeWebActionScript(action browserUseWebAction) ([]browserUseWebActionScriptStep, error) {
+	if strings.TrimSpace(action.Script) == "" {
+		return nil, fmt.Errorf("web action %q is not executable because it has no structured steps. Save it again with browser_use_save_web_action using an explicit parameterized steps array", action.Name)
+	}
+	var steps []browserUseWebActionScriptStep
+	if err := json.Unmarshal([]byte(action.Script), &steps); err != nil {
+		return nil, fmt.Errorf("web action %q has a corrupted structured steps script and cannot run: %w. Save it again with browser_use_save_web_action using an explicit parameterized steps array", action.Name, err)
+	}
+	steps = browserUseNormalizeWebActionScriptSteps(steps)
+	if err := browserUseValidateWebActionScript(action.Name, steps); err != nil {
+		return nil, err
+	}
+	return steps, nil
+}
+
+func browserUseNavigateWithoutLoadWait(rawURL string) chromedp.Action {
+	return chromedp.ActionFunc(func(ctx context.Context) error {
+		_, _, errorText, err := page.Navigate(rawURL).Do(ctx)
+		if err != nil {
+			return err
+		}
+		if errorText != "" {
+			return fmt.Errorf("page load error %s", errorText)
+		}
+		return nil
+	})
+}
+
+func browserUseSelectorNeedsRefRefresh(selector string) bool {
+	return strings.Contains(selector, "data-openagent-browser-use-ref")
+}
+
+func browserUseRefreshElementRefs(provider *BrowserUseTool, selector string) error {
+	if !browserUseSelectorNeedsRefRefresh(selector) {
+		return nil
+	}
+	var elements []browserUseElement
+	return provider.run(chromedp.Evaluate(browserUseSnapshotScript(), &elements))
+}
+
+func browserUseChromeExtRefreshElementRefs(ctx context.Context, selector string) error {
+	if !browserUseSelectorNeedsRefRefresh(selector) {
+		return nil
+	}
+	var snapshot browserUseChromeExtSnapshotResult
+	return browserUseChromeExtCall(ctx, "snapshot", map[string]interface{}{}, &snapshot)
+}
+
+func browserUseRunWebAction(provider *BrowserUseTool, action browserUseWebAction, variables map[string]string) error {
+	steps, err := browserUseDecodeWebActionScript(action)
+	if err != nil {
+		return err
+	}
+	if err = browserUseValidateWebActionVariables(action, variables); err != nil {
+		return err
+	}
+	if err = browserUseOpenWebActionStartURL(provider, action, steps, variables); err != nil {
+		return err
+	}
+	for i, step := range steps {
+		switch strings.TrimSpace(step.Kind) {
+		case "open":
+			rawURL := browserUseApplyVariables(step.URL, variables)
+			if strings.TrimSpace(rawURL) == "" {
+				return fmt.Errorf("step %d open is missing url", i+1)
+			}
+			if err = provider.run(browserUseNavigateWithoutLoadWait(rawURL), chromedp.WaitReady("body", chromedp.ByQuery)); err != nil {
+				return fmt.Errorf("step %d open failed: %w", i+1, err)
+			}
+		case "click":
+			selector := browserUseApplyVariables(step.Selector, variables)
+			if strings.TrimSpace(selector) == "" {
+				if step.X != nil && step.Y != nil {
+					return fmt.Errorf("step %d click uses viewport coordinates, which are only supported in OpenAgent Chrome extension mode", i+1)
+				}
+				return fmt.Errorf("step %d click is missing selector", i+1)
+			}
+			if step.DoubleClick {
+				return fmt.Errorf("step %d double click is only supported in OpenAgent Chrome extension mode", i+1)
+			}
+			if err = browserUseRefreshElementRefs(provider, selector); err != nil {
+				return fmt.Errorf("step %d click could not refresh element refs: %w", i+1, err)
+			}
+			if err = provider.run(
+				chromedp.ScrollIntoView(selector, chromedp.ByQuery),
+				chromedp.Click(selector, chromedp.ByQuery),
+				chromedp.Sleep(800*time.Millisecond),
+			); err != nil {
+				return fmt.Errorf("step %d click failed: %w", i+1, err)
+			}
+		case "type":
+			selector := browserUseApplyVariables(step.Selector, variables)
+			text := browserUseApplyVariables(step.Text, variables)
+			clear := true
+			if step.Clear != nil {
+				clear = *step.Clear
+			}
+			if strings.TrimSpace(selector) == "" {
+				if step.X != nil && step.Y != nil {
+					return fmt.Errorf("step %d type uses viewport coordinates, which are only supported in OpenAgent Chrome extension mode", i+1)
+				}
+				return fmt.Errorf("step %d type is missing selector", i+1)
+			}
+			if err = browserUseRefreshElementRefs(provider, selector); err != nil {
+				return fmt.Errorf("step %d type could not refresh element refs: %w", i+1, err)
+			}
+			if err = provider.run(browserUseTypeActions(selector, text, clear)...); err != nil {
+				return fmt.Errorf("step %d type failed: %w", i+1, err)
+			}
+		case "press":
+			key := browserUseKey(browserUseApplyVariables(step.Key, variables))
+			if strings.TrimSpace(key) == "" {
+				return fmt.Errorf("step %d press is missing key", i+1)
+			}
+			if err = provider.run(chromedp.KeyEvent(key), chromedp.Sleep(800*time.Millisecond)); err != nil {
+				return fmt.Errorf("step %d press failed: %w", i+1, err)
+			}
+		case "drag_and_drop":
+			return fmt.Errorf("step %d drag_and_drop is only supported in OpenAgent Chrome extension mode", i+1)
+		default:
+			return browserUseValidateWebActionScriptStep(action.Name, i, step)
+		}
+	}
+	return nil
+}
+
+func browserUseOpenWebActionStartURL(provider *BrowserUseTool, action browserUseWebAction, steps []browserUseWebActionScriptStep, variables map[string]string) error {
+	rawURL := browserUseApplyVariables(strings.TrimSpace(action.URL), variables)
+	if strings.TrimSpace(rawURL) == "" || browserUseFirstStepIsOpen(steps) {
+		return nil
+	}
+	if err := provider.run(browserUseNavigateWithoutLoadWait(rawURL), chromedp.WaitReady("body", chromedp.ByQuery)); err != nil {
+		return fmt.Errorf("opening web action start url failed: %w", err)
+	}
+	return nil
+}
+
+func browserUseFirstStepIsOpen(steps []browserUseWebActionScriptStep) bool {
+	if len(steps) == 0 {
+		return false
+	}
+	return browserUseNormalizeWebActionStepKind(steps[0].Kind) == "open"
+}
+
+func browserUseChromeExtStepTargetPayload(step browserUseWebActionScriptStep, variables map[string]string) map[string]interface{} {
+	payload := map[string]interface{}{}
+	if selector := strings.TrimSpace(browserUseApplyVariables(step.Selector, variables)); selector != "" {
+		payload["selector"] = selector
+	}
+	if step.X != nil {
+		payload["x"] = *step.X
+	}
+	if step.Y != nil {
+		payload["y"] = *step.Y
+	}
+	if button := strings.TrimSpace(browserUseApplyVariables(step.Button, variables)); button != "" {
+		payload["button"] = button
+	}
+	if step.CtrlKey {
+		payload["ctrlKey"] = true
+	}
+	if step.ShiftKey {
+		payload["shiftKey"] = true
+	}
+	if step.AltKey {
+		payload["altKey"] = true
+	}
+	if step.MetaKey {
+		payload["metaKey"] = true
+	}
+	if step.DoubleClick {
+		payload["doubleClick"] = true
+	}
+	return payload
+}
+
+func browserUseRunChromeExtWebAction(ctx context.Context, action browserUseWebAction, variables map[string]string) error {
+	steps, err := browserUseDecodeWebActionScript(action)
+	if err != nil {
+		return err
+	}
+	if err = browserUseValidateWebActionVariables(action, variables); err != nil {
+		return err
+	}
+	if err = browserUseChromeExtOpenWebActionStartURL(ctx, action, steps, variables); err != nil {
+		return err
+	}
+	for i, step := range steps {
+		switch strings.TrimSpace(step.Kind) {
+		case "open":
+			rawURL := browserUseApplyVariables(step.URL, variables)
+			if strings.TrimSpace(rawURL) == "" {
+				return fmt.Errorf("step %d open is missing url", i+1)
+			}
+			if err = browserUseChromeExtOpen(ctx, rawURL); err != nil {
+				return fmt.Errorf("step %d open failed: %w", i+1, err)
+			}
+		case "click":
+			payload := browserUseChromeExtStepTargetPayload(step, variables)
+			selector, _ := payload["selector"].(string)
+			if strings.TrimSpace(selector) == "" && (payload["x"] == nil || payload["y"] == nil) {
+				return fmt.Errorf("step %d click is missing selector or viewport x/y coordinates", i+1)
+			}
+			if err = browserUseChromeExtRefreshElementRefs(ctx, selector); err != nil {
+				return fmt.Errorf("step %d click could not refresh element refs: %w", i+1, err)
+			}
+			if err = browserUseChromeExtCall(ctx, "click", payload, nil); err != nil {
+				return fmt.Errorf("step %d click failed: %w", i+1, err)
+			}
+		case "type":
+			payload := browserUseChromeExtStepTargetPayload(step, variables)
+			selector, _ := payload["selector"].(string)
+			text := browserUseApplyVariables(step.Text, variables)
+			clear := true
+			if step.Clear != nil {
+				clear = *step.Clear
+			}
+			if strings.TrimSpace(selector) == "" && (payload["x"] == nil || payload["y"] == nil) {
+				return fmt.Errorf("step %d type is missing selector or viewport x/y coordinates", i+1)
+			}
+			if err = browserUseChromeExtRefreshElementRefs(ctx, selector); err != nil {
+				return fmt.Errorf("step %d type could not refresh element refs: %w", i+1, err)
+			}
+			payload["text"] = text
+			payload["clear"] = clear
+			if err = browserUseChromeExtCall(ctx, "type", payload, nil); err != nil {
+				return fmt.Errorf("step %d type failed: %w", i+1, err)
+			}
+		case "press":
+			key := browserUseApplyVariables(step.Key, variables)
+			if strings.TrimSpace(key) == "" {
+				return fmt.Errorf("step %d press is missing key", i+1)
+			}
+			if err = browserUseChromeExtPress(ctx, key); err != nil {
+				return fmt.Errorf("step %d press failed: %w", i+1, err)
+			}
+		case "drag_and_drop":
+			sourceSelector := strings.TrimSpace(browserUseApplyVariables(step.SourceSelector, variables))
+			targetSelector := strings.TrimSpace(browserUseApplyVariables(step.TargetSelector, variables))
+			if sourceSelector == "" || targetSelector == "" {
+				return fmt.Errorf("step %d drag_and_drop is missing sourceSelector or targetSelector", i+1)
+			}
+			if err = browserUseChromeExtCall(ctx, "dragAndDrop", map[string]interface{}{
+				"sourceSelector": sourceSelector,
+				"targetSelector": targetSelector,
+			}, nil); err != nil {
+				return fmt.Errorf("step %d drag_and_drop failed: %w", i+1, err)
+			}
+		default:
+			return browserUseValidateWebActionScriptStep(action.Name, i, step)
+		}
+	}
+	return nil
+}
+
+func browserUseChromeExtOpenWebActionStartURL(ctx context.Context, action browserUseWebAction, steps []browserUseWebActionScriptStep, variables map[string]string) error {
+	rawURL := browserUseApplyVariables(strings.TrimSpace(action.URL), variables)
+	if strings.TrimSpace(rawURL) == "" || browserUseFirstStepIsOpen(steps) {
+		return nil
+	}
+	if err := browserUseChromeExtOpen(ctx, rawURL); err != nil {
+		return fmt.Errorf("opening web action start url failed: %w", err)
+	}
+	return nil
+}
+
+func browserUseWebActionListSchema() interface{} {
+	return map[string]interface{}{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties": map[string]interface{}{
+			"action_group": map[string]interface{}{
+				"type":        "string",
+				"description": "Optional action group name. If omitted, all saved actions are listed.",
+			},
+		},
+	}
+}
+
+func browserUseWebActionSaveSchema() interface{} {
+	return map[string]interface{}{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties": map[string]interface{}{
+			"action_group": map[string]interface{}{
+				"type":        "string",
+				"description": "Action group name used to organize and disambiguate saved web actions.",
+			},
+			"name": map[string]interface{}{
+				"type":        "string",
+				"description": "Short action name, for example search_posts.",
+			},
+			"url": map[string]interface{}{
+				"type":        "string",
+				"description": "Optional start URL for the action. If present and the first step is not open, run_web_action opens this URL before replaying steps. Supports {{variable}} placeholders.",
+			},
+			"steps": map[string]interface{}{
+				"type":        "array",
+				"description": "Explicit parameterized executable action sequence. Use browser_use_inspect_web_action_trace only to review prior attempts, then author these steps directly.",
+				"items": map[string]interface{}{
+					"type":                 "object",
+					"additionalProperties": false,
+					"properties": map[string]interface{}{
+						"kind": map[string]interface{}{
+							"type":        "string",
+							"description": "Step kind: open, click, type, press, or drag_and_drop. Recorder aliases navigate and dblclick are accepted and normalized.",
+							"enum":        []string{"open", "click", "type", "press", "drag_and_drop", "navigate", "dblclick"},
+						},
+						"url": map[string]interface{}{
+							"type":        "string",
+							"description": "URL for open steps. Supports {{variable}} placeholders.",
+						},
+						"selector": map[string]interface{}{
+							"type":        "string",
+							"description": "CSS selector for click/type steps. Supports {{variable}} placeholders.",
+						},
+						"sourceSelector": map[string]interface{}{
+							"type":        "string",
+							"description": "CSS selector for drag_and_drop source. Supports {{variable}} placeholders.",
+						},
+						"targetSelector": map[string]interface{}{
+							"type":        "string",
+							"description": "CSS selector for drag_and_drop target. Supports {{variable}} placeholders.",
+						},
+						"text": map[string]interface{}{
+							"type":        "string",
+							"description": "Text for type steps. Supports {{variable}} placeholders.",
+						},
+						"clear": map[string]interface{}{
+							"type":        "boolean",
+							"description": "Whether type steps should clear existing text first.",
+						},
+						"key": map[string]interface{}{
+							"type":        "string",
+							"description": "Keyboard key for press steps.",
+						},
+						"x": map[string]interface{}{
+							"type":        "number",
+							"description": "Optional viewport x coordinate fallback for click/type steps recorded by the Chrome extension.",
+						},
+						"y": map[string]interface{}{
+							"type":        "number",
+							"description": "Optional viewport y coordinate fallback for click/type steps recorded by the Chrome extension.",
+						},
+						"button": map[string]interface{}{
+							"type":        "string",
+							"description": "Optional mouse button for click steps.",
+							"enum":        []string{"left", "middle", "right"},
+						},
+						"doubleClick": map[string]interface{}{
+							"type":        "boolean",
+							"description": "Whether a click step should dispatch a double click.",
+						},
+						"ctrlKey":  map[string]interface{}{"type": "boolean"},
+						"shiftKey": map[string]interface{}{"type": "boolean"},
+						"altKey":   map[string]interface{}{"type": "boolean"},
+						"metaKey":  map[string]interface{}{"type": "boolean"},
+						"summary": map[string]interface{}{
+							"type":        "string",
+							"description": "Optional human-readable note for this step.",
+						},
+					},
+					"required": []string{"kind"},
+				},
+			},
+			"description": map[string]interface{}{
+				"type":        "string",
+				"description": "Optional natural-language description for the action.",
+			},
+			"action": map[string]interface{}{
+				"type":        "string",
+				"description": "Optional markdown action notes. If omitted, notes are generated from steps.",
+			},
+		},
+		"required": []string{"action_group", "name", "steps"},
+	}
+}
+
+func browserUseWebActionInspectTraceSchema() interface{} {
+	return map[string]interface{}{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties": map[string]interface{}{
+			"limit": map[string]interface{}{
+				"type":        "integer",
+				"description": "Maximum number of recent trace steps to show.",
+				"default":     50,
+			},
+		},
+	}
+}
+
+func browserUseWebActionRunSchema() interface{} {
+	return map[string]interface{}{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties": map[string]interface{}{
+			"action_group": map[string]interface{}{
+				"type":        "string",
+				"description": "Optional action group name used to disambiguate the action.",
+			},
+			"name": map[string]interface{}{
+				"type":        "string",
+				"description": "Saved web action name.",
+			},
+			"variables": map[string]interface{}{
+				"type":        "object",
+				"description": "Optional string replacements for {{variable}} placeholders in URLs, text, selectors, and keys.",
+				"additionalProperties": map[string]interface{}{
+					"type": "string",
+				},
+			},
+		},
+		"required": []string{"name"},
+	}
+}
+
+func browserUseWebActionDeleteSchema() interface{} {
+	return map[string]interface{}{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties": map[string]interface{}{
+			"action_group": map[string]interface{}{
+				"type":        "string",
+				"description": "Optional action group name used to disambiguate the action.",
+			},
+			"name": map[string]interface{}{
+				"type":        "string",
+				"description": "Saved web action name to delete.",
+			},
+		},
+		"required": []string{"name"},
+	}
+}
+
+type browserUseListWebActionsBuiltin struct{ provider *BrowserUseTool }
+
+func (b *browserUseListWebActionsBuiltin) GetName() string { return "browser_use_list_web_actions" }
+
+func (b *browserUseListWebActionsBuiltin) GetDescription() string {
+	return browserUseWithWebActionReflection("List executable Browser Web Actions, including required variables inferred from {{placeholders}} in the saved action script.")
+}
+
+func (b *browserUseListWebActionsBuiltin) GetInputSchema() interface{} {
+	return browserUseWebActionListSchema()
+}
+
+func (b *browserUseListWebActionsBuiltin) Execute(ctx context.Context, arguments map[string]interface{}) (*protocol.CallToolResult, error) {
+	rawURL, _ := arguments["url"].(string)
+	if strings.TrimSpace(rawURL) == "" {
+		page, err := browserUseCurrentPageInfo(b.provider)
+		if err == nil {
+			rawURL = page.URL
+		}
+	}
+	text, err := browserUseListWebActionsText(browserUseWebActionOwner(b.provider), arguments, rawURL)
+	if err != nil {
+		return browserUseErrorWithState(b.provider, fmt.Sprintf("browser use list web actions failed: %s", err.Error())), nil
+	}
+	return browserUseTextWithState(b.provider, text), nil
+}
+
+type browserUseInspectWebActionTraceBuiltin struct{ provider *BrowserUseTool }
+
+func (b *browserUseInspectWebActionTraceBuiltin) GetName() string {
+	return "browser_use_inspect_web_action_trace"
+}
+
+func (b *browserUseInspectWebActionTraceBuiltin) GetDescription() string {
+	return browserUseWithWebActionReflection("Inspect recent Browser Use trace steps so the model can review prior attempts before authoring an explicit parameterized Browser Web Action steps array.")
+}
+
+func (b *browserUseInspectWebActionTraceBuiltin) GetInputSchema() interface{} {
+	return browserUseWebActionInspectTraceSchema()
+}
+
+func (b *browserUseInspectWebActionTraceBuiltin) Execute(ctx context.Context, arguments map[string]interface{}) (*protocol.CallToolResult, error) {
+	limit := 50
+	if rawLimit, ok := arguments["limit"]; ok {
+		if value, err := browserUsePositiveInt(rawLimit, "limit"); err == nil {
+			limit = value
+		}
+	}
+	return browserUseTextWithState(b.provider, browserUseInspectWebActionTraceText(browserUseTraceKey(b.provider), limit)), nil
+}
+
+type browserUseSaveWebActionBuiltin struct{ provider *BrowserUseTool }
+
+func (b *browserUseSaveWebActionBuiltin) GetName() string { return "browser_use_save_web_action" }
+
+func (b *browserUseSaveWebActionBuiltin) GetDescription() string {
+	return browserUseWithWebActionReflection("Save an executable Browser Web Action under an action group. Provide an explicit parameterized steps array using open, click, type, and press steps; do not reference trace step ids.")
+}
+
+func (b *browserUseSaveWebActionBuiltin) GetInputSchema() interface{} {
+	return browserUseWebActionSaveSchema()
+}
+
+func (b *browserUseSaveWebActionBuiltin) Execute(ctx context.Context, arguments map[string]interface{}) (*protocol.CallToolResult, error) {
+	text, err := browserUseSaveWebActionText(browserUseWebActionOwner(b.provider), arguments)
+	if err != nil {
+		return browserUseErrorWithState(b.provider, fmt.Sprintf("browser use save web action failed: %s", err.Error())), nil
+	}
+	return browserUseTextWithState(b.provider, text), nil
+}
+
+type browserUseRunWebActionBuiltin struct{ provider *BrowserUseTool }
+
+func (b *browserUseRunWebActionBuiltin) GetName() string { return "browser_use_run_web_action" }
+
+func (b *browserUseRunWebActionBuiltin) GetDescription() string {
+	return browserUseWithWebActionReflection("Run a saved executable Browser Web Action. Use variables to fill {{placeholder}} values captured in the action script.")
+}
+
+func (b *browserUseRunWebActionBuiltin) GetInputSchema() interface{} {
+	return browserUseWebActionRunSchema()
+}
+
+func (b *browserUseRunWebActionBuiltin) Execute(ctx context.Context, arguments map[string]interface{}) (*protocol.CallToolResult, error) {
+	name, _ := arguments["name"].(string)
+	actionGroup := browserUseActionGroupArgument(arguments)
+	action, err := browserUseResolveWebAction(browserUseWebActionOwner(b.provider), actionGroup, name)
+	if err != nil {
+		return browserUseErrorWithState(b.provider, fmt.Sprintf("browser use run web action failed: %s", err.Error())), nil
+	}
+	if err = browserUseRunWebAction(b.provider, action, browserUseVariables(arguments)); err != nil {
+		return browserUseErrorWithState(b.provider, fmt.Sprintf("browser use run web action failed: %s", err.Error())), nil
+	}
+	snapshot, err := browserUseSnapshot(b.provider)
+	if err != nil {
+		return browserUseErrorWithState(b.provider, fmt.Sprintf("browser use snapshot failed after running web action %s: %s", action.Name, err.Error())), nil
+	}
+	return browserUseTextWithState(b.provider, snapshot), nil
+}
+
+type browserUseDeleteWebActionBuiltin struct{ provider *BrowserUseTool }
+
+func (b *browserUseDeleteWebActionBuiltin) GetName() string { return "browser_use_delete_web_action" }
+
+func (b *browserUseDeleteWebActionBuiltin) GetDescription() string {
+	return browserUseWithWebActionReflection("Delete a saved executable Browser Web Action. Pass action_group when multiple action groups have an action with the same name.")
+}
+
+func (b *browserUseDeleteWebActionBuiltin) GetInputSchema() interface{} {
+	return browserUseWebActionDeleteSchema()
+}
+
+func (b *browserUseDeleteWebActionBuiltin) Execute(ctx context.Context, arguments map[string]interface{}) (*protocol.CallToolResult, error) {
+	text, err := browserUseDeleteWebActionText(browserUseWebActionOwner(b.provider), arguments)
+	if err != nil {
+		return browserUseErrorWithState(b.provider, fmt.Sprintf("browser use delete web action failed: %s", err.Error())), nil
+	}
+	return browserUseTextWithState(b.provider, text), nil
+}
+
+type chromeConnectListWebActionsBuiltin struct{ provider *BrowserUseTool }
+
+func (b *chromeConnectListWebActionsBuiltin) GetName() string { return "browser_use_list_web_actions" }
+
+func (b *chromeConnectListWebActionsBuiltin) GetDescription() string {
+	return browserUseWithWebActionReflection("List executable Browser Web Actions, including required variables inferred from {{placeholders}} in the saved action script.")
+}
+
+func (b *chromeConnectListWebActionsBuiltin) GetInputSchema() interface{} {
+	return browserUseWebActionListSchema()
+}
+
+func (b *chromeConnectListWebActionsBuiltin) Execute(ctx context.Context, arguments map[string]interface{}) (*protocol.CallToolResult, error) {
+	rawURL, _ := arguments["url"].(string)
+	if strings.TrimSpace(rawURL) == "" {
+		page, err := browserUseChromeExtCurrentPageInfo(ctx)
+		if err == nil {
+			rawURL = page.URL
+		}
+	}
+	text, err := browserUseListWebActionsText(browserUseWebActionOwner(b.provider), arguments, rawURL)
+	if err != nil {
+		return chromeConnectErrorWithState(fmt.Sprintf("browser use list web actions failed: %s", err.Error())), nil
+	}
+	return chromeConnectTextWithState(text), nil
+}
+
+type chromeConnectInspectWebActionTraceBuiltin struct{ provider *BrowserUseTool }
+
+func (b *chromeConnectInspectWebActionTraceBuiltin) GetName() string {
+	return "browser_use_inspect_web_action_trace"
+}
+
+func (b *chromeConnectInspectWebActionTraceBuiltin) GetDescription() string {
+	return browserUseWithWebActionReflection("Inspect recent Browser Use trace steps so the model can review prior attempts before authoring an explicit parameterized Browser Web Action steps array.")
+}
+
+func (b *chromeConnectInspectWebActionTraceBuiltin) GetInputSchema() interface{} {
+	return browserUseWebActionInspectTraceSchema()
+}
+
+func (b *chromeConnectInspectWebActionTraceBuiltin) Execute(ctx context.Context, arguments map[string]interface{}) (*protocol.CallToolResult, error) {
+	limit := 50
+	if rawLimit, ok := arguments["limit"]; ok {
+		if value, err := browserUsePositiveInt(rawLimit, "limit"); err == nil {
+			limit = value
+		}
+	}
+	return chromeConnectTextWithState(browserUseInspectWebActionTraceText(browserUseTraceKey(b.provider), limit)), nil
+}
+
+type chromeConnectSaveWebActionBuiltin struct{ provider *BrowserUseTool }
+
+func (b *chromeConnectSaveWebActionBuiltin) GetName() string { return "browser_use_save_web_action" }
+
+func (b *chromeConnectSaveWebActionBuiltin) GetDescription() string {
+	return browserUseWithWebActionReflection("Save an executable Browser Web Action under an action group. Provide an explicit parameterized steps array using open, click, type, and press steps; do not reference trace step ids.")
+}
+
+func (b *chromeConnectSaveWebActionBuiltin) GetInputSchema() interface{} {
+	return browserUseWebActionSaveSchema()
+}
+
+func (b *chromeConnectSaveWebActionBuiltin) Execute(ctx context.Context, arguments map[string]interface{}) (*protocol.CallToolResult, error) {
+	text, err := browserUseSaveWebActionText(browserUseWebActionOwner(b.provider), arguments)
+	if err != nil {
+		return chromeConnectErrorWithState(fmt.Sprintf("browser use save web action failed: %s", err.Error())), nil
+	}
+	return chromeConnectTextWithState(text), nil
+}
+
+type chromeConnectRunWebActionBuiltin struct{ provider *BrowserUseTool }
+
+func (b *chromeConnectRunWebActionBuiltin) GetName() string { return "browser_use_run_web_action" }
+
+func (b *chromeConnectRunWebActionBuiltin) GetDescription() string {
+	return browserUseWithWebActionReflection("Run a saved executable Browser Web Action via the OpenAgent Chrome extension.")
+}
+
+func (b *chromeConnectRunWebActionBuiltin) GetInputSchema() interface{} {
+	return browserUseWebActionRunSchema()
+}
+
+func (b *chromeConnectRunWebActionBuiltin) Execute(ctx context.Context, arguments map[string]interface{}) (*protocol.CallToolResult, error) {
+	name, _ := arguments["name"].(string)
+	actionGroup := browserUseActionGroupArgument(arguments)
+	action, err := browserUseResolveWebAction(browserUseWebActionOwner(b.provider), actionGroup, name)
+	if err != nil {
+		return chromeConnectErrorWithState(fmt.Sprintf("browser use run web action failed: %s", err.Error())), nil
+	}
+	if err = browserUseRunChromeExtWebAction(ctx, action, browserUseVariables(arguments)); err != nil {
+		return chromeConnectErrorWithState(fmt.Sprintf("browser use run web action failed: %s", err.Error())), nil
+	}
+	snapshot, err := browserUseChromeExtSnapshot(b.provider, ctx)
+	if err != nil {
+		return chromeConnectErrorWithState(fmt.Sprintf("browser use snapshot failed after running web action %s: %s", action.Name, err.Error())), nil
+	}
+	return chromeConnectTextWithState(snapshot), nil
+}
+
+type chromeConnectDeleteWebActionBuiltin struct{ provider *BrowserUseTool }
+
+func (b *chromeConnectDeleteWebActionBuiltin) GetName() string {
+	return "browser_use_delete_web_action"
+}
+
+func (b *chromeConnectDeleteWebActionBuiltin) GetDescription() string {
+	return browserUseWithWebActionReflection("Delete a saved executable Browser Web Action. Pass action_group when multiple action groups have an action with the same name.")
+}
+
+func (b *chromeConnectDeleteWebActionBuiltin) GetInputSchema() interface{} {
+	return browserUseWebActionDeleteSchema()
+}
+
+func (b *chromeConnectDeleteWebActionBuiltin) Execute(ctx context.Context, arguments map[string]interface{}) (*protocol.CallToolResult, error) {
+	text, err := browserUseDeleteWebActionText(browserUseWebActionOwner(b.provider), arguments)
+	if err != nil {
+		return chromeConnectErrorWithState(fmt.Sprintf("browser use delete web action failed: %s", err.Error())), nil
+	}
+	return chromeConnectTextWithState(text), nil
+}

--- a/tool/browser_use_web_action_test.go
+++ b/tool/browser_use_web_action_test.go
@@ -1,0 +1,245 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tool
+
+import (
+	"strings"
+	"testing"
+)
+
+func useInMemoryBrowserUseWebActionStore(t *testing.T) {
+	t.Helper()
+	actionStore := []BrowserUseWebActionData{}
+	oldActionList := browserUseListWebActionsFunc
+	oldActionListByActionGroups := browserUseListWebActionsByActionGroupsFunc
+	oldActionUpsert := browserUseUpsertWebActionFunc
+	oldActionDelete := browserUseDeleteWebActionFunc
+	SetBrowserUseWebActionStore(
+		func(owner string) ([]BrowserUseWebActionData, error) {
+			actions := make([]BrowserUseWebActionData, len(actionStore))
+			copy(actions, actionStore)
+			return actions, nil
+		},
+		func(owner string, action BrowserUseWebActionData) (BrowserUseWebActionData, error) {
+			for i := range actionStore {
+				if actionStore[i].ActionGroup == action.ActionGroup && actionStore[i].Name == action.Name {
+					actionStore[i] = action
+					return action, nil
+				}
+			}
+			actionStore = append(actionStore, action)
+			return action, nil
+		},
+		func(owner, actionGroup, name string) (bool, error) {
+			for i := range actionStore {
+				if actionStore[i].ActionGroup == actionGroup && actionStore[i].Name == name {
+					actionStore = append(actionStore[:i], actionStore[i+1:]...)
+					return true, nil
+				}
+			}
+			return false, nil
+		},
+		func(owner string, actionGroups []string) ([]BrowserUseWebActionData, error) {
+			matchedActionGroups := map[string]bool{}
+			for _, actionGroup := range actionGroups {
+				matchedActionGroups[strings.TrimSpace(actionGroup)] = true
+			}
+			actions := []BrowserUseWebActionData{}
+			for _, action := range actionStore {
+				if matchedActionGroups[action.ActionGroup] {
+					actions = append(actions, action)
+				}
+			}
+			return actions, nil
+		},
+	)
+	t.Cleanup(func() {
+		SetBrowserUseWebActionStore(oldActionList, oldActionUpsert, oldActionDelete, oldActionListByActionGroups)
+	})
+}
+
+func TestSaveBrowserUseWebActionAcceptsExtensionPayloadAliases(t *testing.T) {
+	useInMemoryBrowserUseWebActionStore(t)
+
+	action, stepCount, err := SaveBrowserUseWebAction("admin", map[string]interface{}{
+		"actionGroup": "docs",
+		"name":        "search",
+		"script":      `[{"kind":"navigate","url":"https://docs.example.com/search?q={{query}}"}]`,
+	})
+	if err != nil {
+		t.Fatalf("save web action: %v", err)
+	}
+	if stepCount != 1 {
+		t.Fatalf("expected 1 step, got %d", stepCount)
+	}
+	if action.ActionGroup != "docs" || action.Name != "search" {
+		t.Fatalf("unexpected saved action: %+v", action)
+	}
+	if !strings.Contains(action.Script, `"kind":"open"`) {
+		t.Fatalf("expected navigate alias to be normalized to open, got %q", action.Script)
+	}
+}
+
+func TestBrowserUseListWebActionsFiltersByActionGroup(t *testing.T) {
+	useInMemoryBrowserUseWebActionStore(t)
+
+	_, _, err := SaveBrowserUseWebAction("admin", map[string]interface{}{
+		"action_group": "docs",
+		"name":         "search_docs",
+		"steps": []interface{}{
+			map[string]interface{}{"kind": "open", "url": "https://docs.example.com/search?q={{query}}"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("save docs action: %v", err)
+	}
+	_, _, err = SaveBrowserUseWebAction("admin", map[string]interface{}{
+		"action_group": "forum",
+		"name":         "search_forum",
+		"steps": []interface{}{
+			map[string]interface{}{"kind": "open", "url": "https://forum.example.com/search?q={{query}}"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("save forum action: %v", err)
+	}
+
+	text, err := browserUseListWebActionsText("admin", map[string]interface{}{"action_group": "docs"}, "")
+	if err != nil {
+		t.Fatalf("list actions: %v", err)
+	}
+	if !strings.Contains(text, "docs / search_docs") {
+		t.Fatalf("expected docs action, got %q", text)
+	}
+	if strings.Contains(text, "search_forum") {
+		t.Fatalf("did not expect forum action, got %q", text)
+	}
+}
+
+func TestListBrowserUseWebActionsFiltersByCurrentURL(t *testing.T) {
+	useInMemoryBrowserUseWebActionStore(t)
+
+	_, _, err := SaveBrowserUseWebAction("admin", map[string]interface{}{
+		"action_group": "video",
+		"name":         "search",
+		"url":          "https://www.example.com/search",
+		"steps": []interface{}{
+			map[string]interface{}{"kind": "open", "url": "https://www.example.com/search?q={{query}}"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("save matching action: %v", err)
+	}
+	_, _, err = SaveBrowserUseWebAction("admin", map[string]interface{}{
+		"action_group": "docs",
+		"name":         "search",
+		"url":          "https://docs.other.test/search",
+		"steps": []interface{}{
+			map[string]interface{}{"kind": "open", "url": "https://docs.other.test/search?q={{query}}"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("save non-matching action: %v", err)
+	}
+
+	actions, err := ListBrowserUseWebActions("admin", BrowserUseWebActionFilter{URL: "https://search.example.com/results?q=agent"})
+	if err != nil {
+		t.Fatalf("list actions: %v", err)
+	}
+	if len(actions) != 1 || actions[0].ActionGroup != "video" {
+		t.Fatalf("expected same registrable-domain action, got %+v", actions)
+	}
+
+	actions, err = ListBrowserUseWebActions("admin", BrowserUseWebActionFilter{URL: "https://www.example.com.evil.test/search"})
+	if err != nil {
+		t.Fatalf("list evil host actions: %v", err)
+	}
+	if len(actions) != 0 {
+		t.Fatalf("expected no action for prefix-spoofed host, got %+v", actions)
+	}
+
+	text, err := browserUseListWebActionsText("admin", map[string]interface{}{}, "https://search.example.com/results?q=agent")
+	if err != nil {
+		t.Fatalf("list action text by url: %v", err)
+	}
+	if !strings.Contains(text, "video / search") {
+		t.Fatalf("expected same-site action in list text, got %q", text)
+	}
+	if strings.Contains(text, "docs / search") {
+		t.Fatalf("did not expect cross-site action in list text, got %q", text)
+	}
+}
+
+func TestDeleteBrowserUseWebActionResolvesAmbiguity(t *testing.T) {
+	useInMemoryBrowserUseWebActionStore(t)
+
+	for _, group := range []string{"docs", "forum"} {
+		_, _, err := SaveBrowserUseWebAction("admin", map[string]interface{}{
+			"action_group": group,
+			"name":         "search",
+			"steps": []interface{}{
+				map[string]interface{}{"kind": "open", "url": "https://" + group + ".example.com/search?q={{query}}"},
+			},
+		})
+		if err != nil {
+			t.Fatalf("save %s action: %v", group, err)
+		}
+	}
+
+	if _, _, err := DeleteBrowserUseWebAction("admin", "", "search"); err == nil {
+		t.Fatalf("expected ambiguous delete to fail")
+	}
+	deleted, ok, err := DeleteBrowserUseWebAction("admin", "docs", "search")
+	if err != nil {
+		t.Fatalf("delete docs action: %v", err)
+	}
+	if !ok || deleted.ActionGroup != "docs" {
+		t.Fatalf("unexpected deleted action: ok=%v action=%+v", ok, deleted)
+	}
+}
+
+func TestSaveBrowserUseWebActionStoresStartURL(t *testing.T) {
+	useInMemoryBrowserUseWebActionStore(t)
+
+	action, _, err := SaveBrowserUseWebAction("admin", map[string]interface{}{
+		"action_group": "forum",
+		"name":         "login",
+		"url":          "https://forum.example.com/login",
+		"steps": []interface{}{
+			map[string]interface{}{"kind": "click", "selector": "input[name=username]"},
+			map[string]interface{}{"kind": "type", "selector": "input[name=username]", "text": "{{username}}"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("save web action: %v", err)
+	}
+	if action.URL != "https://forum.example.com/login" {
+		t.Fatalf("expected start URL to be saved, got %q", action.URL)
+	}
+}
+
+func TestBrowserUseRunWebActionRequiresVariables(t *testing.T) {
+	action := browserUseWebAction{
+		Name:   "search",
+		Script: `[{"kind":"open","url":"https://docs.example.com/search?q={{ query }}"}]`,
+	}
+
+	if err := browserUseValidateWebActionVariables(action, map[string]string{}); err == nil {
+		t.Fatalf("expected missing variable error")
+	}
+	if err := browserUseValidateWebActionVariables(action, map[string]string{"query": "agent"}); err != nil {
+		t.Fatalf("expected variables to satisfy action: %v", err)
+	}
+}

--- a/tool/tool.go
+++ b/tool/tool.go
@@ -27,6 +27,7 @@ type Tool interface {
 
 // Config contains the fields needed to construct builtin tools.
 type Config struct {
+	Owner        string
 	Type         string
 	SubType      string
 	ProviderUrl  string
@@ -34,6 +35,7 @@ type Config struct {
 	ClientSecret string
 	EnableProxy  bool
 	Mode         string
+	UserDataDir  string
 }
 
 // New instantiates a tool implementation from its type.

--- a/web/src/StoreEditPage.js
+++ b/web/src/StoreEditPage.js
@@ -655,6 +655,14 @@ class StoreEditPage extends React.Component {
                   </Select>,
                   12
                 )}
+                {this.renderStoreSwitch(
+                  Setting.getLabel(i18next.t("store:Browser web action prompt injection"), i18next.t("store:Browser web action prompt injection - Tooltip")),
+                  store.browserUseWebActionPrompt,
+                  checked => {
+                    this.updateStoreField("browserUseWebActionPrompt", checked);
+                  },
+                  8
+                )}
               </>
             ) : null}
             {this.renderStoreField(

--- a/web/src/StoreListPage.js
+++ b/web/src/StoreListPage.js
@@ -181,6 +181,7 @@ class StoreListPage extends BaseListPage {
       isDefault: false,
       state: "Active",
       enableExperienceReview: false,
+      browserUseWebActionPrompt: false,
       enableExtraOptions: false,
     };
   }

--- a/web/src/locales/en/data.json
+++ b/web/src/locales/en/data.json
@@ -755,6 +755,8 @@
     "Private": "Private",
     "Prompt": "Prompt",
     "Prompt - Tooltip": "Global prompt template for AI behavior",
+    "Browser web action prompt injection": "Browser web action prompt injection",
+    "Browser web action prompt injection - Tooltip": "Experimental: inject saved browser web actions and lightweight reuse/recording hints into this agent's prompt.",
     "Publish State": "Publish State",
     "Publish State - Tooltip": "Control whether this agent is visible in the public Hub",
     "Published": "Published",

--- a/web/src/locales/zh/data.json
+++ b/web/src/locales/zh/data.json
@@ -755,6 +755,8 @@
     "Private": "私密",
     "Prompt": "提示词",
     "Prompt - Tooltip": "全局默认提示词",
+    "Browser web action prompt injection": "浏览器动作提示词注入",
+    "Browser web action prompt injection - Tooltip": "实验性功能：向此智能体提示词注入已保存的浏览器网页动作，以及轻量的复用/记录提示。",
     "Publish State": "公开状态",
     "Publish State - Tooltip": "控制此数据仓库是否在公开广场中显示",
     "Published": "已发布",


### PR DESCRIPTION
## Summary
Add recorded browser web actions so browser-use agents can reuse saved site workflows from natural language tasks.

## Changes
- Add browser web action storage model and CRUD APIs.
- Add browser-use tools for listing, saving, running, deleting, and inspecting web action traces.
- Add structured, parameterized action steps for open, click, type, press, and drag/drop workflows.
- Support action start URLs and variable substitution.
- Inject available web actions into browser-use context so agents can choose recorded actions before manual browsing.
- Add tests for web action parsing, matching, validation, and execution behavior.
