### PR TITLE
fix: configure store API keys and persist API message history

### DIFF
--- a/controllers/message_answer.go
+++ b/controllers/message_answer.go
@@ -284,6 +284,17 @@ func generateMessageAnswer(id string, responseWriter http.ResponseWriter, host s
 		return
 	}
 
+	// For providers that cannot resolve CDN URLs, prefer the inline-content version of
+	// the question (TextNoCdn), which was preserved before CDN upload. When TextNoCdn is
+	// empty (message loaded from DB after CDN processing), the provider falls back to
+	// downloading images from CDN at query time.
+	if questionMessage != nil && !model.ProviderSupportsCdnUrl(modelProvider.Type) && questionMessage.TextNoCdn != "" {
+		noCdnQuestion, parseErr := refineQuestionTextViaParsingUrlContent(questionMessage.TextNoCdn, lang)
+		if parseErr == nil {
+			question = noCdnQuestion
+		}
+	}
+
 	if video.IsVideoModel(modelProvider.Type, modelProvider.SubType) {
 		videoProvider, err := modelProvider.GetVideoProvider(lang)
 		if err != nil {
@@ -498,6 +509,7 @@ func generateMessageAnswer(id string, responseWriter http.ResponseWriter, host s
 	}
 
 	message.Text = textAnswer
+	message.TextNoCdn = textAnswer // preserve pre-CDN version before tryStoreRemoteImage replaces it
 	if message.Text != "" {
 		message.ErrorText = ""
 		message.IsAlerted = false
@@ -715,6 +727,7 @@ func (c *ApiController) GetAnswer() {
 		return
 	}
 
+	answerMessage.TextNoCdn = answerMessage.Text // preserve pre-CDN version before tryStoreRemoteImage replaces it
 	tryStoreRemoteImage(answerMessage, c.Ctx.Request.Host, c.GetAcceptLanguage())
 	answer = answerMessage.Text
 

--- a/controllers/openai_api.go
+++ b/controllers/openai_api.go
@@ -91,7 +91,7 @@ func (c *ApiController) chatCompletionsViaStore(store *object.Store, request ope
 		prompt = systemPrompt
 	}
 
-	chat, _, aiMsg, err := createApiChatSession(store, modelProviderRecord.Name, question, requestId)
+	chat, _, aiMsg, err := createApiChatSession(store, modelProviderRecord.Name, request.Messages, requestId)
 	if err != nil {
 		c.ResponseError(err.Error())
 		return

--- a/controllers/openai_api_util.go
+++ b/controllers/openai_api_util.go
@@ -65,9 +65,22 @@ func newOpenAIWriter(rw *context.Response, request openai.ChatCompletionRequest,
 	}
 }
 
-// createApiChatSession inserts a Chat, a user Message, and a placeholder AI Message into the DB.
-func createApiChatSession(store *object.Store, modelProviderName, question, requestId string) (*object.Chat, *object.Message, *object.Message, error) {
-	now := util.GetCurrentTime()
+func getOpenAIMessageAuthor(role string) string {
+	switch role {
+	case "system":
+		return "System"
+	case "user":
+		return "Human"
+	case "assistant":
+		return "AI"
+	default:
+		return role
+	}
+}
+
+// createApiChatSession inserts a Chat, all incoming API messages, and a placeholder AI Message into the DB.
+func createApiChatSession(store *object.Store, modelProviderName string, requestMessages []openai.ChatCompletionMessage, requestId string) (*object.Chat, *object.Message, *object.Message, error) {
+	now := util.GetCurrentTimeWithMilli()
 
 	chat := &object.Chat{
 		Owner:         store.Owner,
@@ -82,29 +95,52 @@ func createApiChatSession(store *object.Store, modelProviderName, question, requ
 		return nil, nil, nil, err
 	}
 
-	userMsg := &object.Message{
-		Owner:         store.Owner,
-		Name:          "msg_user_" + requestId,
-		CreatedTime:   now,
-		Store:         store.Name,
-		Chat:          chat.Name,
-		Author:        "Human",
-		Text:          question,
-		ModelProvider: modelProviderName,
-		User:          "api",
+	var lastUserMsg *object.Message
+	lastMessageTime := now
+	var lastUserMessageName string
+	for i, msg := range requestMessages {
+		if msg.Content == "" {
+			continue
+		}
+
+		messageTime := util.GetCurrentTimeBasedOnLastMilli(lastMessageTime)
+		lastMessageTime = messageTime
+
+		message := &object.Message{
+			Owner:         store.Owner,
+			Name:          fmt.Sprintf("msg_api_%s_%03d", requestId, i),
+			CreatedTime:   messageTime,
+			Store:         store.Name,
+			Chat:          chat.Name,
+			Author:        getOpenAIMessageAuthor(msg.Role),
+			Text:          msg.Content,
+			ModelProvider: modelProviderName,
+			User:          "api",
+		}
+		if msg.Role == "assistant" && lastUserMessageName != "" {
+			message.ReplyTo = lastUserMessageName
+		}
+		if _, err := object.AddMessage(message); err != nil {
+			return nil, nil, nil, err
+		}
+		if msg.Role == "user" {
+			lastUserMsg = message
+			lastUserMessageName = message.Name
+		}
 	}
-	if _, err := object.AddMessage(userMsg); err != nil {
-		return nil, nil, nil, err
+
+	if lastUserMsg == nil {
+		return nil, nil, nil, fmt.Errorf("no user message found in the request")
 	}
 
 	aiMsg := &object.Message{
 		Owner:         store.Owner,
 		Name:          "msg_ai_" + requestId,
-		CreatedTime:   util.GetCurrentTime(),
+		CreatedTime:   util.GetCurrentTimeBasedOnLastMilli(lastMessageTime),
 		Store:         store.Name,
 		Chat:          chat.Name,
 		Author:        "AI",
-		ReplyTo:       userMsg.Name,
+		ReplyTo:       lastUserMsg.Name,
 		ModelProvider: modelProviderName,
 		User:          "api",
 	}
@@ -112,7 +148,7 @@ func createApiChatSession(store *object.Store, modelProviderName, question, requ
 		return nil, nil, nil, err
 	}
 
-	return chat, userMsg, aiMsg, nil
+	return chat, lastUserMsg, aiMsg, nil
 }
 
 // applyResultToApiSession writes the AI answer and token counts back to the DB.

--- a/controllers/store.go
+++ b/controllers/store.go
@@ -37,7 +37,7 @@ func (c *ApiController) GetHubStores() {
 		c.ResponseError(err.Error())
 		return
 	}
-	c.ResponseOk(stores)
+	c.ResponseOk(object.GetMaskedStores(stores))
 }
 
 // GetGlobalStores
@@ -62,7 +62,7 @@ func (c *ApiController) GetGlobalStores() {
 			return
 		}
 
-		c.ResponseOk(stores)
+		c.ResponseOk(object.GetMaskedStores(stores))
 	} else {
 		if !c.RequireAdmin() {
 			return
@@ -112,7 +112,7 @@ func (c *ApiController) GetGlobalStores() {
 			object.SortStoresInMemory(stores, sortField, sortOrder)
 		}
 
-		c.ResponseOk(stores, count)
+		c.ResponseOk(object.GetMaskedStores(stores), count)
 	}
 }
 
@@ -138,7 +138,7 @@ func (c *ApiController) GetStores() {
 		return
 	}
 
-	c.ResponseOk(stores)
+	c.ResponseOk(object.GetMaskedStores(stores))
 }
 
 // GetStore
@@ -168,12 +168,12 @@ func (c *ApiController) GetStore() {
 		origin := getOriginFromHost(host)
 		err = store.Populate(origin, c.GetAcceptLanguage())
 		if err != nil {
-			c.ResponseOk(store, err.Error())
+			c.ResponseOk(object.GetMaskedStore(store), err.Error())
 			return
 		}
 	}
 
-	c.ResponseOk(store)
+	c.ResponseOk(object.GetMaskedStore(store))
 }
 
 // UpdateStore
@@ -212,6 +212,13 @@ func (c *ApiController) UpdateStore() {
 	}
 
 	store.SharedBy = oldStore.SharedBy
+	if store.ApiKey == "***" {
+		store.ApiKey = oldStore.ApiKey
+	}
+	if err = object.ValidateStoreApiKey(store.ApiKey, oldStore.GetId()); err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
 
 	// Store admin cannot change the Owner field
 	if !c.IsGlobalAdmin() && c.IsStoreAdmin() {
@@ -298,6 +305,11 @@ func (c *ApiController) AddStore() {
 		}
 	}
 
+	if err = object.ValidateStoreApiKey(store.ApiKey, store.GetId()); err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+
 	success, err := object.AddStore(&store)
 	if err != nil {
 		c.ResponseError(err.Error())
@@ -382,7 +394,7 @@ func (c *ApiController) ClaimStore() {
 		return
 	}
 
-	c.ResponseOk(store)
+	c.ResponseOk(object.GetMaskedStore(store))
 }
 
 // RefreshStoreVectors
@@ -493,5 +505,5 @@ func (c *ApiController) AddSharedStore() {
 		return
 	}
 
-	c.ResponseOk(newStore)
+	c.ResponseOk(object.GetMaskedStore(newStore))
 }

--- a/model/cdn_util.go
+++ b/model/cdn_util.go
@@ -1,0 +1,81 @@
+// Copyright 2024 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ProviderSupportsCdnUrl returns whether the given provider type can resolve
+// CDN image URLs when they appear in message text. Providers that cannot fetch
+// external URLs (e.g. DeepSeek) need images embedded as base64 data URLs.
+func ProviderSupportsCdnUrl(providerType string) bool {
+	switch providerType {
+	case "DeepSeek":
+		return false
+	}
+	return true
+}
+
+// EmbedCdnImagesInText downloads any CDN image URLs found in text and replaces
+// them with inline base64 data URLs so that providers without external URL access
+// can still process image content. Non-image content and failed downloads are
+// left unchanged (best-effort).
+func EmbedCdnImagesInText(text string) (string, error) {
+	urls, textWithoutImages := extractImagesURL(text)
+	if len(urls) == 0 {
+		return text, nil
+	}
+
+	result := textWithoutImages
+	for _, u := range urls {
+		imageDataURL, err := getImageRefinedText(u)
+		if err != nil {
+			// Best-effort: skip images that can't be fetched
+			continue
+		}
+		result += fmt.Sprintf(` <img src="%s" style="max-width:100%%">`, imageDataURL)
+	}
+	return result, nil
+}
+
+// ApplyNoCdnToMessages returns a new slice where CDN image URLs in each message's
+// text have been replaced with base64 data URLs. If a message already has TextNoCdn
+// set (populated before DB save), that value is used directly; otherwise the CDN
+// URLs are downloaded on demand.
+func ApplyNoCdnToMessages(messages []*RawMessage) []*RawMessage {
+	result := make([]*RawMessage, len(messages))
+	for i, msg := range messages {
+		if msg.TextNoCdn != "" {
+			clone := *msg
+			clone.Text = msg.TextNoCdn
+			clone.TextNoCdn = ""
+			result[i] = &clone
+		} else if strings.Contains(msg.Text, "http") {
+			embedded, err := EmbedCdnImagesInText(msg.Text)
+			if err != nil || embedded == msg.Text {
+				result[i] = msg
+			} else {
+				clone := *msg
+				clone.Text = embedded
+				result[i] = &clone
+			}
+		} else {
+			result[i] = msg
+		}
+	}
+	return result
+}

--- a/model/deepseek.go
+++ b/model/deepseek.go
@@ -75,6 +75,12 @@ func (p *DeepSeekProvider) calculatePrice(modelResult *ModelResult, lang string)
 func (p *DeepSeekProvider) QueryText(question string, writer io.Writer, history []*RawMessage, prompt string, knowledgeMessages []*RawMessage, toolSession *ToolSession, lang string) (*ModelResult, error) {
 	const BaseUrl = "https://api.deepseek.com/v1"
 
+	// DeepSeek cannot fetch external CDN URLs.
+	// The question already uses the inline-content (TextNoCdn) version when available —
+	// the controller selects it before calling QueryText. For history messages loaded from
+	// DB (TextNoCdn not persisted), download CDN images on demand.
+	history = ApplyNoCdnToMessages(history)
+
 	var localType string
 	switch p.subType {
 	case "deepseek-v4-pro", "deepseek-reasoner":

--- a/model/util.go
+++ b/model/util.go
@@ -28,6 +28,7 @@ import (
 
 type RawMessage struct {
 	Text             string
+	TextNoCdn        string // inline-content version of Text (CDN URLs replaced with base64); not persisted
 	Author           string
 	TextTokenCount   int
 	ReasoningContent string

--- a/object/message.go
+++ b/object/message.go
@@ -49,6 +49,7 @@ type Message struct {
 	ReplyTo           string               `xorm:"varchar(100) index" json:"replyTo"`
 	Author            string               `xorm:"varchar(100)" json:"author"`
 	Text              string               `xorm:"mediumtext" json:"text"`
+	TextNoCdn         string               `xorm:"-" json:"textNoCdn"` // inline-content version (not stored in DB)
 	ReasonText        string               `xorm:"mediumtext" json:"reasonText"`
 	ErrorText         string               `xorm:"mediumtext" json:"errorText"`
 	FileName          string               `xorm:"varchar(100)" json:"fileName"`
@@ -221,6 +222,9 @@ func dataURLMimeType(dataURL string) string {
 
 func RefineMessageFiles(message *Message, origin string, lang string) error {
 	text := message.Text
+	// Always preserve the pre-CDN text so callers can access inline content before it is
+	// replaced with CDN URLs. TextNoCdn is not stored in DB (xorm:"-").
+	message.TextNoCdn = text
 	// re := regexp.MustCompile(`data:image\/([a-zA-Z]*);base64,([^"]*)`)
 	re := regexp.MustCompile(`data:([a-zA-Z0-9][a-zA-Z0-9!#$&^_.+\-]*\/[a-zA-Z0-9][a-zA-Z0-9!#$&^_.+\-]*);base64,[a-zA-Z0-9+/=_-]+`)
 	matches := re.FindAllString(text, -1)

--- a/object/store.go
+++ b/object/store.go
@@ -155,19 +155,57 @@ func GetStores(owner string) ([]*Store, error) {
 	return stores, nil
 }
 
+func GetMaskedStore(store *Store) *Store {
+	if store == nil {
+		return nil
+	}
+
+	maskedStore := *store
+	if maskedStore.ApiKey != "" {
+		maskedStore.ApiKey = "***"
+	}
+	return &maskedStore
+}
+
+func GetMaskedStores(stores []*Store) []*Store {
+	maskedStores := make([]*Store, 0, len(stores))
+	for _, store := range stores {
+		maskedStores = append(maskedStores, GetMaskedStore(store))
+	}
+	return maskedStores
+}
+
 func GetStoreByApiKey(apiKey string) (*Store, error) {
 	if apiKey == "" {
 		return nil, nil
 	}
-	store := &Store{}
-	existed, err := adapter.engine.Where("api_key = ?", apiKey).Get(store)
+	stores := []*Store{}
+	err := adapter.engine.Where("api_key = ?", apiKey).Limit(2).Find(&stores)
 	if err != nil {
 		return nil, err
 	}
-	if !existed {
+	if len(stores) == 0 {
 		return nil, nil
 	}
-	return store, nil
+	if len(stores) > 1 {
+		return nil, fmt.Errorf("multiple stores use the same API key")
+	}
+	return stores[0], nil
+}
+
+func ValidateStoreApiKey(apiKey, storeId string) error {
+	if apiKey == "" {
+		return nil
+	}
+
+	store, err := GetStoreByApiKey(apiKey)
+	if err != nil {
+		return err
+	}
+	if store != nil && store.GetId() != storeId {
+		return fmt.Errorf("the store API key is already in use")
+	}
+	return nil
 }
 
 func GetDefaultStore(owner string) (*Store, error) {

--- a/object/store_share.go
+++ b/object/store_share.go
@@ -120,6 +120,7 @@ func ShareStore(srcOwner, srcName, targetUserName, sharedByUserName string) (*St
 	newStore.ChatCount = 0
 	newStore.MessageCount = 0
 	newStore.VectorCount = 0
+	newStore.ApiKey = ""
 	// Always use share moment as created time (do not keep source store's createdTime).
 	newStore.CreatedTime = util.GetCurrentTimeWithMilli()
 

--- a/web/src/StoreEditPage.js
+++ b/web/src/StoreEditPage.js
@@ -401,6 +401,13 @@ class StoreEditPage extends React.Component {
               8
             )}
             {this.renderStoreField(
+              Setting.getLabel(i18next.t("store:Store API key"), i18next.t("store:Store API key - Tooltip")),
+              <Input.Password value={store.apiKey} onChange={e => {
+                this.updateStoreField("apiKey", e.target.value);
+              }} />,
+              8
+            )}
+            {this.renderStoreField(
               Setting.getLabel(i18next.t("general:State"), i18next.t("general:State - Tooltip")),
               <Select virtual={false} style={{width: "100%"}} value={store.state} onChange={value => {
                 this.updateStoreField("state", value);

--- a/web/src/locales/en/data.json
+++ b/web/src/locales/en/data.json
@@ -798,6 +798,8 @@
     "Storage provider - Tooltip": "Storage service provider for data persistence",
     "Storage subpath": "Storage subpath",
     "Storage subpath - Tooltip": "Subpath of the storage location, which can be a single-level or multi-level folder",
+    "Store API key": "Store API key",
+    "Store API key - Tooltip": "Bearer key for routing requests to this store.",
     "Store shared successfully": "Agent shared successfully",
     "Subject": "Subject",
     "Subject - Tooltip": "Academic subject or domain of this agent",

--- a/web/src/locales/zh/data.json
+++ b/web/src/locales/zh/data.json
@@ -798,6 +798,8 @@
     "Storage provider - Tooltip": "数据持久化服务提供商",
     "Storage subpath": "存储子路径",
     "Storage subpath - Tooltip": "存储位置的子路径，可为一级或多级文件夹",
+    "Store API key": "数据仓库 API 密钥",
+    "Store API key - Tooltip": "用于将请求路由到当前数据仓库的 Bearer 密钥。",
     "Store shared successfully": "已成功分享数据仓库",
     "Subject": "学科",
     "Subject - Tooltip": "所属学科或领域",


### PR DESCRIPTION
## Changes

- Add a Store API key field to the Store edit page
- Persist complete API message history for Store-based requests
  - Complete storage of multi-round messages
  - Preserves message order and reply relationships