### PR TITLE
feat: add PPTX template image replacement

### DIFF
--- a/office/template_analyze.go
+++ b/office/template_analyze.go
@@ -76,6 +76,9 @@ func Analyze(pkg *Package, sourcePPTX string) (*Library, error) {
 					"chart_id": "s01_ch4", "categories": []string{"A", "B"},
 					"series": []interface{}{map[string]interface{}{"name": "系列1", "values": []int{1, 2}}},
 				}},
+				"image_edits": []interface{}{map[string]interface{}{
+					"image_id": "s01_img5", "image_path": "https://example.com/image.png",
+				}},
 			}},
 		},
 	}
@@ -99,6 +102,10 @@ func Analyze(pkg *Package, sourcePPTX string) (*Library, error) {
 		if err != nil {
 			return nil, err
 		}
+		images, err := analyzeImages(pkg, slide, ref, objectByID)
+		if err != nil {
+			return nil, err
+		}
 		var textParts []string
 		for _, slot := range slots {
 			if slot.Text != "" {
@@ -108,7 +115,8 @@ func Analyze(pkg *Package, sourcePPTX string) (*Library, error) {
 		slideText := strings.Join(textParts, "\n")
 		library.Slides = append(library.Slides, SlideLibraryItem{
 			SlideIndex: ref.Index, PageType: classifyPageType(ref.Index, len(refs), slideText, len(slots)),
-			TextSummary: truncateRunes(slideText, 500), Slots: slots, Tables: tables, Charts: charts, Objects: objects,
+			TextSummary: truncateRunes(slideText, 500), Slots: slots, Tables: tables, Charts: charts,
+			Images: images, Objects: objects,
 		})
 	}
 	library.SlideCount = len(library.Slides)

--- a/office/template_apply.go
+++ b/office/template_apply.go
@@ -160,6 +160,9 @@ func applyPlanUnchecked(pkg *Package, plan *Plan, library *Library, options Appl
 		if err := cloneSlidePrivateParts(pkg, slideRels, newSlidePart, types, allocator); err != nil {
 			return err
 		}
+		if err := applyImageEdits(pkg, slide, slideRels, types, allocator, item.SourceSlide, newSlidePart, item.ImageEdits); err != nil {
+			return err
+		}
 		if err := applyChartEdits(pkg, slide, slideRels, types, item.SourceSlide, newSlidePart, item.ChartEdits, &nextChart, &nextEmbedding); err != nil {
 			return err
 		}

--- a/office/template_check.go
+++ b/office/template_check.go
@@ -42,6 +42,7 @@ func CheckPlan(library *Library, plan *Plan) *CheckReport {
 		checkReplacements(report, planIndex+1, source, item.Replacements)
 		checkTables(report, planIndex+1, source, item.TableEdits)
 		checkCharts(report, planIndex+1, source, item.ChartEdits)
+		checkImages(report, planIndex+1, source, item.ImageEdits)
 	}
 	return report
 }
@@ -414,4 +415,55 @@ func displayWidth(value float64) interface{} {
 		return int(value)
 	}
 	return math.Round(value*10) / 10
+}
+
+func checkImages(report *CheckReport, planIndex int, slide *SlideLibraryItem, edits []ImageEdit) {
+	seen := make(map[string]bool)
+	for _, edit := range edits {
+		if edit.ImageID == "" {
+			addCheck(report, "ERROR", CheckResult{
+				"plan_slide": planIndex, "source_slide": slide.SlideIndex,
+				"message": "image edit requires a non-empty image_id",
+			})
+			continue
+		}
+		if edit.ImagePath == "" {
+			addCheck(report, "ERROR", CheckResult{
+				"plan_slide": planIndex, "source_slide": slide.SlideIndex,
+				"image_id": edit.ImageID,
+				"message":  "image edit requires a non-empty image_path",
+			})
+			continue
+		}
+		if seen[edit.ImageID] {
+			addCheck(report, "ERROR", CheckResult{
+				"plan_slide": planIndex, "source_slide": slide.SlideIndex,
+				"image_id": edit.ImageID,
+				"message":  "duplicate image_id in the same plan slide",
+			})
+			continue
+		}
+		seen[edit.ImageID] = true
+
+		found := false
+		for index := range slide.Images {
+			if slide.Images[index].ImageID == edit.ImageID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			addCheck(report, "ERROR", CheckResult{
+				"plan_slide": planIndex, "source_slide": slide.SlideIndex,
+				"image_id": edit.ImageID,
+				"message":  "image target not found in slide library",
+			})
+			continue
+		}
+		addCheck(report, "OK", CheckResult{
+			"plan_slide": planIndex, "source_slide": slide.SlideIndex,
+			"image_id": edit.ImageID,
+			"message":  "image edit target is valid",
+		})
+	}
 }

--- a/office/template_image.go
+++ b/office/template_image.go
@@ -1,0 +1,230 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+
+package office
+
+import (
+	"fmt"
+	"image"
+	_ "image/jpeg"
+	_ "image/png"
+	"io"
+	"os"
+)
+
+func pictureContainers(root *xmlNode) []*xmlNode {
+	return root.descendants(nsPresentation, "pic")
+}
+
+func analyzeImages(
+	pkg *Package,
+	slide *xmlNode,
+	ref slideRef,
+	objectByID map[string]*SlideObject,
+) ([]ImageInfo, error) {
+	rels, err := pkg.Relationships(ref.PartName)
+	if err != nil {
+		return nil, err
+	}
+	byID := make(map[string]Relationship, len(rels.Items))
+	for _, rel := range rels.Items {
+		byID[rel.ID] = rel
+	}
+
+	containers := pictureContainers(slide)
+	result := make([]ImageInfo, 0, len(containers))
+
+	for order, container := range containers {
+		shapeID, shapeName := shapeIdentity(container, order+1)
+		description := ""
+		if cNvPr := container.firstDescendant(nsPresentation, "cNvPr"); cNvPr != nil {
+			description = cNvPr.attr("", "descr")
+		}
+
+		blip := firstContainerBlip(container)
+		if blip == nil {
+			continue
+		}
+		embedID := blip.attr(nsOfficeRels, "embed")
+		if embedID == "" {
+			continue
+		}
+		rel, ok := byID[embedID]
+		if !ok || rel.Type != RelationshipTypeImage || rel.Mode != TargetInternal {
+			continue
+		}
+		partName, resolveErr := ResolveTarget(ref.PartName, rel.Target)
+		if resolveErr != nil || !pkg.HasPart(partName) {
+			continue
+		}
+
+		geometry := Geometry{}
+		if obj := objectByID[shapeID]; obj != nil {
+			geometry = obj.Geometry
+		}
+
+		result = append(result, ImageInfo{
+			ImageID:     fmt.Sprintf("s%02d_img%s", ref.Index, shapeID),
+			ShapeID:     shapeID,
+			ShapeName:   shapeName,
+			Description: description,
+			Geometry:    geometry,
+		})
+	}
+	return result, nil
+}
+
+func firstContainerBlip(pic *xmlNode) *xmlNode {
+	blipFill := pic.child(nsPresentation, "blipFill")
+	if blipFill == nil {
+		return nil
+	}
+	return blipFill.child(nsDrawingML, "blip")
+}
+
+type imagePayload struct {
+	Data        []byte
+	Extension   string
+	ContentType string
+}
+
+func readImagePayload(path string, limit int64) (imagePayload, error) {
+	if path == "" {
+		return imagePayload{}, fmt.Errorf("image path is empty")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return imagePayload{}, fmt.Errorf("image file not found: %w", err)
+	}
+	if info.IsDir() {
+		return imagePayload{}, fmt.Errorf("image path is a directory")
+	}
+	if info.Size() > limit {
+		return imagePayload{}, fmt.Errorf("image file exceeds the %d MB size limit", limit>>20)
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return imagePayload{}, fmt.Errorf("cannot read image file: %w", err)
+	}
+	defer file.Close()
+
+	limited := io.LimitReader(file, limit+1)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return imagePayload{}, fmt.Errorf("cannot read image file: %w", err)
+	}
+	if int64(len(data)) > limit {
+		return imagePayload{}, fmt.Errorf("image file exceeds the %d MB size limit", limit>>20)
+	}
+	if len(data) == 0 {
+		return imagePayload{}, fmt.Errorf("image file is empty")
+	}
+
+	config, format, err := image.DecodeConfig(bytesWrapper{data})
+	if err != nil {
+		return imagePayload{}, fmt.Errorf("cannot decode image: %w", err)
+	}
+	_ = config
+
+	switch format {
+	case "png":
+		return imagePayload{Data: data, Extension: ".png", ContentType: ContentTypeImagePNG}, nil
+	case "jpeg":
+		return imagePayload{Data: data, Extension: ".jpeg", ContentType: ContentTypeImageJPEG}, nil
+	default:
+		return imagePayload{}, fmt.Errorf("unsupported image format %q; only PNG and JPEG are supported", format)
+	}
+}
+
+type bytesWrapper struct {
+	data []byte
+}
+
+func (b bytesWrapper) Read(p []byte) (int, error) {
+	if len(b.data) == 0 {
+		return 0, io.EOF
+	}
+	n := copy(p, b.data)
+	b.data = b.data[n:]
+	return n, nil
+}
+
+type imageShape struct {
+	Node *xmlNode
+	Blip *xmlNode
+}
+
+func applyImageEdits(
+	pkg *Package,
+	slide *xmlNode,
+	rels *Relationships,
+	types *ContentTypes,
+	allocator *PartAllocator,
+	sourceSlide int,
+	newSlidePart string,
+	edits []ImageEdit,
+) error {
+	if len(edits) == 0 {
+		return nil
+	}
+
+	targets := make(map[string]imageShape)
+	for _, pic := range pictureContainers(slide) {
+		blip := firstContainerBlip(pic)
+		if blip == nil {
+			continue
+		}
+		embedID := blip.attr(nsOfficeRels, "embed")
+		if embedID == "" {
+			continue
+		}
+		shapeID, _ := shapeIdentity(pic, 0)
+		imageID := fmt.Sprintf("s%02d_img%s", sourceSlide, shapeID)
+		targets[imageID] = imageShape{Node: pic, Blip: blip}
+	}
+
+	for _, edit := range edits {
+		target, ok := targets[edit.ImageID]
+		if !ok {
+			return fmt.Errorf("image edit %s on slide %d: image target not found", edit.ImageID, sourceSlide)
+		}
+
+		payload, err := readImagePayload(edit.ImagePath, pkg.limits.MaxPartSize)
+		if err != nil {
+			return fmt.Errorf("image edit %s on slide %d: %s", edit.ImageID, sourceSlide, err.Error())
+		}
+
+		mediaPart := allocator.NextNumbered("ppt/media", "templateFillImage", payload.Extension)
+
+		if err := pkg.SetPart(mediaPart, payload.Data); err != nil {
+			return err
+		}
+		if err := types.EnsureOverride(mediaPart, payload.ContentType); err != nil {
+			return err
+		}
+
+		relID := rels.NextID()
+		targetName, err := RelativeTarget(newSlidePart, mediaPart)
+		if err != nil {
+			return err
+		}
+		if err := rels.Add(Relationship{
+			ID:     relID,
+			Type:   RelationshipTypeImage,
+			Target: targetName,
+			Mode:   TargetInternal,
+		}); err != nil {
+			return err
+		}
+
+		target.Blip.setAttr(nsOfficeRels, "embed", relID)
+	}
+
+	return nil
+}

--- a/office/template_types.go
+++ b/office/template_types.go
@@ -97,6 +97,14 @@ type ChartInfo struct {
 	categoryAxis  *chartCategoryAxis
 }
 
+type ImageInfo struct {
+	ImageID     string   `json:"image_id"`
+	ShapeID     string   `json:"shape_id"`
+	ShapeName   string   `json:"shape_name"`
+	Description string   `json:"description,omitempty"`
+	Geometry    Geometry `json:"geometry"`
+}
+
 type SlideObject struct {
 	ShapeID   string   `json:"shape_id"`
 	ShapeName string   `json:"shape_name"`
@@ -113,6 +121,7 @@ type SlideLibraryItem struct {
 	Slots       []TextSlot    `json:"slots"`
 	Tables      []TableInfo   `json:"tables"`
 	Charts      []ChartInfo   `json:"charts"`
+	Images      []ImageInfo   `json:"images"`
 	Objects     []SlideObject `json:"objects"`
 }
 
@@ -157,6 +166,11 @@ type TableEdit struct {
 	Optional  bool            `json:"optional,omitempty"`
 }
 
+type ImageEdit struct {
+	ImageID   string `json:"image_id"`
+	ImagePath string `json:"image_path"`
+}
+
 type ChartEdit struct {
 	ChartID    string        `json:"chart_id,omitempty"`
 	ShapeID    string        `json:"shape_id,omitempty"`
@@ -172,6 +186,7 @@ type PlanSlide struct {
 	Replacements       []Replacement   `json:"replacements,omitempty"`
 	TableEdits         []TableEdit     `json:"table_edits,omitempty"`
 	ChartEdits         []ChartEdit     `json:"chart_edits,omitempty"`
+	ImageEdits         []ImageEdit     `json:"image_edits,omitempty"`
 	Notes              string          `json:"notes,omitempty"`
 	SpeakerNotes       string          `json:"speaker_notes,omitempty"`
 	Transition         json.RawMessage `json:"transition,omitempty"`

--- a/tool/office_ppt_template.go
+++ b/tool/office_ppt_template.go
@@ -59,7 +59,7 @@ func (t *pptxTemplateAnalyzeBuiltin) GetName() string { return "pptx_template_an
 func (t *pptxTemplateAnalyzeBuiltin) GetDescription() string {
 	return `Analyze a user-provided PowerPoint template before filling it.
 - template (required): local .pptx path or an HTTP(S) URL from a chat attachment.
-Returns template_fill_pptx_library.v1 JSON with slide types, text slot IDs, geometry, capacity metrics, tables, charts, and a plan contract. Use the returned IDs to build a template_fill_pptx_plan.v1 plan, then call pptx_template_fill.`
+Returns template_fill_pptx_library.v1 JSON with slide types, text slot IDs, image IDs, table IDs, chart IDs, geometry, capacity metrics, and a plan contract. Use the returned IDs to build a template_fill_pptx_plan.v1 plan, then call pptx_template_fill.`
 }
 
 func (t *pptxTemplateAnalyzeBuiltin) GetInputSchema() interface{} {
@@ -107,10 +107,11 @@ func (t *pptxTemplateFillBuiltin) GetName() string { return "pptx_template_fill"
 
 func (t *pptxTemplateFillBuiltin) GetDescription() string {
 	return `Create a new PowerPoint file by deterministically filling and reusing slides from an existing template.
-- Call pptx_template_analyze first and use its exact slide, slot, table, and chart IDs.
+- Call pptx_template_analyze first and use its exact slide, slot, table, chart, and image IDs.
 - template: local .pptx path or HTTP(S) chat attachment URL.
 - path: exact output .pptx path; relative paths resolve to the user's Documents folder.
-- plan: template_fill_pptx_plan.v1 object. Slides may be selected, repeated, and reordered. Each slide supports replacements, table_edits, chart_edits, and notes.
+- plan: template_fill_pptx_plan.v1 object. Slides may be selected, repeated, and reordered. Each slide supports replacements, table_edits, chart_edits, image_edits, and notes.
+- image_edits: each edit needs an image_id and image_path (local PNG/JPEG path or HTTP(S) URL). Only PNG and JPEG are supported. Replacing an image preserves the template picture frame's position, size, rotation, cropping, and styles without recomputing the aspect ratio.
 - Do not insert manual line breaks into titles unless they are intentional; single-line template titles are auto-fitted by default.
 - Keep replacement text concise and respect capacity warnings. New text/image or text/text collisions are validation errors: shorten the content or choose another template slide.
 - transition defaults to "keep", preserving source transitions and object animations.
@@ -200,6 +201,19 @@ func (t *pptxTemplateFillBuiltin) GetInputSchema() interface{} {
 										"required": []string{"chart_id", "categories", "series"},
 									},
 								},
+								"image_edits": map[string]interface{}{
+									"type": "array",
+									"items": map[string]interface{}{
+										"type": "object",
+										"properties": map[string]interface{}{
+											"image_id": stringProperty("Image ID from template analysis."),
+											"image_path": stringProperty(
+												"Local PNG/JPEG path or HTTP(S) image URL.",
+											),
+										},
+										"required": []string{"image_id", "image_path"},
+									},
+								},
 								"notes":      stringProperty("Speaker notes for the generated slide."),
 								"transition": stringProperty("Optional per-slide transition; keep preserves the source."),
 								"transition_duration": map[string]interface{}{
@@ -277,6 +291,11 @@ func (t *pptxTemplateFillBuiltin) Execute(ctx context.Context, arguments map[str
 		duration = 0.5
 	}
 	outputPath := ResolveOutputPath(args.Path)
+	cleanupImages, err := resolvePptxPlanImages(ctx, &plan, office.DefaultLimits().MaxPartSize)
+	if err != nil {
+		return officeToolError(fmt.Sprintf("Failed to resolve plan images: %s", err.Error())), nil
+	}
+	defer cleanupImages()
 	library, err := office.AnalyzeFile(templatePath, office.DefaultLimits())
 	if err != nil {
 		return officeToolError(fmt.Sprintf("Failed to fill PowerPoint template: %s", err.Error())), nil
@@ -332,7 +351,7 @@ func compactPptxCheckReport(report *office.CheckReport) *office.CheckReport {
 		}
 		result := office.CheckResult{}
 		for _, key := range []string{
-			"status", "plan_slide", "source_slide", "slot_id", "table_id", "chart_id", "selector",
+			"status", "plan_slide", "source_slide", "slot_id", "table_id", "chart_id", "image_id", "selector",
 			"new_text", "message", "estimated_font_scale_percent", "capacity_visual_width", "collisions",
 			"category_axis_font_size_pt", "category_label_area_percent", "category_labels_fit",
 			"longest_category", "longest_category_visual_width", "suggested_max_visual_width",
@@ -357,9 +376,23 @@ func pptxCheckSuggestion(item office.CheckResult) string {
 	case strings.Contains(message, "overlap"):
 		return "Shorten this replacement or choose a source slide with more space; the generated text would overlap another object."
 	case strings.Contains(message, "target not found"):
+		if _, ok := item["image_id"]; ok {
+			return "Re-run pptx_template_analyze and use an exact image ID from the returned library."
+		}
 		return "Re-run pptx_template_analyze and use an exact slot, table, or chart ID from the returned library."
 	case strings.Contains(message, "out of bounds"):
 		return "Use a row and column that exist in the analyzed table."
+	case strings.Contains(message, "image"):
+		if strings.Contains(message, "unsupported") || strings.Contains(message, "format") {
+			return "Convert the source to PNG or JPEG; only these two formats are supported."
+		}
+		if strings.Contains(message, "not found") {
+			return "Re-run pptx_template_analyze and use an exact image ID from the returned library."
+		}
+		if strings.Contains(message, "empty") || strings.Contains(message, "path") {
+			return "Provide a local PNG/JPEG path or an HTTP(S) URL pointing to a PNG/JPEG image."
+		}
+		return "Check that the image file or URL is valid and points to a PNG or JPEG image."
 	case strings.Contains(message, "chart"):
 		if labelsFit, ok := item["category_labels_fit"].(bool); ok && !labelsFit {
 			return "Shorten the longest category label; the chart already uses the maximum label area and minimum 8pt axis font."
@@ -475,6 +508,118 @@ func downloadPptxTemplate(ctx context.Context, location *url.URL) (string, func(
 		return "", func() {}, err
 	}
 	return path, cleanup, nil
+}
+
+func resolvePptxPlanImages(ctx context.Context, plan *office.Plan, limit int64) (func(), error) {
+	var tempFiles []string
+	cleanup := func() {
+		for _, path := range tempFiles {
+			_ = os.Remove(path)
+		}
+	}
+
+	for slideIdx := range plan.Slides {
+		slide := &plan.Slides[slideIdx]
+		for editIdx := range slide.ImageEdits {
+			edit := &slide.ImageEdits[editIdx]
+			edit.ImagePath = strings.TrimSpace(edit.ImagePath)
+			if edit.ImagePath == "" {
+				cleanup()
+				return nil, fmt.Errorf("image edit %s: empty image_path", edit.ImageID)
+			}
+
+			parsed, err := url.Parse(edit.ImagePath)
+			if err != nil {
+				cleanup()
+				return nil, fmt.Errorf("image edit %s: invalid image_path: %w", edit.ImageID, err)
+			}
+
+			if parsed.Scheme == "http" || parsed.Scheme == "https" {
+				file, dlErr := downloadPptxImage(ctx, parsed, limit)
+				if dlErr != nil {
+					cleanup()
+					return nil, fmt.Errorf("image edit %s: %s", edit.ImageID, dlErr.Error())
+				}
+				path := file.Name()
+				tempFiles = append(tempFiles, path)
+				_ = file.Close()
+				edit.ImagePath = path
+				continue
+			}
+
+			if parsed.Scheme != "" && strings.Contains(edit.ImagePath, "://") {
+				cleanup()
+				return nil, fmt.Errorf("image edit %s: unsupported URL scheme %q; only HTTP(S) is allowed", edit.ImageID, parsed.Scheme)
+			}
+
+			absPath, err := filepath.Abs(edit.ImagePath)
+			if err != nil {
+				cleanup()
+				return nil, fmt.Errorf("image edit %s: cannot resolve path: %w", edit.ImageID, err)
+			}
+			edit.ImagePath = absPath
+		}
+	}
+
+	return cleanup, nil
+}
+
+func downloadPptxImage(ctx context.Context, location *url.URL, limit int64) (*os.File, error) {
+	client := &http.Client{
+		Timeout: 90 * time.Second,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 5 {
+				return errors.New("too many redirects")
+			}
+			if req.URL.Scheme != "http" && req.URL.Scheme != "https" {
+				return errors.New("redirected to a non-HTTP(S) URL")
+			}
+			return nil
+		},
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, location.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return nil, fmt.Errorf("download returned HTTP %d", response.StatusCode)
+	}
+	if response.ContentLength > limit {
+		return nil, fmt.Errorf("image exceeds the %d MB size limit", limit>>20)
+	}
+
+	file, err := os.CreateTemp("", "openagent-pptx-image-*")
+	if err != nil {
+		return nil, err
+	}
+	limited := io.LimitReader(response.Body, limit+1)
+	written, copyErr := io.Copy(file, limited)
+	if copyErr != nil {
+		_ = file.Close()
+		_ = os.Remove(file.Name())
+		return nil, copyErr
+	}
+	if written > limit {
+		_ = file.Close()
+		_ = os.Remove(file.Name())
+		return nil, fmt.Errorf("image exceeds the %d MB size limit", limit>>20)
+	}
+	if written == 0 {
+		_ = file.Close()
+		_ = os.Remove(file.Name())
+		return nil, fmt.Errorf("downloaded image is empty")
+	}
+	if _, seekErr := file.Seek(0, io.SeekStart); seekErr != nil {
+		_ = file.Close()
+		_ = os.Remove(file.Name())
+		return nil, seekErr
+	}
+	return file, nil
 }
 
 func validatePptxPackage(path string) error {


### PR DESCRIPTION
## Summary

- Implement image replacement for the PPTX template fill pipeline.
pptx_template_analyze now returns image IDs; pptx_template_fill replaces
`p:pic` images via local PNG/JPEG or HTTP(S) URL, preserving all shape
geometry, cropping, and styles.