### PR TITLE
docs: note Go version for source builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ Open [http://localhost:14000](http://localhost:14000) and you're in.
 > Optional env vars: `OPENAGENT_VERSION`, `INSTALL_DIR`, `BIN_DIR`
 
 **Build from source**
+
+Requires Go 1.25.0+ for the backend, matching `go.mod`.
+
 ```bash
 # Backend
 go build


### PR DESCRIPTION
The README has source-build commands, but it does not mention the Go version expected by the backend.

This adds a small prerequisite note matching the current `go.mod` directive so contributors know which Go toolchain to use before running `go build`.