### PR TITLE
fix: render text in empty PPT template placeholders

### DIFF
--- a/office/template_text.go
+++ b/office/template_text.go
@@ -223,7 +223,7 @@ func ensureParagraphTextNodes(paragraph *xmlNode) []*xmlNode {
 	run := paragraph.child(nsDrawingML, "r")
 	if run == nil {
 		run = element(nsDrawingML, "r")
-		paragraph.Children = append(paragraph.Children, run)
+		insertBeforeParagraphEnd(paragraph, run)
 	}
 	text := run.child(nsDrawingML, "t")
 	if text == nil {
@@ -231,6 +231,18 @@ func ensureParagraphTextNodes(paragraph *xmlNode) []*xmlNode {
 		run.Children = append(run.Children, text)
 	}
 	return []*xmlNode{text}
+}
+
+func insertBeforeParagraphEnd(paragraph, child *xmlNode) {
+	for index, current := range paragraph.Children {
+		if current.Name.Space == nsDrawingML && current.Name.Local == "endParaRPr" {
+			paragraph.Children = append(paragraph.Children, nil)
+			copy(paragraph.Children[index+1:], paragraph.Children[index:])
+			paragraph.Children[index] = child
+			return
+		}
+	}
+	paragraph.Children = append(paragraph.Children, child)
 }
 
 func setNormalAutofit(body *xmlNode, singleLine bool) {


### PR DESCRIPTION
## Summary

  Fixes PPT template text replacement for empty placeholders that do not already contain `<a:r>/<a:t>` text nodes.

  ## Problem

  Some empty PowerPoint placeholders contain paragraph end properties (`<a:endParaRPr>`) but no actual text run. When
  replacement text was inserted, the new `<a:r>` node was appended after `<a:endParaRPr>`, producing an invalid/out-of-
  order paragraph structure. In that case, the replacement text could be present in XML but not render in PowerPoint.

  ## Changes

  - Insert newly created DrawingML text runs before `<a:endParaRPr>` when it exists.
  - Keep the previous append behavior when the paragraph has no `<a:endParaRPr>`.