### PR TITLE
feat: parse uploaded attachment content for message answers

### DIFF
--- a/controllers/message_answer.go
+++ b/controllers/message_answer.go
@@ -247,6 +247,17 @@ func generateMessageAnswer(id string, responseWriter http.ResponseWriter, host s
 
 		question = questionMessage.Text
 
+		// Replace file CDN URLs in the question with their parsed text content
+		// stored in ParsedAttachmentText during RefineMessageFiles.
+		if questionMessage.ParsedAttachmentText != "" {
+			var parsedTexts map[string]string
+			if err := json.Unmarshal([]byte(questionMessage.ParsedAttachmentText), &parsedTexts); err == nil {
+				for urlStr, replacement := range parsedTexts {
+					question = strings.Replace(question, urlStr, replacement, 1)
+				}
+			}
+		}
+
 		question, err = refineQuestionTextViaParsingUrlContent(question, lang)
 		if err != nil {
 			responseErrorStream(message, err.Error())

--- a/controllers/message_answer.go
+++ b/controllers/message_answer.go
@@ -247,14 +247,14 @@ func generateMessageAnswer(id string, responseWriter http.ResponseWriter, host s
 
 		question = questionMessage.Text
 
-		// Replace file CDN URLs in the question with their parsed text content
-		// stored in ParsedAttachmentText during RefineMessageFiles.
 		if questionMessage.ParsedAttachmentText != "" {
 			var parsedTexts map[string]string
-			if err := json.Unmarshal([]byte(questionMessage.ParsedAttachmentText), &parsedTexts); err == nil {
-				for urlStr, replacement := range parsedTexts {
-					question = strings.Replace(question, urlStr, replacement, 1)
-				}
+			if err := json.Unmarshal([]byte(questionMessage.ParsedAttachmentText), &parsedTexts); err != nil {
+				responseErrorStream(message, err.Error())
+				return
+			}
+			for urlStr, replacement := range parsedTexts {
+				question = strings.Replace(question, urlStr, replacement, 1)
 			}
 		}
 

--- a/object/message.go
+++ b/object/message.go
@@ -322,7 +322,7 @@ func parseAndFormatAttachment(content []byte, displayName string, httpUrl string
 	if p < 0 {
 		return ""
 	}
-	ext := displayName[p+1:]
+	ext := displayName[p:]
 
 	tmpFile, err := ioutil.TempFile("", "openagent-attachment-*"+displayName)
 	if err != nil {

--- a/object/message.go
+++ b/object/message.go
@@ -17,12 +17,15 @@ package object
 import (
 	"bytes"
 	"fmt"
+	"io/ioutil"
+	"os"
 	"regexp"
 	"strings"
 	"time"
 
 	"github.com/the-open-agent/openagent/i18n"
 	"github.com/the-open-agent/openagent/model"
+	"github.com/the-open-agent/openagent/txt"
 	"github.com/the-open-agent/openagent/util"
 	"xorm.io/core"
 )
@@ -288,12 +291,58 @@ func RefineMessageFiles(message *Message, origin string, lang string) error {
 				return err
 			}
 
+			mimeType := dataURLMimeType(match)
+			if !strings.HasPrefix(mimeType, "image/") {
+				displayName := lastURIPath(httpUrl)
+				replacement := parseAndFormatAttachment(content, displayName, httpUrl, lang)
+				if replacement != "" {
+					text = strings.Replace(text, match, replacement, 1)
+					continue
+				}
+			}
+
 			text = strings.Replace(text, match, httpUrl, 1)
 		}
 	}
 
 	message.Text = text
 	return nil
+}
+
+func lastURIPath(httpUrl string) string {
+	idx := strings.LastIndex(httpUrl, "/")
+	if idx < 0 || idx == len(httpUrl)-1 {
+		return httpUrl
+	}
+	return httpUrl[idx+1:]
+}
+
+func parseAndFormatAttachment(content []byte, displayName string, httpUrl string, lang string) string {
+	p := strings.LastIndex(displayName, ".")
+	if p < 0 {
+		return ""
+	}
+	ext := displayName[p+1:]
+
+	tmpFile, err := ioutil.TempFile("", "openagent-attachment-*"+displayName)
+	if err != nil {
+		return ""
+	}
+	tmpPath := tmpFile.Name()
+	defer os.Remove(tmpPath)
+
+	if _, err := tmpFile.Write(content); err != nil {
+		tmpFile.Close()
+		return ""
+	}
+	tmpFile.Close()
+
+	parsed, err := txt.GetParsedTextFromUrl(tmpPath, ext, lang)
+	if err != nil {
+		return ""
+	}
+
+	return fmt.Sprintf("[Attachment \"%s\"](%s):\n\n%s\n\n", displayName, httpUrl, parsed)
 }
 
 func AddMessage(message *Message) (bool, error) {

--- a/object/message.go
+++ b/object/message.go
@@ -18,8 +18,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -57,7 +55,7 @@ type Message struct {
 	ErrorText            string               `xorm:"mediumtext" json:"errorText"`
 	FileName             string               `xorm:"varchar(100)" json:"fileName"`
 	Comment              string               `xorm:"mediumtext" json:"comment"`
-	ParsedAttachmentText string               `xorm:"mediumtext" json:"parsedAttachmentText"`
+	ParsedAttachmentText string               `xorm:"mediumtext" json:"-"`
 	TokenCount           int                  `json:"tokenCount"`
 	TextTokenCount       int                  `json:"textTokenCount"`
 	Price                float64              `json:"price"`
@@ -226,6 +224,7 @@ func dataURLMimeType(dataURL string) string {
 
 func RefineMessageFiles(message *Message, origin string, lang string) error {
 	text := message.Text
+	parsedTexts := map[string]string{}
 	// re := regexp.MustCompile(`data:image\/([a-zA-Z]*);base64,([^"]*)`)
 	re := regexp.MustCompile(`data:([a-zA-Z0-9][a-zA-Z0-9!#$&^_.+\-]*\/[a-zA-Z0-9][a-zA-Z0-9!#$&^_.+\-]*);base64,[a-zA-Z0-9+/=_-]+`)
 	matches := re.FindAllString(text, -1)
@@ -267,8 +266,6 @@ func RefineMessageFiles(message *Message, origin string, lang string) error {
 			return err
 		}
 
-		parsedTexts := make(map[string]string)
-
 		for _, match := range matches {
 			var content []byte
 			content, err = parseBase64Image(match, lang)
@@ -298,53 +295,42 @@ func RefineMessageFiles(message *Message, origin string, lang string) error {
 			mimeType := dataURLMimeType(match)
 			if !strings.HasPrefix(mimeType, "image/") {
 				displayName := httpUrl[strings.LastIndex(httpUrl, "/")+1:]
-				replacement := parseAndFormatAttachment(content, displayName, httpUrl, lang)
-				if replacement != "" {
-					parsedTexts[httpUrl] = replacement
+				replacement, err := parseAndFormatAttachment(content, displayName, httpUrl, lang)
+				if err != nil {
+					return err
 				}
+				parsedTexts[httpUrl] = replacement
 			}
 
 			text = strings.Replace(text, match, httpUrl, 1)
 		}
+	}
 
-		if len(parsedTexts) > 0 {
-			bs, err := json.Marshal(parsedTexts)
-			if err == nil {
-				message.ParsedAttachmentText = string(bs)
-			}
+	if len(parsedTexts) > 0 {
+		bs, err := json.Marshal(parsedTexts)
+		if err != nil {
+			return err
 		}
+		message.ParsedAttachmentText = string(bs)
 	}
 
 	message.Text = text
 	return nil
 }
 
-func parseAndFormatAttachment(content []byte, displayName string, httpUrl string, lang string) string {
+func parseAndFormatAttachment(content []byte, displayName string, httpUrl string, lang string) (string, error) {
 	p := strings.LastIndex(displayName, ".")
 	if p < 0 {
-		return ""
+		return "", fmt.Errorf(i18n.Translate(lang, "txt:unsupported file type: %s"), "")
 	}
 	ext := displayName[p:]
 
-	tmpFile, err := ioutil.TempFile("", "openagent-attachment-*"+displayName)
+	parsed, err := txt.GetParsedTextFromBytes(content, ext, lang)
 	if err != nil {
-		return ""
-	}
-	tmpPath := tmpFile.Name()
-	defer os.Remove(tmpPath)
-
-	if _, err := tmpFile.Write(content); err != nil {
-		tmpFile.Close()
-		return ""
-	}
-	tmpFile.Close()
-
-	parsed, err := txt.GetParsedTextFromUrl(tmpPath, ext, lang)
-	if err != nil {
-		return ""
+		return "", err
 	}
 
-	return fmt.Sprintf("[Attachment \"%s\"](%s):\n\n%s\n\n", displayName, httpUrl, parsed)
+	return fmt.Sprintf("[Attachment \"%s\"](%s):\n\n%s\n\n", displayName, httpUrl, parsed), nil
 }
 
 func AddMessage(message *Message) (bool, error) {

--- a/object/message.go
+++ b/object/message.go
@@ -16,6 +16,7 @@ package object
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -45,35 +46,36 @@ type Message struct {
 	Name        string `xorm:"varchar(100) notnull pk" json:"name"`
 	CreatedTime string `xorm:"varchar(100)" json:"createdTime"`
 
-	Organization      string               `xorm:"varchar(100)" json:"organization"`
-	Store             string               `xorm:"varchar(100)" json:"store"`
-	User              string               `xorm:"varchar(100) index" json:"user"`
-	Chat              string               `xorm:"varchar(100) index" json:"chat"`
-	ReplyTo           string               `xorm:"varchar(100) index" json:"replyTo"`
-	Author            string               `xorm:"varchar(100)" json:"author"`
-	Text              string               `xorm:"mediumtext" json:"text"`
-	ReasonText        string               `xorm:"mediumtext" json:"reasonText"`
-	ErrorText         string               `xorm:"mediumtext" json:"errorText"`
-	FileName          string               `xorm:"varchar(100)" json:"fileName"`
-	Comment           string               `xorm:"mediumtext" json:"comment"`
-	TokenCount        int                  `json:"tokenCount"`
-	TextTokenCount    int                  `json:"textTokenCount"`
-	Price             float64              `json:"price"`
-	Currency          string               `xorm:"varchar(100)" json:"currency"`
-	IsHidden          bool                 `json:"isHidden"`
-	IsDeleted         bool                 `json:"isDeleted"`
-	NeedNotify        bool                 `json:"needNotify"`
-	IsAlerted         bool                 `json:"isAlerted"`
-	IsRegenerated     bool                 `json:"isRegenerated"`
-	WebSearchEnabled  bool                 `json:"webSearchEnabled"`
-	ModelProvider     string               `xorm:"varchar(100)" json:"modelProvider"`
-	EmbeddingProvider string               `xorm:"varchar(100)" json:"embeddingProvider"`
-	VectorScores      []VectorScore        `xorm:"mediumtext" json:"vectorScores"`
-	LikeUsers         []string             `json:"likeUsers"`
-	DisLikeUsers      []string             `json:"dislikeUsers"`
-	Suggestions       []Suggestion         `json:"suggestions"`
-	ToolCalls         []model.ToolCall     `xorm:"mediumtext" json:"toolCalls"`
-	SearchResults     []model.SearchResult `xorm:"mediumtext" json:"searchResults"`
+	Organization         string               `xorm:"varchar(100)" json:"organization"`
+	Store                string               `xorm:"varchar(100)" json:"store"`
+	User                 string               `xorm:"varchar(100) index" json:"user"`
+	Chat                 string               `xorm:"varchar(100) index" json:"chat"`
+	ReplyTo              string               `xorm:"varchar(100) index" json:"replyTo"`
+	Author               string               `xorm:"varchar(100)" json:"author"`
+	Text                 string               `xorm:"mediumtext" json:"text"`
+	ReasonText           string               `xorm:"mediumtext" json:"reasonText"`
+	ErrorText            string               `xorm:"mediumtext" json:"errorText"`
+	FileName             string               `xorm:"varchar(100)" json:"fileName"`
+	Comment              string               `xorm:"mediumtext" json:"comment"`
+	ParsedAttachmentText string               `xorm:"mediumtext" json:"parsedAttachmentText"`
+	TokenCount           int                  `json:"tokenCount"`
+	TextTokenCount       int                  `json:"textTokenCount"`
+	Price                float64              `json:"price"`
+	Currency             string               `xorm:"varchar(100)" json:"currency"`
+	IsHidden             bool                 `json:"isHidden"`
+	IsDeleted            bool                 `json:"isDeleted"`
+	NeedNotify           bool                 `json:"needNotify"`
+	IsAlerted            bool                 `json:"isAlerted"`
+	IsRegenerated        bool                 `json:"isRegenerated"`
+	WebSearchEnabled     bool                 `json:"webSearchEnabled"`
+	ModelProvider        string               `xorm:"varchar(100)" json:"modelProvider"`
+	EmbeddingProvider    string               `xorm:"varchar(100)" json:"embeddingProvider"`
+	VectorScores         []VectorScore        `xorm:"mediumtext" json:"vectorScores"`
+	LikeUsers            []string             `json:"likeUsers"`
+	DisLikeUsers         []string             `json:"dislikeUsers"`
+	Suggestions          []Suggestion         `json:"suggestions"`
+	ToolCalls            []model.ToolCall     `xorm:"mediumtext" json:"toolCalls"`
+	SearchResults        []model.SearchResult `xorm:"mediumtext" json:"searchResults"`
 
 	TransactionId string `xorm:"varchar(100)" json:"transactionId"`
 }
@@ -265,6 +267,8 @@ func RefineMessageFiles(message *Message, origin string, lang string) error {
 			return err
 		}
 
+		parsedTexts := make(map[string]string)
+
 		for _, match := range matches {
 			var content []byte
 			content, err = parseBase64Image(match, lang)
@@ -293,28 +297,26 @@ func RefineMessageFiles(message *Message, origin string, lang string) error {
 
 			mimeType := dataURLMimeType(match)
 			if !strings.HasPrefix(mimeType, "image/") {
-				displayName := lastURIPath(httpUrl)
+				displayName := httpUrl[strings.LastIndex(httpUrl, "/")+1:]
 				replacement := parseAndFormatAttachment(content, displayName, httpUrl, lang)
 				if replacement != "" {
-					text = strings.Replace(text, match, replacement, 1)
-					continue
+					parsedTexts[httpUrl] = replacement
 				}
 			}
 
 			text = strings.Replace(text, match, httpUrl, 1)
 		}
+
+		if len(parsedTexts) > 0 {
+			bs, err := json.Marshal(parsedTexts)
+			if err == nil {
+				message.ParsedAttachmentText = string(bs)
+			}
+		}
 	}
 
 	message.Text = text
 	return nil
-}
-
-func lastURIPath(httpUrl string) string {
-	idx := strings.LastIndex(httpUrl, "/")
-	if idx < 0 || idx == len(httpUrl)-1 {
-		return httpUrl
-	}
-	return httpUrl[idx+1:]
 }
 
 func parseAndFormatAttachment(content []byte, displayName string, httpUrl string, lang string) string {

--- a/txt/txt.go
+++ b/txt/txt.go
@@ -17,6 +17,7 @@ package txt
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/beego/beego/logs"
@@ -66,4 +67,27 @@ func GetParsedTextFromUrl(url string, ext string, lang string) (string, error) {
 	}
 
 	return res, nil
+}
+
+func GetParsedTextFromBytes(content []byte, ext string, lang string) (string, error) {
+	tmpFile, err := os.CreateTemp("", "openagent-attachment-*"+filepath.Clean(ext))
+	if err != nil {
+		return "", err
+	}
+	path := tmpFile.Name()
+	defer func() {
+		if err := os.Remove(path); err != nil {
+			logs.Error("%v", err.Error())
+		}
+	}()
+
+	if _, err = tmpFile.Write(content); err != nil {
+		tmpFile.Close()
+		return "", err
+	}
+	if err = tmpFile.Close(); err != nil {
+		return "", err
+	}
+
+	return GetParsedTextFromUrl(path, ext, lang)
 }

--- a/txt/util.go
+++ b/txt/util.go
@@ -16,7 +16,7 @@ package txt
 
 import (
 	"io"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/the-open-agent/openagent/util"
@@ -28,13 +28,17 @@ func getTempFilePathFromUrl(url string) (string, error) {
 		return "", err
 	}
 
-	file, err := ioutil.TempFile("", filepath.Base(url))
+	file, err := os.CreateTemp("", filepath.Base(url))
 	if err != nil {
 		return "", err
 	}
 
 	_, err = io.Copy(file, buffer)
 	if err != nil {
+		file.Close()
+		return "", err
+	}
+	if err = file.Close(); err != nil {
 		return "", err
 	}
 


### PR DESCRIPTION
## Summary
- Chat file attachments (PDF, DOCX, PPTX, XLSX, CSV, TXT, MD, YAML) are
now parsed during RefineMessageFiles and their text content is inlined
directly into the message text alongside the CDN URL.
