### PR TITLE
Enhance/ppt create

### DIFF
--- a/skills/powerpoint/SKILL.md
+++ b/skills/powerpoint/SKILL.md
@@ -5,23 +5,26 @@ description: Create designed, editable PowerPoint .pptx presentations with PptxG
 
 # PowerPoint
 
-Use this skill whenever a PowerPoint deck is involved. For new decks, first design a structured deck specification, then pass a trusted PptxGenJS build script to the `pptx_write` tool.
+Use this skill whenever a PowerPoint deck is involved. For new decks, first design a structured deck specification, then choose either editable PptxGenJS rendering or visual-first HTML rendering with the `pptx_write` tool.
 
 ## Workflow
 
 1. Infer the audience, goal, language, level of detail, and likely presentation setting from the user's request. Make conservative defaults when details are missing.
 2. Create an internal deck specification before writing code: deck thesis, visual system, slide rhythm, slide types, per-slide message, on-slide content, visual treatment, and speaker notes.
 3. Check the deck specification for content quality: each slide has one job, titles are conclusion-oriented, slide text is scannable, layouts vary, and visuals support the message.
-4. Write JavaScript module content that exports `default async function build(pptx, ctx)` or named `build(pptx, ctx)`.
-5. In the script, add slides directly with PptxGenJS. Do not generate HTML for this workflow.
-6. Call `pptx_write` with `path`, `script`, optional `assets_dir`, and optional `data`.
-7. Verify the result with `pptx_read`; for visual QA, convert the PPTX to images if the environment has LibreOffice and Poppler.
+4. Choose the rendering mode:
+   - Use PptxGenJS script mode when editable text/shapes/tables matter.
+   - Use HTML slides mode when visual fidelity, modern CSS layout, or fast high-quality composition matters more than editability.
+5. For script mode, write JavaScript module content that exports `default async function build(pptx, ctx)` or named `build(pptx, ctx)`.
+6. For HTML mode, provide complete HTML/CSS per slide in `html` or `slides`; each slide is rendered as an image and embedded full-slide in the PPTX.
+7. Call `pptx_write` with `path` and either `script`, `html`, or `slides`, plus optional `assets_dir`, `width`, `height`, and `data`.
+8. Verify the result with `pptx_read`; for visual QA, convert the PPTX to images if the environment has LibreOffice and Poppler.
 
 ## Planning Gate
 
 Do not jump straight from the user request to PptxGenJS code. First form a compact deck spec, even if it remains internal. The spec is the quality control layer: it prevents repetitive title-plus-bullet decks and keeps the script focused on rendering a coherent presentation.
 
-When a deck is more than three slides, use `deck-spec.md` and `content-quality.md` as the planning references. For API syntax, use `pptxgenjs.md`.
+When a deck is more than three slides, use `deck-spec.md` and `content-quality.md` as the planning references. For editable API syntax, use `pptxgenjs.md`. For visual-first HTML rendering, use `html-slides.md`.
 
 ## Script Creation
 
@@ -61,6 +64,27 @@ export default async function build(pptx, ctx) {
 }
 ```
 
+HTML mode example:
+
+```json
+{
+  "tool": "pptx_write",
+  "arguments": {
+    "path": "deck.pptx",
+    "width": 1280,
+    "height": 720,
+    "slides": [
+      {
+        "html": "<!doctype html><html><head><style>body{margin:0;width:1280px;height:720px}</style></head><body>...</body></html>",
+        "notes": "Speaker notes"
+      }
+    ]
+  }
+}
+```
+
+HTML slides are screenshot-based: they preserve CSS visual design well, but slide text is not editable inside PowerPoint. Use this intentionally.
+
 `ctx` includes:
 
 - `ctx.data`: JSON data passed from the tool call.
@@ -94,6 +118,7 @@ For API patterns, chart examples, bullets, image sizing, icons, and common file-
 - Load `deck-spec.md` when planning a new deck or revising the structure of an existing deck.
 - Load `content-quality.md` when the user asks for a polished, executive, educational, sales, research, or high-stakes deck.
 - Load `pptxgenjs.md` when implementing the final PptxGenJS script.
+- Load `html-slides.md` when implementing visual-first HTML slides.
 
 ## Required QA
 

--- a/skills/powerpoint/SKILL.md
+++ b/skills/powerpoint/SKILL.md
@@ -5,15 +5,23 @@ description: Create designed, editable PowerPoint .pptx presentations with PptxG
 
 # PowerPoint
 
-Use this skill whenever a PowerPoint deck is involved. For new decks, pass a trusted PptxGenJS build script directly to the `pptx_write` tool.
+Use this skill whenever a PowerPoint deck is involved. For new decks, first design a structured deck specification, then pass a trusted PptxGenJS build script to the `pptx_write` tool.
 
 ## Workflow
 
-1. Decide the deck outline and choose a visual system: palette, typography, repeated motif, and slide rhythm.
-2. Write JavaScript module content that exports `default async function build(pptx, ctx)` or named `build(pptx, ctx)`.
-3. In the script, add slides directly with PptxGenJS. Do not generate HTML for this workflow.
-4. Call `pptx_write` with `path`, `script`, optional `assets_dir`, and optional `data`.
-5. Verify the result with `pptx_read`; for visual QA, convert the PPTX to images if the environment has LibreOffice and Poppler.
+1. Infer the audience, goal, language, level of detail, and likely presentation setting from the user's request. Make conservative defaults when details are missing.
+2. Create an internal deck specification before writing code: deck thesis, visual system, slide rhythm, slide types, per-slide message, on-slide content, visual treatment, and speaker notes.
+3. Check the deck specification for content quality: each slide has one job, titles are conclusion-oriented, slide text is scannable, layouts vary, and visuals support the message.
+4. Write JavaScript module content that exports `default async function build(pptx, ctx)` or named `build(pptx, ctx)`.
+5. In the script, add slides directly with PptxGenJS. Do not generate HTML for this workflow.
+6. Call `pptx_write` with `path`, `script`, optional `assets_dir`, and optional `data`.
+7. Verify the result with `pptx_read`; for visual QA, convert the PPTX to images if the environment has LibreOffice and Poppler.
+
+## Planning Gate
+
+Do not jump straight from the user request to PptxGenJS code. First form a compact deck spec, even if it remains internal. The spec is the quality control layer: it prevents repetitive title-plus-bullet decks and keeps the script focused on rendering a coherent presentation.
+
+When a deck is more than three slides, use `deck-spec.md` and `content-quality.md` as the planning references. For API syntax, use `pptxgenjs.md`.
 
 ## Script Creation
 
@@ -71,14 +79,27 @@ export default async function build(pptx, ctx) {
 - Keep at least 0.5 inch margins and consistent gaps around 0.3-0.5 inch.
 - Use editable text wherever practical; use images for photos, screenshots, logos, or complex visual backgrounds.
 - Add speaker notes when useful; `pptx_read` can surface them later.
+- Slides are visual aids, not lecture scripts. Keep on-slide copy concise; move detailed explanation to notes.
+- Prefer message titles over topic labels. Use "Retention improves after onboarding fixes" instead of "Retention".
+- Every slide needs a clear information role: orient, compare, explain, prove, decide, summarize, or prompt action.
+- Use charts for quantities, tables for structured comparison, timelines/process flows for sequences, and card grids for parallel ideas.
+- Never include placeholder text, speaker self-references, or generic filler such as "More details here".
 
 ## PptxGenJS Reference
 
 For API patterns, chart examples, bullets, image sizing, icons, and common file-corruption pitfalls, load `pptxgenjs.md`.
+
+## Content References
+
+- Load `deck-spec.md` when planning a new deck or revising the structure of an existing deck.
+- Load `content-quality.md` when the user asks for a polished, executive, educational, sales, research, or high-stakes deck.
+- Load `pptxgenjs.md` when implementing the final PptxGenJS script.
 
 ## Required QA
 
 - Run `pptx_read` on the generated file and check slide order, missing text, typo risk, and notes.
 - Inspect generated XML or render slides when visual precision matters.
 - Watch for overlap, text overflow, low contrast, cramped spacing, repeated layouts, and leftover placeholder text.
+- Check that slide titles, key messages, and notes match the user's requested language and level of detail.
+- Confirm that at least 70% of non-cover slides use a layout richer than title-plus-bullets.
 - If a visual issue is found, edit the `.mjs` script and rewrite the PPTX.

--- a/skills/powerpoint/references/content-quality.md
+++ b/skills/powerpoint/references/content-quality.md
@@ -1,0 +1,123 @@
+# PowerPoint Content Quality Reference
+
+Use this reference to improve the quality of generated presentation content. It adapts the structured slide-planning discipline used by high-quality lesson and deck generators, while staying compatible with the `pptx_write` PptxGenJS workflow.
+
+## Core Principle
+
+Slides are visual aids, not lecture scripts. A strong deck separates:
+
+- on-slide content: keywords, short phrases, labels, data, diagrams, formulas, and concise claims
+- speaker notes: context, transitions, examples, caveats, and spoken explanation
+
+If a sentence sounds like something the presenter would say aloud, move it to notes or rewrite it as a shorter visual phrase.
+
+## Content Rules
+
+1. One slide, one job.
+   A slide should orient, compare, explain, prove, decide, summarize, or prompt action. Mixed-purpose slides become crowded.
+
+2. Use message titles.
+   Prefer "Three bottlenecks explain the delay" over "Project Status".
+
+3. Keep text scannable.
+   Use 3-5 points per slide. Keep each point under about 14 English words or 28 Chinese characters when practical.
+
+4. Use specific nouns and verbs.
+   Replace "Improve efficiency" with "Reduce review time from days to hours" when the user's context supports it.
+
+5. Match visuals to information.
+   - quantities: chart, stat callout, or annotated number
+   - comparisons: table, matrix, or side-by-side cards
+   - sequences: timeline or process flow
+   - systems: diagram with labeled parts and arrows
+   - concepts: icon cards, metaphor image, or before/after
+   - decisions: options table, scorecard, or recommendation slide
+
+6. Vary slide rhythm.
+   A typical 8-slide deck might use: cover, agenda, section, two-column, chart, cards, process, summary.
+
+7. Preserve audience fit.
+   Executive decks need conclusions, implications, and decisions. Educational decks need scaffolding, examples, and checks for understanding. Technical decks need precision, assumptions, and tradeoffs.
+
+8. Avoid speaker identity on slides.
+   Do not write "teacher's tip", "my advice", or named-presenter comments as slide content. Use neutral labels such as "Tip", "Note", "Key Takeaway", or "Reminder".
+
+## Layout Content Patterns
+
+### Cover
+
+- Big literal title or offer
+- Short subtitle with context
+- Optional date, audience, or owner
+
+### Section Divider
+
+- Section label
+- One claim that previews the section
+- Minimal body text
+
+### Two Column
+
+- Left: claim and 2-3 supporting points
+- Right: visual evidence, image, chart, or diagram
+- Title states the takeaway
+
+### Card Grid
+
+- 2x2 or 3x2 cards
+- Each card has icon, header, and one short body line
+- Cards should be parallel in grammar and length
+
+### Timeline or Process
+
+- 3-6 steps
+- Each step has verb-led title and short description
+- Use arrows or connectors only when they clarify sequence
+
+### Chart Slide
+
+- Title states what the data means
+- Chart uses minimal legend and direct labels when possible
+- Add one or two callouts for interpretation
+
+### Table Slide
+
+- Use for criteria-based comparison
+- Keep columns few enough to read
+- Highlight the recommended or important row
+
+### Summary
+
+- 3 takeaways or 3 next actions
+- Avoid repeating the agenda
+- Make the final implication clear
+
+## Language and Terminology
+
+- Follow the language of the user's request unless explicitly asked otherwise.
+- Preserve product names, code terms, model names, and established acronyms in their usual form.
+- For bilingual or learning contexts, introduce terminology once, then use consistently.
+- Use audience-appropriate vocabulary; do not overcomplicate beginner decks.
+
+## Pre-Script Quality Gate
+
+Before writing PptxGenJS code, verify the deck spec:
+
+- The deck thesis is clear.
+- Every slide has a message and role.
+- No slide has more than one dense text block.
+- Slide titles are not generic labels only.
+- At least 70% of content slides include a meaningful visual element.
+- Consecutive slide layouts are not repetitive.
+- Notes carry the deeper explanation.
+- No placeholders or filler phrases remain.
+
+## Final QA Gate
+
+After generating the PPTX and reading it back:
+
+- Slide order follows the planned narrative.
+- Text content matches the requested language.
+- Important slide titles and takeaways are present.
+- Notes are present when the on-slide text is intentionally concise.
+- No leftover scaffold labels such as "TODO", "placeholder", "insert chart", or "more details" appear.

--- a/skills/powerpoint/references/deck-spec.md
+++ b/skills/powerpoint/references/deck-spec.md
@@ -1,0 +1,84 @@
+# Deck Specification Reference
+
+Use this reference before writing a PptxGenJS script. The goal is to plan the presentation as structured content first, then render it.
+
+## Deck Spec Shape
+
+Create this structure mentally or in `ctx.data` when helpful:
+
+```json
+{
+  "title": "Deck title",
+  "audience": "Who will read or hear this",
+  "goal": "What the deck should make the audience understand or do",
+  "language": "Language and terminology policy",
+  "thesis": "One sentence that the deck proves",
+  "style": {
+    "tone": "executive|educational|technical|sales|workshop|research",
+    "palette": ["primary", "support", "accent"],
+    "typography": "font direction",
+    "motif": "repeated visual device"
+  },
+  "slides": [
+    {
+      "type": "cover|agenda|section|two_column|cards|timeline|process|chart|table|case|summary|closing",
+      "role": "orient|compare|explain|prove|decide|summarize|act",
+      "message": "The one idea this slide must land",
+      "title": "Conclusion-oriented slide title",
+      "content": ["short on-slide point"],
+      "visual": {
+        "kind": "icon|diagram|chart|table|image|callout|timeline|none",
+        "description": "What the visual shows and why"
+      },
+      "speakerNotes": "Optional fuller explanation"
+    }
+  ]
+}
+```
+
+## Planning Steps
+
+1. Infer audience and situation.
+   Decide whether the deck is for an executive decision, teaching, sales, research, internal planning, or public storytelling.
+
+2. Write the thesis.
+   A good deck is not a pile of related facts; it has a point of view.
+
+3. Choose slide roles.
+   Each slide should do one job: orient, compare, explain, prove, decide, summarize, or prompt action.
+
+4. Select slide types.
+   Use varied slide types. Avoid repeating title-plus-bullets for more than two consecutive slides.
+
+5. Assign visuals deliberately.
+   If the content has numbers, use a chart or stat callout. If it has steps, use a process. If it has alternatives, use a table or comparison cards.
+
+6. Move narration into notes.
+   On-slide text should be short and scannable; speaker notes can carry nuance and explanation.
+
+## Slide Type Guidance
+
+- `cover`: title, subtitle, context, date or owner when relevant.
+- `agenda`: 3-5 sections with short labels.
+- `section`: transition slide with a strong section claim.
+- `two_column`: explanation plus evidence, image, diagram, or comparison.
+- `cards`: 2-6 parallel ideas, each with icon/header/one-sentence body.
+- `timeline`: events, milestones, roadmap, or phased plan.
+- `process`: causal chain, workflow, decision path, or system flow.
+- `chart`: quantitative evidence with a takeaway title.
+- `table`: structured comparison, criteria matrix, options, or risks.
+- `case`: example, scenario, before/after, or mini-story.
+- `summary`: key takeaways, decision, risks, or next steps.
+- `closing`: final statement and call to action.
+
+## Spec Quality Checklist
+
+- The deck has one thesis, not just a topic.
+- Every slide has one message.
+- Slide titles state the takeaway when possible.
+- Content uses short phrases, not paragraphs.
+- Detailed explanation is in speaker notes.
+- The layout sequence has rhythm: simple, dense, visual, summary.
+- Visual choices match the information type.
+- The language matches the user request and audience.
+- No placeholder, filler, or generic business wording remains.

--- a/skills/powerpoint/references/html-slides.md
+++ b/skills/powerpoint/references/html-slides.md
@@ -1,0 +1,111 @@
+# HTML Slides Reference
+
+Use this reference when creating visual-first PowerPoint decks with `pptx_write` HTML mode. This mode renders each HTML slide in a headless browser, screenshots it as PNG, and embeds the image full-slide in a `.pptx`.
+
+## When to Use
+
+Use HTML mode when:
+
+- The user wants a polished, modern, highly visual deck.
+- CSS layout, gradients, cards, complex grids, or precise typography matter.
+- Fast visual composition is more important than PowerPoint editability.
+- The deck is for presenting or sharing as final output rather than heavy manual editing.
+
+Use PptxGenJS script mode instead when:
+
+- The user needs editable text, tables, charts, and shapes in PowerPoint.
+- The deck will be revised manually by non-technical users.
+- File size must stay small.
+
+## Tool Contract
+
+Single slide:
+
+```json
+{
+  "tool": "pptx_write",
+  "arguments": {
+    "path": "deck.pptx",
+    "width": 1280,
+    "height": 720,
+    "html": "<!doctype html><html>...</html>"
+  }
+}
+```
+
+Multiple slides:
+
+```json
+{
+  "tool": "pptx_write",
+  "arguments": {
+    "path": "deck.pptx",
+    "width": 1280,
+    "height": 720,
+    "assets_dir": "/absolute/path/to/assets",
+    "slides": [
+      {
+        "title": "Cover",
+        "html": "<!doctype html><html>...</html>",
+        "notes": "Opening narration."
+      }
+    ]
+  }
+}
+```
+
+Defaults:
+
+- `width`: 1280
+- `height`: 720
+- Aspect ratio is preserved in the generated PPTX layout.
+- Relative image/font paths in HTML resolve from `assets_dir` when provided.
+
+## HTML Requirements
+
+- Provide complete HTML for each slide, including `<!doctype html>`, `<html>`, `<head>`, `<meta charset="utf-8">`, and `<style>`.
+- Set fixed slide dimensions in CSS matching the viewport:
+
+```html
+<style>
+  html, body {
+    margin: 0;
+    width: 1280px;
+    height: 720px;
+    overflow: hidden;
+  }
+  .slide {
+    width: 1280px;
+    height: 720px;
+    position: relative;
+    box-sizing: border-box;
+  }
+</style>
+```
+
+- Use system fonts or local assets. Avoid remote web fonts unless the environment can access them.
+- Keep all content inside the slide bounds. Anything outside the viewport will be clipped.
+- Use SVG, CSS shapes, icon text, or local images for visual elements.
+- Use speaker notes in the `notes` field instead of placing long narration on the slide.
+
+## Design Guidance
+
+- Treat each HTML page as a finished slide, not a scrolling web page.
+- Use CSS grid/flex for layout, but keep dimensions deterministic.
+- Use strong hierarchy: title, key message, supporting evidence, visual.
+- Prefer concise, high-contrast text.
+- Avoid tiny text; body copy should usually be at least 22px at 1280x720.
+- Use 48-72px outer margins unless making an intentional full-bleed design.
+- Vary slide layouts across the deck.
+
+## Tradeoffs
+
+HTML mode creates screenshot-based slides:
+
+- Visual fidelity: high
+- PowerPoint editability: low
+- Text selection/editing: unavailable
+- Speaker notes: supported
+- Local image assets: supported through `assets_dir`
+
+Make this tradeoff clear when the user asks for an editable deck.

--- a/skills/powerpoint/references/pptxgenjs.md
+++ b/skills/powerpoint/references/pptxgenjs.md
@@ -19,6 +19,44 @@ export default async function build(pptx, ctx) {
 }
 ```
 
+## Deck Spec Driven Structure
+
+For medium or large decks, prefer passing a structured deck spec through `ctx.data` and rendering it. This keeps content planning separate from drawing instructions.
+
+```javascript
+export default async function build(pptx, ctx) {
+  pptx.layout = "LAYOUT_WIDE";
+  pptx.title = ctx.data?.title || ctx.data?.deckSpec?.title || "Presentation";
+
+  const deck = ctx.data?.deckSpec || {
+    title: "Presentation",
+    slides: [
+      {
+        type: "cover",
+        title: "Presentation",
+        message: "A clear point of view",
+        content: [],
+        speakerNotes: "",
+      },
+    ],
+  };
+
+  for (const item of deck.slides) {
+    const slide = pptx.addSlide();
+    slide.background = { color: "FFFFFF" };
+    if (item.type === "cover") {
+      slide.addText(item.title, { x: 0.7, y: 2.4, w: 9.2, h: 0.7, fontSize: 42, bold: true, margin: 0 });
+      slide.addText(item.message || "", { x: 0.72, y: 3.2, w: 8.4, h: 0.35, fontSize: 17, color: "475569", margin: 0 });
+    } else {
+      slide.addText(item.title || item.message, { x: 0.65, y: 0.45, w: 11.5, h: 0.45, fontSize: 28, bold: true, margin: 0 });
+    }
+    if (item.speakerNotes) slide.addNotes(item.speakerNotes);
+  }
+}
+```
+
+Use the deck spec to decide slide type, message, content, visual, and notes. Use PptxGenJS only to render that plan.
+
 Useful layouts:
 
 - `LAYOUT_WIDE`: 13.333 x 7.5 in.
@@ -145,6 +183,17 @@ Prefer a small set of chart colors from the deck palette. Hide legends when ther
 - Data slide: one large chart plus two or three stat callouts.
 - Closing: strong statement, next action, or summary trio.
 
+## Content-to-Layout Mapping
+
+- Use a chart when the message depends on quantitative change, ranking, distribution, or proportion.
+- Use a table when the message compares options across repeated criteria.
+- Use cards when the slide lists parallel themes, capabilities, risks, or recommendations.
+- Use a timeline for dates, phases, milestones, or maturity paths.
+- Use a process flow for cause-effect, operations, decision paths, or system steps.
+- Use a quote/callout only for one memorable sentence, not a paragraph.
+
+Do not use the same layout for more than two consecutive content slides unless the user asked for a template-like deck.
+
 ## QA Checklist
 
 - Slide order and text match the requested content.
@@ -153,4 +202,7 @@ Prefer a small set of chart colors from the deck palette. Hide legends when ther
 - Contrast is readable on every background.
 - Margins are at least 0.5 in unless intentionally full bleed.
 - Layouts vary; the deck does not read as repeated title-plus-bullets.
+- Titles express messages, not only topics, wherever practical.
+- Speaker notes contain the narrative when on-slide content is intentionally concise.
+- No placeholder text, generic filler, or invented data appears.
 - Generated file opens and `pptx_read` returns the expected text.

--- a/tool/office_ppt_write.go
+++ b/tool/office_ppt_write.go
@@ -33,14 +33,22 @@ type pptxWriteBuiltin struct{}
 
 type pptxWriteArgs struct {
 	Path      string          `json:"path"`
-	Script    string          `json:"script"`
+	Script    string          `json:"script,omitempty"`
+	HTML      string          `json:"html,omitempty"`
+	Slides    json.RawMessage `json:"slides,omitempty"`
+	Width     int             `json:"width,omitempty"`
+	Height    int             `json:"height,omitempty"`
 	AssetsDir string          `json:"assets_dir,omitempty"`
 	Data      json.RawMessage `json:"data,omitempty"`
 }
 
 type pptxWriteWorkerSpec struct {
 	Path       string          `json:"path"`
-	ScriptPath string          `json:"script_path"`
+	ScriptPath string          `json:"script_path,omitempty"`
+	HTML       string          `json:"html,omitempty"`
+	Slides     json.RawMessage `json:"slides,omitempty"`
+	Width      int             `json:"width,omitempty"`
+	Height     int             `json:"height,omitempty"`
 	AssetsDir  string          `json:"assets_dir,omitempty"`
 	Data       json.RawMessage `json:"data,omitempty"`
 }
@@ -61,11 +69,14 @@ type pptxWorkerCandidate struct {
 func (t *pptxWriteBuiltin) GetName() string { return "pptx_write" }
 
 func (t *pptxWriteBuiltin) GetDescription() string {
-	return `Create a designed PowerPoint (.pptx) file by running a PptxGenJS build script.
+	return `Create a designed PowerPoint (.pptx) file either by running a PptxGenJS build script or by rendering HTML slides to images and embedding them into a .pptx.
 - path (required): output path for the .pptx file. Absolute paths are used as-is. Relative paths or bare filenames are resolved inside the current user's Documents folder.
-- script (required): JavaScript module content that exports default async function build(pptx, ctx) or a named build function. The script adds slides to the provided PptxGenJS instance.
+- script: JavaScript module content that exports default async function build(pptx, ctx) or a named build function. The script adds slides to the provided PptxGenJS instance.
+- html: a single complete HTML slide to render as a full-slide screenshot.
+- slides: an array of HTML slide objects, each with html and optional notes/title fields. Use this for HTML/CSS-authored decks.
+- width/height: optional HTML render viewport in pixels. Defaults to 1280x720.
 - data (optional): JSON value passed to ctx.data inside the script for content or configuration.
-- assets_dir (optional): base directory for ctx.resolveAsset() and ctx.imageData() calls.
+- assets_dir (optional): base directory for ctx.resolveAsset() and ctx.imageData() calls, and for relative assets inside HTML slides.
 Creates the file if it does not exist; overwrites otherwise.`
 }
 
@@ -79,7 +90,41 @@ func (t *pptxWriteBuiltin) GetInputSchema() interface{} {
 			},
 			"script": map[string]interface{}{
 				"type":        "string",
-				"description": "JavaScript module content exporting default build(pptx, ctx) or named build(pptx, ctx).",
+				"description": "JavaScript module content exporting default build(pptx, ctx) or named build(pptx, ctx). Required unless html or slides is provided.",
+			},
+			"html": map[string]interface{}{
+				"type":        "string",
+				"description": "Single complete HTML slide to render as a full-slide screenshot and embed in the PPTX.",
+			},
+			"slides": map[string]interface{}{
+				"type":        "array",
+				"description": "HTML slide objects for screenshot-based PPTX export.",
+				"items": map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"html": map[string]interface{}{
+							"type":        "string",
+							"description": "Complete HTML for this slide.",
+						},
+						"notes": map[string]interface{}{
+							"type":        "string",
+							"description": "Optional speaker notes for this slide.",
+						},
+						"title": map[string]interface{}{
+							"type":        "string",
+							"description": "Optional slide title metadata.",
+						},
+					},
+					"required": []string{"html"},
+				},
+			},
+			"width": map[string]interface{}{
+				"type":        "integer",
+				"description": "Optional HTML render viewport width in pixels. Defaults to 1280.",
+			},
+			"height": map[string]interface{}{
+				"type":        "integer",
+				"description": "Optional HTML render viewport height in pixels. Defaults to 720.",
 			},
 			"data": map[string]interface{}{
 				"type":        "object",
@@ -90,12 +135,12 @@ func (t *pptxWriteBuiltin) GetInputSchema() interface{} {
 				"description": "Optional asset base directory for ctx.resolveAsset() and ctx.imageData().",
 			},
 		},
-		"required": []string{"path", "script"},
+		"required": []string{"path"},
 	}
 }
 
-// Execute writes the inline build script to a temporary module, then runs the
-// local Node/PptxGenJS worker.
+// Execute writes the inline build script when needed, then runs the local
+// Node/PptxGenJS worker.
 func (t *pptxWriteBuiltin) Execute(ctx context.Context, arguments map[string]interface{}) (*protocol.CallToolResult, error) {
 	argBytes, err := json.Marshal(arguments)
 	if err != nil {
@@ -112,8 +157,10 @@ func (t *pptxWriteBuiltin) Execute(ctx context.Context, arguments map[string]int
 		return officeToolError("Missing required parameter: path"), nil
 	}
 
-	if strings.TrimSpace(args.Script) == "" {
-		return officeToolError("Missing required parameter: script"), nil
+	args.Script = strings.TrimSpace(args.Script)
+	args.HTML = strings.TrimSpace(args.HTML)
+	if args.Script == "" && args.HTML == "" && len(args.Slides) == 0 {
+		return officeToolError("Missing required parameter: script, html, or slides"), nil
 	}
 
 	args.AssetsDir = strings.TrimSpace(args.AssetsDir)
@@ -144,24 +191,31 @@ func (t *pptxWriteBuiltin) Execute(ctx context.Context, arguments map[string]int
 
 	args.Path = ResolveOutputPath(args.Path)
 
-	scriptFile, err := os.CreateTemp("", "openagent-pptx-build-*.mjs")
-	if err != nil {
-		return officeToolError(fmt.Sprintf("Failed to create build script: %s", err.Error())), nil
-	}
-	scriptPath := scriptFile.Name()
-	defer os.Remove(scriptPath)
+	var scriptPath string
+	if args.Script != "" {
+		scriptFile, err := os.CreateTemp("", "openagent-pptx-build-*.mjs")
+		if err != nil {
+			return officeToolError(fmt.Sprintf("Failed to create build script: %s", err.Error())), nil
+		}
+		scriptPath = scriptFile.Name()
+		defer os.Remove(scriptPath)
 
-	if _, err := scriptFile.WriteString(args.Script); err != nil {
-		scriptFile.Close()
-		return officeToolError(fmt.Sprintf("Failed to write build script: %s", err.Error())), nil
-	}
-	if err := scriptFile.Close(); err != nil {
-		return officeToolError(fmt.Sprintf("Failed to close build script: %s", err.Error())), nil
+		if _, err := scriptFile.WriteString(args.Script); err != nil {
+			scriptFile.Close()
+			return officeToolError(fmt.Sprintf("Failed to write build script: %s", err.Error())), nil
+		}
+		if err := scriptFile.Close(); err != nil {
+			return officeToolError(fmt.Sprintf("Failed to close build script: %s", err.Error())), nil
+		}
 	}
 
 	spec := pptxWriteWorkerSpec{
 		Path:       args.Path,
 		ScriptPath: scriptPath,
+		HTML:       args.HTML,
+		Slides:     args.Slides,
+		Width:      args.Width,
+		Height:     args.Height,
 		AssetsDir:  args.AssetsDir,
 		Data:       args.Data,
 	}

--- a/tool/pptx-worker/worker.mjs
+++ b/tool/pptx-worker/worker.mjs
@@ -1,6 +1,8 @@
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { execFile, execFileSync } from 'node:child_process';
 import * as solidIcons from '@fortawesome/free-solid-svg-icons';
 import PptxGenJS from 'pptxgenjs';
 
@@ -125,9 +127,234 @@ function createPresentation() {
   return pptx;
 }
 
+function execFileAsync(file, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    execFile(file, args, options, (error, stdout, stderr) => {
+      if (error) {
+        error.stdout = stdout;
+        error.stderr = stderr;
+        reject(error);
+        return;
+      }
+      resolve({ stdout, stderr });
+    });
+  });
+}
+
+function chromeCandidates() {
+  const envCandidates = [
+    process.env.OPENAGENT_CHROME_PATH,
+    process.env.CHROME_PATH,
+    process.env.PUPPETEER_EXECUTABLE_PATH,
+  ].filter(Boolean);
+
+  const platformCandidates = process.platform === 'win32'
+    ? [
+        'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
+        'C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe',
+        'C:\\Program Files\\Microsoft\\Edge\\Application\\msedge.exe',
+        'C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe',
+      ]
+    : process.platform === 'darwin'
+      ? [
+          '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+          '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
+          '/Applications/Chromium.app/Contents/MacOS/Chromium',
+        ]
+      : [
+          'google-chrome',
+          'google-chrome-stable',
+          'chromium',
+          'chromium-browser',
+          'microsoft-edge',
+        ];
+
+  return [...envCandidates, ...platformCandidates];
+}
+
+function findChromeExecutable() {
+  for (const candidate of chromeCandidates()) {
+    if (path.isAbsolute(candidate)) {
+      if (fs.existsSync(candidate)) return candidate;
+      continue;
+    }
+    try {
+      execFileSync(candidate, ['--version'], { stdio: 'ignore' });
+      return candidate;
+    } catch {
+      // Try the next browser command.
+    }
+  }
+  return '';
+}
+
+function baseHrefForDir(dir) {
+  const resolved = path.resolve(dir || process.cwd());
+  const withSep = resolved.endsWith(path.sep) ? resolved : `${resolved}${path.sep}`;
+  return pathToFileURL(withSep).href;
+}
+
+function htmlWithBase(html, assetsDir) {
+  const source = text(html).trim();
+  if (!source) {
+    throw new Error('HTML slide content is required');
+  }
+
+  const baseTag = `<base href="${escapeXml(baseHrefForDir(assetsDir))}">`;
+  if (/<base\s/i.test(source)) {
+    return source;
+  }
+  if (/<head[^>]*>/i.test(source)) {
+    return source.replace(/<head([^>]*)>/i, `<head$1>${baseTag}`);
+  }
+  if (/<html[^>]*>/i.test(source)) {
+    return source.replace(/<html([^>]*)>/i, `<html$1><head>${baseTag}</head>`);
+  }
+  return `<!doctype html><html><head>${baseTag}<meta charset="utf-8"></head><body>${source}</body></html>`;
+}
+
+function normalizeHtmlSlides(spec) {
+  if (Array.isArray(spec.slides) && spec.slides.length > 0) {
+    return spec.slides.map((item, index) => {
+      if (typeof item === 'string') {
+        return { html: item, title: `Slide ${index + 1}`, notes: '' };
+      }
+      if (!item || typeof item !== 'object') {
+        throw new Error(`slides[${index}] must be a string or object`);
+      }
+      return {
+        html: text(item.html),
+        title: text(item.title || `Slide ${index + 1}`),
+        notes: text(item.notes),
+      };
+    });
+  }
+  if (text(spec.html).trim()) {
+    return [{ html: spec.html, title: 'Slide 1', notes: '' }];
+  }
+  return [];
+}
+
+function htmlViewport(spec) {
+  const width = Number.isFinite(Number(spec.width)) && Number(spec.width) > 0
+    ? Math.round(Number(spec.width))
+    : 1280;
+  const height = Number.isFinite(Number(spec.height)) && Number(spec.height) > 0
+    ? Math.round(Number(spec.height))
+    : 720;
+  return { width, height };
+}
+
+function defineHtmlLayout(pptx, viewport) {
+  const widthIn = 13.333;
+  const heightIn = widthIn * (viewport.height / viewport.width);
+  pptx.defineLayout({ name: 'OPENAGENT_HTML', width: widthIn, height: heightIn });
+  pptx.layout = 'OPENAGENT_HTML';
+  return { w: widthIn, h: heightIn };
+}
+
+async function screenshotHtmlSlide({ chromePath, tmpDir, html, assetsDir, viewport, index }) {
+  const htmlPath = path.join(tmpDir, `slide-${String(index + 1).padStart(3, '0')}.html`);
+  const pngPath = path.join(tmpDir, `slide-${String(index + 1).padStart(3, '0')}.png`);
+  const profileDir = path.join(tmpDir, `chrome-profile-${String(index + 1).padStart(3, '0')}`);
+  fs.writeFileSync(htmlPath, htmlWithBase(html, assetsDir), 'utf8');
+
+  const argsFor = (headlessFlag) => [
+    headlessFlag,
+    '--disable-gpu',
+    '--disable-gpu-sandbox',
+    '--disable-gpu-compositing',
+    '--disable-features=VizDisplayCompositor,UseSkiaRenderer',
+    '--disable-dev-shm-usage',
+    '--disable-extensions',
+    '--disable-background-networking',
+    '--no-sandbox',
+    '--hide-scrollbars',
+    '--no-first-run',
+    '--no-default-browser-check',
+    `--user-data-dir=${profileDir}`,
+    `--window-size=${viewport.width},${viewport.height}`,
+    '--virtual-time-budget=1500',
+    `--screenshot=${pngPath}`,
+    pathToFileURL(htmlPath).href,
+  ];
+
+  try {
+    await execFileAsync(chromePath, argsFor('--headless=new'), { timeout: 30000 });
+  } catch (firstError) {
+    try {
+      await execFileAsync(chromePath, argsFor('--headless'), { timeout: 30000 });
+    } catch (secondError) {
+      const detail = text(secondError.stderr || secondError.message || firstError.message).trim();
+      throw new Error(`failed to render HTML slide ${index + 1} with Chrome: ${detail}`);
+    }
+  }
+
+  if (!fs.existsSync(pngPath)) {
+    throw new Error(`Chrome did not create a screenshot for HTML slide ${index + 1}`);
+  }
+  return `data:image/png;base64,${fs.readFileSync(pngPath).toString('base64')}`;
+}
+
+async function generateHtmlDeck(spec) {
+  if (!spec.path) {
+    throw new Error('path is required');
+  }
+
+  spec.path = path.resolve(spec.path);
+  fs.mkdirSync(path.dirname(spec.path), { recursive: true });
+
+  const slides = normalizeHtmlSlides(spec);
+  if (slides.length === 0) {
+    throw new Error('html or slides is required for HTML PowerPoint export');
+  }
+
+  const chromePath = findChromeExecutable();
+  if (!chromePath) {
+    throw new Error('Chrome or Edge was not found; install Chrome/Edge or set OPENAGENT_CHROME_PATH to enable HTML PowerPoint export');
+  }
+
+  const viewport = htmlViewport(spec);
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openagent-pptx-html-'));
+  const pptx = createPresentation();
+  const slideSize = defineHtmlLayout(pptx, viewport);
+
+  try {
+    for (let i = 0; i < slides.length; i++) {
+      const image = await screenshotHtmlSlide({
+        chromePath,
+        tmpDir,
+        html: slides[i].html,
+        assetsDir: spec.assets_dir || path.dirname(spec.path),
+        viewport,
+        index: i,
+      });
+      const slide = pptx.addSlide();
+      slide.background = { color: 'FFFFFF' };
+      slide.addImage({ data: image, x: 0, y: 0, w: slideSize.w, h: slideSize.h });
+      if (slides[i].notes) {
+        slide.addNotes(slides[i].notes);
+      }
+    }
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+
+  await pptx.writeFile({ fileName: spec.path });
+  return {
+    ok: true,
+    path: spec.path,
+    slideCount: slides.length,
+    mode: 'html-screenshot',
+  };
+}
+
 async function generateDeck(spec) {
   if (!spec.path) {
     throw new Error('path is required');
+  }
+  if (text(spec.html).trim() || (Array.isArray(spec.slides) && spec.slides.length > 0)) {
+    return generateHtmlDeck(spec);
   }
   if (!spec.script_path) {
     throw new Error('script_path is required');
@@ -165,7 +392,7 @@ async function main() {
     throw new Error('usage: node worker.mjs <spec.json>');
   }
 
-  const spec = JSON.parse(fs.readFileSync(specPath, 'utf8'));
+  const spec = JSON.parse(fs.readFileSync(specPath, 'utf8').replace(/^\uFEFF/, ''));
   return generateDeck(spec);
 }
 


### PR DESCRIPTION
## Summary

Closes #2297.

This PR improves PowerPoint generation quality by adding a structured content-planning layer to the `powerpoint` skill before generating PptxGenJS code.

Instead of jumping directly from a user request to a `.pptx` build script, the skill now guides the agent to first plan the deck thesis, audience, slide roles, per-slide messages, visual treatments, and speaker notes. This should produce more coherent, less repetitive, and more presentation-ready `.pptx` decks.

## Changes

- Updated `skills/powerpoint/SKILL.md` to require a deck specification and content quality check before writing PptxGenJS scripts.
- Added `deck-spec.md` as a planning reference for structured presentation generation.
- Added `content-quality.md` with slide quality rules around message titles, concise slide text, visual matching, layout rhythm, and speaker notes.
- Extended `pptxgenjs.md` with a deck-spec-driven implementation pattern and content-to-layout mapping guidance.

## Notes

This PR focuses on improving PPT content quality through skill and prompt guidance. It does not change the underlying `pptx_write` tool or the PptxGenJS worker.

## Testing

- Not run; documentation/skill guidance changes only.