### PR TITLE
feat: Add image search support for web search tools

### DIFF
--- a/controllers/message_answer.go
+++ b/controllers/message_answer.go
@@ -403,6 +403,7 @@ func generateMessageAnswer(id string, responseWriter http.ResponseWriter, host s
 		toolSession := &model.ToolSession{
 			McpToolSet:   mcpToolSet,
 			ToolMessages: messages,
+			IsVision:     model.IsVisionModel(modelProvider.SubType),
 		}
 		modelResult, err = model.QueryTextWithTools(modelProviderObj, question, writer, history, prompt, knowledge, toolSession, lang)
 	} else {

--- a/model/local_gptvision.go
+++ b/model/local_gptvision.go
@@ -223,6 +223,15 @@ func OpenaiRawMessagesToGptVisionMessages(messages []*RawMessage) ([]openai.Chat
 				},
 			})
 		}
+		for _, image := range message.Images {
+			item.MultiContent = append(item.MultiContent, openai.ChatMessagePart{
+				Type: openai.ChatMessagePartTypeImageURL,
+				ImageURL: &openai.ChatMessageImageURL{
+					URL:    fmt.Sprintf("data:%s;base64,%s", image.MimeType, base64.StdEncoding.EncodeToString(image.Data)),
+					Detail: openai.ImageURLDetailAuto,
+				},
+			})
+		}
 
 		res = append(res, item)
 	}

--- a/model/mcp.go
+++ b/model/mcp.go
@@ -40,6 +40,7 @@ type ToolMessages struct {
 type ToolSession struct {
 	McpToolSet   *mcp.ToolSet
 	ToolMessages *ToolMessages
+	IsVision     bool
 }
 
 type ToolCallResponse struct {
@@ -188,9 +189,14 @@ func QueryTextWithTools(p ModelProvider, question string, writer io.Writer, hist
 		fmt.Printf("\n--- Agent Round %d | LLM Decision: [%d tool call(s)] ---\n", round, len(toolCalls))
 		for i, tc := range toolCalls {
 			fmt.Printf("  Tool %d: [%s] args: %s\n", i+1, tc.Function.Name, tc.Function.Arguments)
+			_, toolName := mcp.GetServerNameAndToolNameFromId(tc.Function.Name)
+			if toolName == "image_search" && !toolSession.IsVision {
+				return nil, fmt.Errorf("当前模型不支持看图")
+			}
 		}
 
 		roundHasToolError := false
+		var roundImages []ImageAttachment
 		for _, toolCall := range toolCalls {
 			serverName, toolName := mcp.GetServerNameAndToolNameFromId(toolCall.Function.Name)
 
@@ -202,13 +208,22 @@ func QueryTextWithTools(p ModelProvider, question string, writer io.Writer, hist
 			})
 
 			var toolFailed bool
-			messages, toolFailed, err = callMcpTool(toolCall, serverName, toolName, toolSession.McpToolSet, messages, writer, lang)
+			var images []ImageAttachment
+			messages, images, toolFailed, err = callMcpTool(toolCall, serverName, toolName, toolSession.McpToolSet, messages, writer, lang)
 			if err != nil {
 				return nil, err
 			}
+			roundImages = append(roundImages, images...)
 			if toolFailed {
 				roundHasToolError = true
 			}
+		}
+		if len(roundImages) > 0 {
+			messages = append(messages, &RawMessage{
+				Text:   "Images returned by image_search, in the same order as the result metadata.",
+				Author: "User",
+				Images: roundImages,
+			})
 		}
 
 		toolSession.ToolMessages.Messages = messages
@@ -274,12 +289,12 @@ func startHeartbeat(writer io.Writer, mu *sync.Mutex) chan<- struct{} {
 	return stop
 }
 
-func callMcpTool(toolCall openai.ToolCall, serverName, toolName string, mcpToolSet *mcp.ToolSet, messages []*RawMessage, writer io.Writer, lang string) ([]*RawMessage, bool, error) {
+func callMcpTool(toolCall openai.ToolCall, serverName, toolName string, mcpToolSet *mcp.ToolSet, messages []*RawMessage, writer io.Writer, lang string) ([]*RawMessage, []ImageAttachment, bool, error) {
 	var arguments map[string]interface{}
 	ctx := context.Background()
 
 	if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &arguments); err != nil {
-		return nil, false, fmt.Errorf(i18n.Translate(lang, "model:failed to parse tool arguments: %v"), err)
+		return nil, nil, false, fmt.Errorf(i18n.Translate(lang, "model:failed to parse tool arguments: %v"), err)
 	}
 
 	// Send tool-start event immediately so the frontend can show the tool call before execution
@@ -303,14 +318,14 @@ func callMcpTool(toolCall openai.ToolCall, serverName, toolName string, mcpToolS
 	if serverName == "" {
 		// builtin tools
 		if mcpToolSet.BuiltinTools == nil {
-			return messages, false, nil
+			return messages, nil, false, nil
 		}
 		result, err = mcpToolSet.BuiltinTools.ExecuteTool(ctx, toolName, arguments)
 	} else {
 		// MCP server tools
 		conn, ok := mcpToolSet.Connections[serverName]
 		if !ok {
-			return messages, false, nil
+			return messages, nil, false, nil
 		}
 		req := &protocol.CallToolRequest{
 			Name:      toolName,
@@ -322,13 +337,27 @@ func callMcpTool(toolCall openai.ToolCall, serverName, toolName string, mcpToolS
 	response := &ToolCallResponse{
 		ToolName: toolCall.Function.Name,
 	}
+	var images []ImageAttachment
+	var responseContent []protocol.Content
+	if result != nil {
+		for _, content := range result.Content {
+			if imageContent, ok := content.(*protocol.ImageContent); ok {
+				images = append(images, ImageAttachment{
+					Data:     imageContent.Data,
+					MimeType: imageContent.MimeType,
+				})
+				continue
+			}
+			responseContent = append(responseContent, content)
+		}
+	}
 
 	if err != nil {
 		response.Success = false
 		response.Error = err.Error()
 	} else if result.IsError {
 		response.Success = false
-		contentBytes, err := json.Marshal(result.Content)
+		contentBytes, err := json.Marshal(responseContent)
 		if err != nil {
 			response.Error = fmt.Sprintf(i18n.Translate(lang, "model:failed to marshal error content: %v"), err)
 		} else {
@@ -336,7 +365,7 @@ func callMcpTool(toolCall openai.ToolCall, serverName, toolName string, mcpToolS
 		}
 	} else {
 		response.Success = true
-		contentBytes, err := json.Marshal(result.Content)
+		contentBytes, err := json.Marshal(responseContent)
 		if err != nil {
 			response.Data = fmt.Sprintf(i18n.Translate(lang, "model:failed to marshal content: %v"), err)
 		} else {
@@ -346,7 +375,7 @@ func callMcpTool(toolCall openai.ToolCall, serverName, toolName string, mcpToolS
 
 	responseJson, err := json.Marshal(response)
 	if err != nil {
-		return nil, false, fmt.Errorf(i18n.Translate(lang, "model:failed to marshal tool response: %v"), err)
+		return nil, nil, false, fmt.Errorf(i18n.Translate(lang, "model:failed to marshal tool response: %v"), err)
 	}
 
 	var contentStr string
@@ -374,7 +403,7 @@ func callMcpTool(toolCall openai.ToolCall, serverName, toolName string, mcpToolS
 	}
 
 	messages = append(messages, createToolMessage(toolCall, string(responseJson)))
-	return messages, !response.Success, nil
+	return messages, images, !response.Success, nil
 }
 
 func GetToolCallsFromWriter(toolMessage string) []ToolCall {

--- a/model/mcp.go
+++ b/model/mcp.go
@@ -29,6 +29,7 @@ import (
 	"github.com/sashabaranov/go-openai"
 	"github.com/the-open-agent/openagent/i18n"
 	"github.com/the-open-agent/openagent/mcp"
+	"github.com/the-open-agent/openagent/tool"
 )
 
 type ToolMessages struct {
@@ -189,10 +190,6 @@ func QueryTextWithTools(p ModelProvider, question string, writer io.Writer, hist
 		fmt.Printf("\n--- Agent Round %d | LLM Decision: [%d tool call(s)] ---\n", round, len(toolCalls))
 		for i, tc := range toolCalls {
 			fmt.Printf("  Tool %d: [%s] args: %s\n", i+1, tc.Function.Name, tc.Function.Arguments)
-			_, toolName := mcp.GetServerNameAndToolNameFromId(tc.Function.Name)
-			if toolName == "image_search" && !toolSession.IsVision {
-				return nil, fmt.Errorf("当前模型不支持看图")
-			}
 		}
 
 		roundHasToolError := false
@@ -209,7 +206,7 @@ func QueryTextWithTools(p ModelProvider, question string, writer io.Writer, hist
 
 			var toolFailed bool
 			var images []ImageAttachment
-			messages, images, toolFailed, err = callMcpTool(toolCall, serverName, toolName, toolSession.McpToolSet, messages, writer, lang)
+			messages, images, toolFailed, err = callMcpTool(toolCall, serverName, toolName, toolSession.IsVision, toolSession.McpToolSet, messages, writer, lang)
 			if err != nil {
 				return nil, err
 			}
@@ -289,9 +286,9 @@ func startHeartbeat(writer io.Writer, mu *sync.Mutex) chan<- struct{} {
 	return stop
 }
 
-func callMcpTool(toolCall openai.ToolCall, serverName, toolName string, mcpToolSet *mcp.ToolSet, messages []*RawMessage, writer io.Writer, lang string) ([]*RawMessage, []ImageAttachment, bool, error) {
+func callMcpTool(toolCall openai.ToolCall, serverName, toolName string, isVision bool, mcpToolSet *mcp.ToolSet, messages []*RawMessage, writer io.Writer, lang string) ([]*RawMessage, []ImageAttachment, bool, error) {
 	var arguments map[string]interface{}
-	ctx := context.Background()
+	ctx := tool.WithModelVision(context.Background(), isVision)
 
 	if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &arguments); err != nil {
 		return nil, nil, false, fmt.Errorf(i18n.Translate(lang, "model:failed to parse tool arguments: %v"), err)

--- a/model/openai.go
+++ b/model/openai.go
@@ -16,6 +16,7 @@ package model
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -781,6 +782,17 @@ func openaiRawMessagesToGptVisionMessages(messages []*RawMessage) (responses.Res
 			itemContentList = append(itemContentList, responses.ResponseInputContentUnionParam{
 				OfInputImage: &responses.ResponseInputImageParam{
 					ImageURL: param.NewOpt[string](imageText),
+				},
+			})
+		}
+		for _, image := range message.Images {
+			itemContentList = append(itemContentList, responses.ResponseInputContentUnionParam{
+				OfInputImage: &responses.ResponseInputImageParam{
+					ImageURL: param.NewOpt[string](fmt.Sprintf(
+						"data:%s;base64,%s",
+						image.MimeType,
+						base64.StdEncoding.EncodeToString(image.Data),
+					)),
 				},
 			})
 		}

--- a/model/util.go
+++ b/model/util.go
@@ -33,6 +33,12 @@ type RawMessage struct {
 	ReasoningContent string
 	ToolCall         openai.ToolCall
 	ToolCallID       string
+	Images           []ImageAttachment
+}
+
+type ImageAttachment struct {
+	Data     []byte
+	MimeType string
 }
 
 type SearchResult struct {

--- a/object/message_tool.go
+++ b/object/message_tool.go
@@ -61,7 +61,7 @@ func buildToolSetForBuiltinTool(toolName, user, origin, lang string) (*mcp.ToolS
 }
 
 func GetAnswerWithTool(modelProviderName, toolName, question, user, origin, lang string) (string, *model.ModelResult, error) {
-	_, modelProviderObj, err := GetModelProviderFromContext("admin", modelProviderName, lang)
+	modelProvider, modelProviderObj, err := GetModelProviderFromContext("admin", modelProviderName, lang)
 	if err != nil {
 		return "", nil, err
 	}
@@ -86,6 +86,7 @@ func GetAnswerWithTool(modelProviderName, toolName, question, user, origin, lang
 		toolSession := &model.ToolSession{
 			McpToolSet:   mcpToolSet,
 			ToolMessages: messages,
+			IsVision:     modelProvider != nil && model.IsVisionModel(modelProvider.SubType),
 		}
 		modelResult, err = model.QueryTextWithTools(modelProviderObj, question, &writer, history, prompt, knowledge, toolSession, lang)
 	} else {

--- a/tool/image_search.go
+++ b/tool/image_search.go
@@ -1,0 +1,449 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tool
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	stdhtml "html"
+	"image"
+	_ "image/gif"
+	_ "image/jpeg"
+	_ "image/png"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/ThinkInAIXYZ/go-mcp/protocol"
+	_ "golang.org/x/image/webp"
+	"golang.org/x/net/html"
+)
+
+const (
+	imageSearchMaxImageSize = 5 * 1024 * 1024
+)
+
+var (
+	duckDuckGoHomeEndpoint  = "https://duckduckgo.com/"
+	duckDuckGoImageEndpoint = "https://duckduckgo.com/i.js"
+	bingImageSearchEndpoint = "https://www.bing.com/images/search"
+)
+
+type imageSearchBuiltin struct {
+	engine         webSearchEngine
+	apiKey         string
+	searchEngineID string
+	endpoint       string
+	httpClient     *http.Client
+}
+
+type modelVisionContextKey struct{}
+
+func WithModelVision(ctx context.Context, enabled bool) context.Context {
+	return context.WithValue(ctx, modelVisionContextKey{}, enabled)
+}
+
+type imageSearchResult struct {
+	ID           string `json:"id"`
+	Title        string `json:"title,omitempty"`
+	ImageURL     string `json:"imageUrl"`
+	ThumbnailURL string `json:"thumbnailUrl,omitempty"`
+	SourceURL    string `json:"sourceUrl,omitempty"`
+	Width        int    `json:"width,omitempty"`
+	Height       int    `json:"height,omitempty"`
+}
+
+type imageSearchPayload struct {
+	Query           string                   `json:"query"`
+	Provider        string                   `json:"provider"`
+	Count           int                      `json:"count"`
+	ExternalContent webSearchExternalContent `json:"externalContent"`
+	Results         []imageSearchResult      `json:"results"`
+}
+
+type duckDuckGoImageResponse struct {
+	Results []struct {
+		Title     string `json:"title"`
+		Image     string `json:"image"`
+		Thumbnail string `json:"thumbnail"`
+		URL       string `json:"url"`
+		Width     int    `json:"width"`
+		Height    int    `json:"height"`
+	} `json:"results"`
+}
+
+func (t *imageSearchBuiltin) GetName() string {
+	return "image_search"
+}
+
+func (t *imageSearchBuiltin) GetDescription() string {
+	return `Search the web for images and inspect the returned thumbnails. Use this when visual comparison is needed before choosing an image. Returns image URLs, source pages, dimensions, and the actual thumbnails for visual analysis.`
+}
+
+func (t *imageSearchBuiltin) GetInputSchema() interface{} {
+	return (&webSearchBuiltin{}).GetInputSchema()
+}
+
+func (t *imageSearchBuiltin) Execute(ctx context.Context, arguments map[string]interface{}) (*protocol.CallToolResult, error) {
+	if isVision, ok := ctx.Value(modelVisionContextKey{}).(bool); ok && !isVision {
+		return webSearchToolError("The current model does not support image input. Do not call image_search; continue using text-based tools instead."), nil
+	}
+
+	params, err := parseWebSearchArguments(arguments)
+	if err != nil {
+		return webSearchToolError(err.Error()), nil
+	}
+
+	results, provider, err := t.runImageSearch(ctx, params)
+	if err != nil {
+		return webSearchToolError(fmt.Sprintf("Image search failed: %s", err.Error())), nil
+	}
+
+	content := make([]protocol.Content, 0, len(results)+1)
+	visibleResults := make([]imageSearchResult, 0, len(results))
+	for _, result := range results {
+		imageURL := result.ThumbnailURL
+		if imageURL == "" {
+			imageURL = result.ImageURL
+		}
+		data, mimeType, width, height, err := downloadImage(ctx, imageURL, imageSearchMaxImageSize, t.httpClient)
+		if err != nil {
+			continue
+		}
+		if result.Width == 0 {
+			result.Width = width
+		}
+		if result.Height == 0 {
+			result.Height = height
+		}
+		result.ID = fmt.Sprintf("image_%d", len(visibleResults)+1)
+		visibleResults = append(visibleResults, result)
+		content = append(content, &protocol.ImageContent{
+			Type:     "image",
+			Data:     data,
+			MimeType: mimeType,
+		})
+	}
+	if len(visibleResults) == 0 {
+		return webSearchToolError("Image search failed: no image thumbnails could be downloaded"), nil
+	}
+
+	payload := imageSearchPayload{
+		Query:    params.Query,
+		Provider: provider,
+		Count:    len(visibleResults),
+		ExternalContent: webSearchExternalContent{
+			Untrusted: true,
+			Source:    "image_search",
+		},
+		Results: visibleResults,
+	}
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	content = append([]protocol.Content{
+		&protocol.TextContent{Type: "text", Text: string(payloadBytes)},
+	}, content...)
+	return &protocol.CallToolResult{Content: content}, nil
+}
+
+func (t *imageSearchBuiltin) runImageSearch(ctx context.Context, params webSearchParams) ([]imageSearchResult, string, error) {
+	switch t.engine {
+	case webSearchEngineGoogle:
+		results, err := runGoogleImageSearch(ctx, params, t.apiKey, t.searchEngineID, t.endpoint, t.httpClient)
+		return results, "google", err
+	case webSearchEngineBing:
+		results, err := runBingImageSearch(ctx, params, t.httpClient)
+		return results, "bing", err
+	case webSearchEngineDuckDuckGo:
+		results, err := runDuckDuckGoImageSearch(ctx, params, t.httpClient)
+		return results, "duckduckgo", err
+	case webSearchEngineBaidu:
+		results, err := runBaiduImageSearch(ctx, params, t.apiKey, t.endpoint, t.httpClient)
+		return results, "baidu", err
+	default:
+		return nil, "", fmt.Errorf("image search is not supported by %s", t.engine)
+	}
+}
+
+func runGoogleImageSearch(ctx context.Context, params webSearchParams, apiKey string, searchEngineID string, endpoint string, httpClient *http.Client) ([]imageSearchResult, error) {
+	if strings.TrimSpace(apiKey) == "" {
+		return nil, fmt.Errorf("Google search requires an API key in clientSecret")
+	}
+	if strings.TrimSpace(searchEngineID) == "" {
+		return nil, fmt.Errorf("Google search requires a search engine ID (cx) in clientId")
+	}
+
+	query := url.Values{}
+	query.Set("key", apiKey)
+	query.Set("cx", searchEngineID)
+	query.Set("q", params.Query)
+	query.Set("num", strconv.Itoa(params.Count))
+	query.Set("searchType", "image")
+	query.Set("safe", "active")
+	if params.Language != "" {
+		query.Set("hl", params.Language)
+	}
+	if params.Country != "" {
+		query.Set("gl", params.Country)
+	}
+
+	body, err := fetchWebSearchAPI(ctx, http.MethodGet, resolveWebSearchEndpoint(endpoint, googleJSONSearchEndpoint), query, nil, nil, httpClient)
+	if err != nil {
+		return nil, err
+	}
+	var response googleSearchResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, err
+	}
+	if response.Error != nil && response.Error.Message != "" {
+		return nil, fmt.Errorf("Google returned an error: %s", response.Error.Message)
+	}
+
+	results := make([]imageSearchResult, 0, len(response.Items))
+	for _, item := range response.Items {
+		if strings.TrimSpace(item.Link) == "" {
+			continue
+		}
+		results = append(results, imageSearchResult{
+			Title:        cleanWebSearchText(item.Title),
+			ImageURL:     strings.TrimSpace(item.Link),
+			ThumbnailURL: strings.TrimSpace(item.Image.ThumbnailLink),
+			SourceURL:    strings.TrimSpace(item.Image.ContextLink),
+			Width:        item.Image.Width,
+			Height:       item.Image.Height,
+		})
+	}
+	if len(results) == 0 {
+		return nil, fmt.Errorf("Google returned no image results")
+	}
+	return limitImageSearchResults(results, params.Count), nil
+}
+
+func runBingImageSearch(ctx context.Context, params webSearchParams, httpClient *http.Client) ([]imageSearchResult, error) {
+	query := url.Values{}
+	query.Set("q", params.Query)
+	query.Set("count", strconv.Itoa(params.Count))
+	query.Set("safeSearch", "Strict")
+	if params.Language != "" {
+		query.Set("setlang", params.Language)
+	}
+	if params.Country != "" {
+		query.Set("cc", params.Country)
+	}
+	body, err := fetchWebSearchHTML(ctx, bingImageSearchEndpoint, query, httpClient)
+	if err != nil {
+		return nil, err
+	}
+	results, err := parseBingImageHTML(body)
+	if err != nil {
+		return nil, err
+	}
+	if len(results) == 0 {
+		return nil, fmt.Errorf("Bing returned no image results")
+	}
+	return limitImageSearchResults(results, params.Count), nil
+}
+
+func runDuckDuckGoImageSearch(ctx context.Context, params webSearchParams, httpClient *http.Client) ([]imageSearchResult, error) {
+	form := url.Values{"q": []string{params.Query}}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, duckDuckGoHomeEndpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", webSearchUserAgent)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, webSearchMaxResponseSize+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(body) > webSearchMaxResponseSize {
+		return nil, fmt.Errorf("response body exceeds %d bytes", webSearchMaxResponseSize)
+	}
+	tokenMatch := regexp.MustCompile(`vqd=["']?([0-9-]+)`).FindSubmatch(body)
+	if len(tokenMatch) < 2 {
+		return nil, fmt.Errorf("DuckDuckGo image token was not found")
+	}
+
+	query := url.Values{}
+	query.Set("q", params.Query)
+	query.Set("vqd", string(tokenMatch[1]))
+	query.Set("o", "json")
+	query.Set("f", ",,,")
+	query.Set("p", "1")
+	if params.Country != "" && params.Language != "" {
+		query.Set("l", fmt.Sprintf("%s-%s", params.Country, params.Language))
+	}
+	data, err := fetchWebSearchAPI(ctx, http.MethodGet, duckDuckGoImageEndpoint, query, nil, map[string]string{
+		"Referer": duckDuckGoHomeEndpoint,
+	}, httpClient)
+	if err != nil {
+		return nil, err
+	}
+	var response duckDuckGoImageResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, err
+	}
+	results := make([]imageSearchResult, 0, len(response.Results))
+	for _, item := range response.Results {
+		if strings.TrimSpace(item.Image) == "" {
+			continue
+		}
+		results = append(results, imageSearchResult{
+			Title:        cleanWebSearchText(item.Title),
+			ImageURL:     strings.TrimSpace(item.Image),
+			ThumbnailURL: strings.TrimSpace(item.Thumbnail),
+			SourceURL:    strings.TrimSpace(item.URL),
+			Width:        item.Width,
+			Height:       item.Height,
+		})
+	}
+	if len(results) == 0 {
+		return nil, fmt.Errorf("DuckDuckGo returned no image results")
+	}
+	return limitImageSearchResults(results, params.Count), nil
+}
+
+func runBaiduImageSearch(ctx context.Context, params webSearchParams, apiKey string, endpoint string, httpClient *http.Client) ([]imageSearchResult, error) {
+	response, err := fetchBaiduSearch(ctx, params, apiKey, endpoint, "image", httpClient)
+	if err != nil {
+		return nil, err
+	}
+	results := parseBaiduImageSearchResponse(response)
+	if len(results) == 0 {
+		return nil, fmt.Errorf("Baidu returned no image results")
+	}
+	return limitImageSearchResults(results, params.Count), nil
+}
+
+func parseBingImageHTML(body string) ([]imageSearchResult, error) {
+	root, err := html.Parse(strings.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	nodes := findHTMLNodes(root, func(n *html.Node) bool {
+		return n.Type == html.ElementNode && n.Data == "a" && htmlNodeHasClass(n, "iusc")
+	})
+	results := make([]imageSearchResult, 0, len(nodes))
+	for _, node := range nodes {
+		var metadata struct {
+			Title        string `json:"t"`
+			ImageURL     string `json:"murl"`
+			ThumbnailURL string `json:"turl"`
+			SourceURL    string `json:"purl"`
+			Width        int    `json:"mw"`
+			Height       int    `json:"mh"`
+		}
+		raw := stdhtml.UnescapeString(htmlAttribute(node, "m"))
+		if raw == "" || json.Unmarshal([]byte(raw), &metadata) != nil || metadata.ImageURL == "" {
+			continue
+		}
+		results = append(results, imageSearchResult{
+			Title:        cleanWebSearchText(metadata.Title),
+			ImageURL:     metadata.ImageURL,
+			ThumbnailURL: metadata.ThumbnailURL,
+			SourceURL:    metadata.SourceURL,
+			Width:        metadata.Width,
+			Height:       metadata.Height,
+		})
+	}
+	return results, nil
+}
+
+func parseBaiduImageSearchResponse(response baiduWebSearchResponse) []imageSearchResult {
+	results := make([]imageSearchResult, 0, len(response.References))
+	for _, reference := range response.References {
+		if reference.Image == nil || strings.TrimSpace(reference.Image.URL) == "" {
+			continue
+		}
+		title := cleanWebSearchText(reference.Title)
+		if title == "" {
+			title = cleanWebSearchText(reference.WebAnchor)
+		}
+		width, _ := strconv.Atoi(reference.Image.Width)
+		height, _ := strconv.Atoi(reference.Image.Height)
+		results = append(results, imageSearchResult{
+			Title:     title,
+			ImageURL:  strings.TrimSpace(reference.Image.URL),
+			SourceURL: strings.TrimSpace(reference.URL),
+			Width:     width,
+			Height:    height,
+		})
+	}
+	return results
+}
+
+func limitImageSearchResults(results []imageSearchResult, count int) []imageSearchResult {
+	if len(results) <= count {
+		return results
+	}
+	return results[:count]
+}
+
+func downloadImage(ctx context.Context, rawURL string, limit int64, httpClient *http.Client) ([]byte, string, int, int, error) {
+	parsed, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+		return nil, "", 0, 0, fmt.Errorf("invalid HTTP(S) image URL")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, parsed.String(), nil)
+	if err != nil {
+		return nil, "", 0, 0, err
+	}
+	req.Header.Set("User-Agent", webSearchUserAgent)
+	req.Header.Set("Accept", "image/*")
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, "", 0, 0, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, "", 0, 0, fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+	if resp.ContentLength > limit {
+		return nil, "", 0, 0, fmt.Errorf("image exceeds %d bytes", limit)
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, limit+1))
+	if err != nil {
+		return nil, "", 0, 0, err
+	}
+	if int64(len(data)) > limit {
+		return nil, "", 0, 0, fmt.Errorf("image exceeds %d bytes", limit)
+	}
+	config, format, err := image.DecodeConfig(bytes.NewReader(data))
+	if err != nil {
+		return nil, "", 0, 0, fmt.Errorf("cannot decode image: %w", err)
+	}
+	mimeType := map[string]string{
+		"jpeg": "image/jpeg",
+		"png":  "image/png",
+		"gif":  "image/gif",
+		"webp": "image/webp",
+	}[format]
+	if mimeType == "" {
+		return nil, "", 0, 0, fmt.Errorf("unsupported image format %q", format)
+	}
+	return data, mimeType, config.Width, config.Height, nil
+}

--- a/tool/web_search.go
+++ b/tool/web_search.go
@@ -241,6 +241,12 @@ type baiduWebSearchResponse struct {
 		Content   string `json:"content"`
 		Website   string `json:"website"`
 		WebAnchor string `json:"web_anchor"`
+		Type      string `json:"type"`
+		Image     *struct {
+			URL    string `json:"url"`
+			Width  string `json:"width"`
+			Height string `json:"height"`
+		} `json:"image"`
 	} `json:"references"`
 }
 
@@ -331,6 +337,9 @@ func (t *imageSearchBuiltin) runImageSearch(ctx context.Context, params webSearc
 	case webSearchEngineDuckDuckGo:
 		results, err := runDuckDuckGoImageSearch(ctx, params, t.httpClient)
 		return results, "duckduckgo", err
+	case webSearchEngineBaidu:
+		results, err := runBaiduImageSearch(ctx, params, t.apiKey, t.endpoint, t.httpClient)
+		return results, "baidu", err
 	default:
 		return nil, "", fmt.Errorf("image search is not supported by %s", t.engine)
 	}
@@ -798,11 +807,35 @@ func runDuckDuckGoImageSearch(ctx context.Context, params webSearchParams, httpC
 }
 
 func runBaiduSearch(ctx context.Context, params webSearchParams, apiKey string, endpoint string, httpClient *http.Client) ([]webSearchResult, error) {
+	response, err := fetchBaiduSearch(ctx, params, apiKey, endpoint, "web", httpClient)
+	if err != nil {
+		return nil, err
+	}
+	results := parseBaiduSearchResponse(response)
+	if len(results) == 0 {
+		return nil, fmt.Errorf("Baidu returned no results")
+	}
+	return limitWebSearchResults(results, params.Count), nil
+}
+
+func runBaiduImageSearch(ctx context.Context, params webSearchParams, apiKey string, endpoint string, httpClient *http.Client) ([]imageSearchResult, error) {
+	response, err := fetchBaiduSearch(ctx, params, apiKey, endpoint, "image", httpClient)
+	if err != nil {
+		return nil, err
+	}
+	results := parseBaiduImageSearchResponse(response)
+	if len(results) == 0 {
+		return nil, fmt.Errorf("Baidu returned no image results")
+	}
+	return limitImageSearchResults(results, params.Count), nil
+}
+
+func fetchBaiduSearch(ctx context.Context, params webSearchParams, apiKey string, endpoint string, resourceType string, httpClient *http.Client) (baiduWebSearchResponse, error) {
 	if strings.TrimSpace(apiKey) == "" {
-		return nil, fmt.Errorf("Baidu search requires an API key in clientSecret")
+		return baiduWebSearchResponse{}, fmt.Errorf("Baidu search requires an API key in clientSecret")
 	}
 
-	requestBody := baiduWebSearchRequest{
+	requestBytes, err := json.Marshal(baiduWebSearchRequest{
 		Messages: []baiduWebSearchMessage{
 			{
 				Content: params.Query,
@@ -812,41 +845,42 @@ func runBaiduSearch(ctx context.Context, params webSearchParams, apiKey string, 
 		SearchSource: "baidu_search_v2",
 		ResourceTypeFilter: []baiduWebSearchResourceType{
 			{
-				Type: "web",
+				Type: resourceType,
 				TopK: params.Count,
 			},
 		},
-	}
-	requestBytes, err := json.Marshal(requestBody)
+	})
 	if err != nil {
-		return nil, err
+		return baiduWebSearchResponse{}, err
 	}
 
-	headers := map[string]string{
-		"Content-Type":               "application/json",
-		"X-Appbuilder-Authorization": fmt.Sprintf("Bearer %s", apiKey),
-	}
-	body, err := fetchWebSearchAPI(ctx, http.MethodPost, resolveWebSearchEndpoint(endpoint, baiduWebSearchEndpoint), nil, bytes.NewReader(requestBytes), headers, httpClient)
+	body, err := fetchWebSearchAPI(
+		ctx,
+		http.MethodPost,
+		resolveWebSearchEndpoint(endpoint, baiduWebSearchEndpoint),
+		nil,
+		bytes.NewReader(requestBytes),
+		map[string]string{
+			"Content-Type":               "application/json",
+			"X-Appbuilder-Authorization": fmt.Sprintf("Bearer %s", apiKey),
+		},
+		httpClient,
+	)
 	if err != nil {
-		return nil, err
+		return baiduWebSearchResponse{}, err
 	}
 
 	var response baiduWebSearchResponse
 	if err := json.Unmarshal(body, &response); err != nil {
-		return nil, err
+		return baiduWebSearchResponse{}, err
 	}
 	if response.Code != "" && len(response.References) == 0 {
 		if response.Message != "" {
-			return nil, fmt.Errorf("Baidu returned an error: %s", response.Message)
+			return baiduWebSearchResponse{}, fmt.Errorf("Baidu returned an error: %s", response.Message)
 		}
-		return nil, fmt.Errorf("Baidu returned an error: %s", response.Code)
+		return baiduWebSearchResponse{}, fmt.Errorf("Baidu returned an error: %s", response.Code)
 	}
-
-	results := parseBaiduSearchResponse(response)
-	if len(results) == 0 {
-		return nil, fmt.Errorf("Baidu returned no results")
-	}
-	return limitWebSearchResults(results, params.Count), nil
+	return response, nil
 }
 
 func fetchWebSearchAPI(ctx context.Context, method string, endpoint string, query url.Values, body io.Reader, headers map[string]string, httpClient *http.Client) ([]byte, error) {
@@ -1102,6 +1136,29 @@ func parseBaiduSearchResponse(response baiduWebSearchResponse) []webSearchResult
 			URL:      resultURL,
 			Snippet:  cleanWebSearchText(reference.Content),
 			SiteName: siteName,
+		})
+	}
+	return results
+}
+
+func parseBaiduImageSearchResponse(response baiduWebSearchResponse) []imageSearchResult {
+	results := make([]imageSearchResult, 0, len(response.References))
+	for _, reference := range response.References {
+		if reference.Image == nil || strings.TrimSpace(reference.Image.URL) == "" {
+			continue
+		}
+		title := cleanWebSearchText(reference.Title)
+		if title == "" {
+			title = cleanWebSearchText(reference.WebAnchor)
+		}
+		width, _ := strconv.Atoi(reference.Image.Width)
+		height, _ := strconv.Atoi(reference.Image.Height)
+		results = append(results, imageSearchResult{
+			Title:     title,
+			ImageURL:  strings.TrimSpace(reference.Image.URL),
+			SourceURL: strings.TrimSpace(reference.URL),
+			Width:     width,
+			Height:    height,
 		})
 	}
 	return results

--- a/tool/web_search.go
+++ b/tool/web_search.go
@@ -187,6 +187,12 @@ type imageDownloadBuiltin struct {
 	httpClient *http.Client
 }
 
+type modelVisionContextKey struct{}
+
+func WithModelVision(ctx context.Context, enabled bool) context.Context {
+	return context.WithValue(ctx, modelVisionContextKey{}, enabled)
+}
+
 type imageSearchResult struct {
 	ID           string `json:"id"`
 	Title        string `json:"title,omitempty"`
@@ -267,6 +273,10 @@ func (t *imageSearchBuiltin) GetInputSchema() interface{} {
 }
 
 func (t *imageSearchBuiltin) Execute(ctx context.Context, arguments map[string]interface{}) (*protocol.CallToolResult, error) {
+	if isVision, ok := ctx.Value(modelVisionContextKey{}).(bool); ok && !isVision {
+		return webSearchToolError("当前模型不支持看图"), nil
+	}
+
 	params, err := parseWebSearchArguments(arguments)
 	if err != nil {
 		return webSearchToolError(err.Error()), nil

--- a/tool/web_search.go
+++ b/tool/web_search.go
@@ -20,23 +20,14 @@ import (
 	"encoding/json"
 	"fmt"
 	stdhtml "html"
-	"image"
-	_ "image/gif"
-	_ "image/jpeg"
-	_ "image/png"
 	"io"
 	"net/http"
 	"net/url"
-	"os"
-	"path/filepath"
-	"regexp"
-	"strconv"
 	"strings"
 	"time"
 
 	"github.com/ThinkInAIXYZ/go-mcp/protocol"
 	"github.com/the-open-agent/openagent/proxy"
-	_ "golang.org/x/image/webp"
 	"golang.org/x/net/html"
 )
 
@@ -87,8 +78,6 @@ func (p *WebSearchTool) BuiltinTools() []BuiltinTool {
 		searchEngineID: p.searchEngineID,
 		endpoint:       p.endpoint,
 		httpClient:     p.httpClient,
-	}, &imageDownloadBuiltin{
-		httpClient: p.httpClient,
 	}}
 }
 
@@ -106,8 +95,6 @@ const (
 	webSearchTimeout         = 20 * time.Second
 	webSearchMaxResponseSize = 2 * 1024 * 1024
 	webSearchUserAgent       = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"
-	imageSearchMaxImageSize  = 5 * 1024 * 1024
-	imageDownloadMaxSize     = 25 * 1024 * 1024
 )
 
 type webSearchEngine string
@@ -122,10 +109,7 @@ const (
 var (
 	webSearchHTTPClient          = &http.Client{Timeout: webSearchTimeout}
 	duckDuckGoHTMLSearchEndpoint = "https://html.duckduckgo.com/html"
-	duckDuckGoHomeEndpoint       = "https://duckduckgo.com/"
-	duckDuckGoImageEndpoint      = "https://duckduckgo.com/i.js"
 	bingHTMLSearchEndpoint       = "https://www.bing.com/search"
-	bingImageSearchEndpoint      = "https://www.bing.com/images/search"
 	googleJSONSearchEndpoint     = "https://www.googleapis.com/customsearch/v1"
 	baiduWebSearchEndpoint       = "https://qianfan.baidubce.com/v2/ai_search/web_search"
 )
@@ -175,53 +159,6 @@ type googleSearchResponse struct {
 	} `json:"error,omitempty"`
 }
 
-type imageSearchBuiltin struct {
-	engine         webSearchEngine
-	apiKey         string
-	searchEngineID string
-	endpoint       string
-	httpClient     *http.Client
-}
-
-type imageDownloadBuiltin struct {
-	httpClient *http.Client
-}
-
-type modelVisionContextKey struct{}
-
-func WithModelVision(ctx context.Context, enabled bool) context.Context {
-	return context.WithValue(ctx, modelVisionContextKey{}, enabled)
-}
-
-type imageSearchResult struct {
-	ID           string `json:"id"`
-	Title        string `json:"title,omitempty"`
-	ImageURL     string `json:"imageUrl"`
-	ThumbnailURL string `json:"thumbnailUrl,omitempty"`
-	SourceURL    string `json:"sourceUrl,omitempty"`
-	Width        int    `json:"width,omitempty"`
-	Height       int    `json:"height,omitempty"`
-}
-
-type imageSearchPayload struct {
-	Query           string                   `json:"query"`
-	Provider        string                   `json:"provider"`
-	Count           int                      `json:"count"`
-	ExternalContent webSearchExternalContent `json:"externalContent"`
-	Results         []imageSearchResult      `json:"results"`
-}
-
-type duckDuckGoImageResponse struct {
-	Results []struct {
-		Title     string `json:"title"`
-		Image     string `json:"image"`
-		Thumbnail string `json:"thumbnail"`
-		URL       string `json:"url"`
-		Width     int    `json:"width"`
-		Height    int    `json:"height"`
-	} `json:"results"`
-}
-
 type baiduWebSearchRequest struct {
 	Messages           []baiduWebSearchMessage      `json:"messages"`
 	SearchSource       string                       `json:"search_source"`
@@ -258,166 +195,6 @@ type baiduWebSearchResponse struct {
 
 func (w *webSearchBuiltin) GetName() string {
 	return "web_search"
-}
-
-func (t *imageSearchBuiltin) GetName() string {
-	return "image_search"
-}
-
-func (t *imageSearchBuiltin) GetDescription() string {
-	return `Search the web for images and inspect the returned thumbnails. Use this when visual comparison is needed before choosing an image. Returns image URLs, source pages, dimensions, and the actual thumbnails for visual analysis.`
-}
-
-func (t *imageSearchBuiltin) GetInputSchema() interface{} {
-	return (&webSearchBuiltin{}).GetInputSchema()
-}
-
-func (t *imageSearchBuiltin) Execute(ctx context.Context, arguments map[string]interface{}) (*protocol.CallToolResult, error) {
-	if isVision, ok := ctx.Value(modelVisionContextKey{}).(bool); ok && !isVision {
-		return webSearchToolError("当前模型不支持看图"), nil
-	}
-
-	params, err := parseWebSearchArguments(arguments)
-	if err != nil {
-		return webSearchToolError(err.Error()), nil
-	}
-
-	results, provider, err := t.runImageSearch(ctx, params)
-	if err != nil {
-		return webSearchToolError(fmt.Sprintf("Image search failed: %s", err.Error())), nil
-	}
-
-	content := make([]protocol.Content, 0, len(results)+1)
-	visibleResults := make([]imageSearchResult, 0, len(results))
-	for _, result := range results {
-		imageURL := result.ThumbnailURL
-		if imageURL == "" {
-			imageURL = result.ImageURL
-		}
-		data, mimeType, width, height, err := downloadImage(ctx, imageURL, imageSearchMaxImageSize, t.httpClient)
-		if err != nil {
-			continue
-		}
-		if result.Width == 0 {
-			result.Width = width
-		}
-		if result.Height == 0 {
-			result.Height = height
-		}
-		result.ID = fmt.Sprintf("image_%d", len(visibleResults)+1)
-		visibleResults = append(visibleResults, result)
-		content = append(content, &protocol.ImageContent{
-			Type:     "image",
-			Data:     data,
-			MimeType: mimeType,
-		})
-	}
-	if len(visibleResults) == 0 {
-		return webSearchToolError("Image search failed: no image thumbnails could be downloaded"), nil
-	}
-
-	payload := imageSearchPayload{
-		Query:    params.Query,
-		Provider: provider,
-		Count:    len(visibleResults),
-		ExternalContent: webSearchExternalContent{
-			Untrusted: true,
-			Source:    "image_search",
-		},
-		Results: visibleResults,
-	}
-	payloadBytes, err := json.Marshal(payload)
-	if err != nil {
-		return nil, err
-	}
-	content = append([]protocol.Content{
-		&protocol.TextContent{Type: "text", Text: string(payloadBytes)},
-	}, content...)
-	return &protocol.CallToolResult{Content: content}, nil
-}
-
-func (t *imageSearchBuiltin) runImageSearch(ctx context.Context, params webSearchParams) ([]imageSearchResult, string, error) {
-	switch t.engine {
-	case webSearchEngineGoogle:
-		results, err := runGoogleImageSearch(ctx, params, t.apiKey, t.searchEngineID, t.endpoint, t.httpClient)
-		return results, "google", err
-	case webSearchEngineBing:
-		results, err := runBingImageSearch(ctx, params, t.httpClient)
-		return results, "bing", err
-	case webSearchEngineDuckDuckGo:
-		results, err := runDuckDuckGoImageSearch(ctx, params, t.httpClient)
-		return results, "duckduckgo", err
-	case webSearchEngineBaidu:
-		results, err := runBaiduImageSearch(ctx, params, t.apiKey, t.endpoint, t.httpClient)
-		return results, "baidu", err
-	default:
-		return nil, "", fmt.Errorf("image search is not supported by %s", t.engine)
-	}
-}
-
-func (t *imageDownloadBuiltin) GetName() string {
-	return "image_download"
-}
-
-func (t *imageDownloadBuiltin) GetDescription() string {
-	return `Download a selected HTTP(S) image to a local path. Use an imageUrl returned by image_search.`
-}
-
-func (t *imageDownloadBuiltin) GetInputSchema() interface{} {
-	return map[string]interface{}{
-		"type":                 "object",
-		"additionalProperties": false,
-		"properties": map[string]interface{}{
-			"url": map[string]interface{}{
-				"type":        "string",
-				"description": "Direct HTTP(S) image URL.",
-			},
-			"path": map[string]interface{}{
-				"type":        "string",
-				"description": "Local destination path.",
-			},
-		},
-		"required": []string{"url", "path"},
-	}
-}
-
-func (t *imageDownloadBuiltin) Execute(ctx context.Context, arguments map[string]interface{}) (*protocol.CallToolResult, error) {
-	imageURL := readWebSearchString(arguments, "url", "")
-	outputPath := readWebSearchString(arguments, "path", "")
-	if imageURL == "" {
-		return webSearchToolError("missing required parameter: url"), nil
-	}
-	if outputPath == "" {
-		return webSearchToolError("missing required parameter: path"), nil
-	}
-	parsed, err := url.Parse(imageURL)
-	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") {
-		return webSearchToolError("url must use HTTP(S)"), nil
-	}
-
-	data, mimeType, width, height, err := downloadImage(ctx, imageURL, imageDownloadMaxSize, t.httpClient)
-	if err != nil {
-		return webSearchToolError(fmt.Sprintf("Image download failed: %s", err.Error())), nil
-	}
-	outputPath, err = filepath.Abs(outputPath)
-	if err != nil {
-		return webSearchToolError(fmt.Sprintf("Image download failed: %s", err.Error())), nil
-	}
-	if err := os.MkdirAll(filepath.Dir(outputPath), 0o755); err != nil {
-		return webSearchToolError(fmt.Sprintf("Image download failed: %s", err.Error())), nil
-	}
-	if err := os.WriteFile(outputPath, data, 0o644); err != nil {
-		return webSearchToolError(fmt.Sprintf("Image download failed: %s", err.Error())), nil
-	}
-
-	payload, _ := json.Marshal(map[string]interface{}{
-		"path":     outputPath,
-		"mimeType": mimeType,
-		"width":    width,
-		"height":   height,
-		"bytes":    len(data),
-	})
-	return webSearchToolText(string(payload), false), nil
 }
 
 func (t *webSearchBuiltin) GetDescription() string {
@@ -673,149 +450,6 @@ func runGoogleSearch(ctx context.Context, params webSearchParams, apiKey string,
 	return limitWebSearchResults(results, params.Count), nil
 }
 
-func runGoogleImageSearch(ctx context.Context, params webSearchParams, apiKey string, searchEngineID string, endpoint string, httpClient *http.Client) ([]imageSearchResult, error) {
-	if strings.TrimSpace(apiKey) == "" {
-		return nil, fmt.Errorf("Google search requires an API key in clientSecret")
-	}
-	if strings.TrimSpace(searchEngineID) == "" {
-		return nil, fmt.Errorf("Google search requires a search engine ID (cx) in clientId")
-	}
-
-	query := url.Values{}
-	query.Set("key", apiKey)
-	query.Set("cx", searchEngineID)
-	query.Set("q", params.Query)
-	query.Set("num", strconv.Itoa(params.Count))
-	query.Set("searchType", "image")
-	query.Set("safe", "active")
-	if params.Language != "" {
-		query.Set("hl", params.Language)
-	}
-	if params.Country != "" {
-		query.Set("gl", params.Country)
-	}
-
-	body, err := fetchWebSearchAPI(ctx, http.MethodGet, resolveWebSearchEndpoint(endpoint, googleJSONSearchEndpoint), query, nil, nil, httpClient)
-	if err != nil {
-		return nil, err
-	}
-	var response googleSearchResponse
-	if err := json.Unmarshal(body, &response); err != nil {
-		return nil, err
-	}
-	if response.Error != nil && response.Error.Message != "" {
-		return nil, fmt.Errorf("Google returned an error: %s", response.Error.Message)
-	}
-
-	results := make([]imageSearchResult, 0, len(response.Items))
-	for _, item := range response.Items {
-		if strings.TrimSpace(item.Link) == "" {
-			continue
-		}
-		results = append(results, imageSearchResult{
-			Title:        cleanWebSearchText(item.Title),
-			ImageURL:     strings.TrimSpace(item.Link),
-			ThumbnailURL: strings.TrimSpace(item.Image.ThumbnailLink),
-			SourceURL:    strings.TrimSpace(item.Image.ContextLink),
-			Width:        item.Image.Width,
-			Height:       item.Image.Height,
-		})
-	}
-	if len(results) == 0 {
-		return nil, fmt.Errorf("Google returned no image results")
-	}
-	return limitImageSearchResults(results, params.Count), nil
-}
-
-func runBingImageSearch(ctx context.Context, params webSearchParams, httpClient *http.Client) ([]imageSearchResult, error) {
-	query := url.Values{}
-	query.Set("q", params.Query)
-	query.Set("count", strconv.Itoa(params.Count))
-	query.Set("safeSearch", "Strict")
-	if params.Language != "" {
-		query.Set("setlang", params.Language)
-	}
-	if params.Country != "" {
-		query.Set("cc", params.Country)
-	}
-	body, err := fetchWebSearchHTML(ctx, bingImageSearchEndpoint, query, httpClient)
-	if err != nil {
-		return nil, err
-	}
-	results, err := parseBingImageHTML(body)
-	if err != nil {
-		return nil, err
-	}
-	if len(results) == 0 {
-		return nil, fmt.Errorf("Bing returned no image results")
-	}
-	return limitImageSearchResults(results, params.Count), nil
-}
-
-func runDuckDuckGoImageSearch(ctx context.Context, params webSearchParams, httpClient *http.Client) ([]imageSearchResult, error) {
-	form := url.Values{"q": []string{params.Query}}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, duckDuckGoHomeEndpoint, strings.NewReader(form.Encode()))
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("User-Agent", webSearchUserAgent)
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	body, err := io.ReadAll(io.LimitReader(resp.Body, webSearchMaxResponseSize+1))
-	if err != nil {
-		return nil, err
-	}
-	if len(body) > webSearchMaxResponseSize {
-		return nil, fmt.Errorf("response body exceeds %d bytes", webSearchMaxResponseSize)
-	}
-	tokenMatch := regexp.MustCompile(`vqd=["']?([0-9-]+)`).FindSubmatch(body)
-	if len(tokenMatch) < 2 {
-		return nil, fmt.Errorf("DuckDuckGo image token was not found")
-	}
-
-	query := url.Values{}
-	query.Set("q", params.Query)
-	query.Set("vqd", string(tokenMatch[1]))
-	query.Set("o", "json")
-	query.Set("f", ",,,")
-	query.Set("p", "1")
-	if params.Country != "" && params.Language != "" {
-		query.Set("l", fmt.Sprintf("%s-%s", params.Country, params.Language))
-	}
-	data, err := fetchWebSearchAPI(ctx, http.MethodGet, duckDuckGoImageEndpoint, query, nil, map[string]string{
-		"Referer": duckDuckGoHomeEndpoint,
-	}, httpClient)
-	if err != nil {
-		return nil, err
-	}
-	var response duckDuckGoImageResponse
-	if err := json.Unmarshal(data, &response); err != nil {
-		return nil, err
-	}
-	results := make([]imageSearchResult, 0, len(response.Results))
-	for _, item := range response.Results {
-		if strings.TrimSpace(item.Image) == "" {
-			continue
-		}
-		results = append(results, imageSearchResult{
-			Title:        cleanWebSearchText(item.Title),
-			ImageURL:     strings.TrimSpace(item.Image),
-			ThumbnailURL: strings.TrimSpace(item.Thumbnail),
-			SourceURL:    strings.TrimSpace(item.URL),
-			Width:        item.Width,
-			Height:       item.Height,
-		})
-	}
-	if len(results) == 0 {
-		return nil, fmt.Errorf("DuckDuckGo returned no image results")
-	}
-	return limitImageSearchResults(results, params.Count), nil
-}
-
 func runBaiduSearch(ctx context.Context, params webSearchParams, apiKey string, endpoint string, httpClient *http.Client) ([]webSearchResult, error) {
 	response, err := fetchBaiduSearch(ctx, params, apiKey, endpoint, "web", httpClient)
 	if err != nil {
@@ -826,18 +460,6 @@ func runBaiduSearch(ctx context.Context, params webSearchParams, apiKey string, 
 		return nil, fmt.Errorf("Baidu returned no results")
 	}
 	return limitWebSearchResults(results, params.Count), nil
-}
-
-func runBaiduImageSearch(ctx context.Context, params webSearchParams, apiKey string, endpoint string, httpClient *http.Client) ([]imageSearchResult, error) {
-	response, err := fetchBaiduSearch(ctx, params, apiKey, endpoint, "image", httpClient)
-	if err != nil {
-		return nil, err
-	}
-	results := parseBaiduImageSearchResponse(response)
-	if len(results) == 0 {
-		return nil, fmt.Errorf("Baidu returned no image results")
-	}
-	return limitImageSearchResults(results, params.Count), nil
 }
 
 func fetchBaiduSearch(ctx context.Context, params webSearchParams, apiKey string, endpoint string, resourceType string, httpClient *http.Client) (baiduWebSearchResponse, error) {
@@ -1068,40 +690,6 @@ func parseBingHTML(body string) ([]webSearchResult, error) {
 	return results, nil
 }
 
-func parseBingImageHTML(body string) ([]imageSearchResult, error) {
-	root, err := html.Parse(strings.NewReader(body))
-	if err != nil {
-		return nil, err
-	}
-	nodes := findHTMLNodes(root, func(n *html.Node) bool {
-		return n.Type == html.ElementNode && n.Data == "a" && htmlNodeHasClass(n, "iusc")
-	})
-	results := make([]imageSearchResult, 0, len(nodes))
-	for _, node := range nodes {
-		var metadata struct {
-			Title        string `json:"t"`
-			ImageURL     string `json:"murl"`
-			ThumbnailURL string `json:"turl"`
-			SourceURL    string `json:"purl"`
-			Width        int    `json:"mw"`
-			Height       int    `json:"mh"`
-		}
-		raw := stdhtml.UnescapeString(htmlAttribute(node, "m"))
-		if raw == "" || json.Unmarshal([]byte(raw), &metadata) != nil || metadata.ImageURL == "" {
-			continue
-		}
-		results = append(results, imageSearchResult{
-			Title:        cleanWebSearchText(metadata.Title),
-			ImageURL:     metadata.ImageURL,
-			ThumbnailURL: metadata.ThumbnailURL,
-			SourceURL:    metadata.SourceURL,
-			Width:        metadata.Width,
-			Height:       metadata.Height,
-		})
-	}
-	return results, nil
-}
-
 func parseGoogleSearchResponse(response googleSearchResponse) []webSearchResult {
 	results := make([]webSearchResult, 0, len(response.Items))
 	for _, item := range response.Items {
@@ -1146,29 +734,6 @@ func parseBaiduSearchResponse(response baiduWebSearchResponse) []webSearchResult
 			URL:      resultURL,
 			Snippet:  cleanWebSearchText(reference.Content),
 			SiteName: siteName,
-		})
-	}
-	return results
-}
-
-func parseBaiduImageSearchResponse(response baiduWebSearchResponse) []imageSearchResult {
-	results := make([]imageSearchResult, 0, len(response.References))
-	for _, reference := range response.References {
-		if reference.Image == nil || strings.TrimSpace(reference.Image.URL) == "" {
-			continue
-		}
-		title := cleanWebSearchText(reference.Title)
-		if title == "" {
-			title = cleanWebSearchText(reference.WebAnchor)
-		}
-		width, _ := strconv.Atoi(reference.Image.Width)
-		height, _ := strconv.Atoi(reference.Image.Height)
-		results = append(results, imageSearchResult{
-			Title:     title,
-			ImageURL:  strings.TrimSpace(reference.Image.URL),
-			SourceURL: strings.TrimSpace(reference.URL),
-			Width:     width,
-			Height:    height,
 		})
 	}
 	return results
@@ -1304,58 +869,6 @@ func limitWebSearchResults(results []webSearchResult, count int) []webSearchResu
 		return results
 	}
 	return results[:count]
-}
-
-func limitImageSearchResults(results []imageSearchResult, count int) []imageSearchResult {
-	if len(results) <= count {
-		return results
-	}
-	return results[:count]
-}
-
-func downloadImage(ctx context.Context, rawURL string, limit int64, httpClient *http.Client) ([]byte, string, int, int, error) {
-	parsed, err := url.Parse(strings.TrimSpace(rawURL))
-	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") {
-		return nil, "", 0, 0, fmt.Errorf("invalid HTTP(S) image URL")
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, parsed.String(), nil)
-	if err != nil {
-		return nil, "", 0, 0, err
-	}
-	req.Header.Set("User-Agent", webSearchUserAgent)
-	req.Header.Set("Accept", "image/*")
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return nil, "", 0, 0, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return nil, "", 0, 0, fmt.Errorf("HTTP %d", resp.StatusCode)
-	}
-	if resp.ContentLength > limit {
-		return nil, "", 0, 0, fmt.Errorf("image exceeds %d bytes", limit)
-	}
-	data, err := io.ReadAll(io.LimitReader(resp.Body, limit+1))
-	if err != nil {
-		return nil, "", 0, 0, err
-	}
-	if int64(len(data)) > limit {
-		return nil, "", 0, 0, fmt.Errorf("image exceeds %d bytes", limit)
-	}
-	config, format, err := image.DecodeConfig(bytes.NewReader(data))
-	if err != nil {
-		return nil, "", 0, 0, fmt.Errorf("cannot decode image: %w", err)
-	}
-	mimeType := map[string]string{
-		"jpeg": "image/jpeg",
-		"png":  "image/png",
-		"gif":  "image/gif",
-		"webp": "image/webp",
-	}[format]
-	if mimeType == "" {
-		return nil, "", 0, 0, fmt.Errorf("unsupported image format %q", format)
-	}
-	return data, mimeType, config.Width, config.Height, nil
 }
 
 func resolveWebSearchSiteName(rawURL string) string {

--- a/tool/web_search.go
+++ b/tool/web_search.go
@@ -20,18 +20,27 @@ import (
 	"encoding/json"
 	"fmt"
 	stdhtml "html"
+	"image"
+	_ "image/gif"
+	_ "image/jpeg"
+	_ "image/png"
 	"io"
 	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/ThinkInAIXYZ/go-mcp/protocol"
 	"github.com/the-open-agent/openagent/proxy"
+	_ "golang.org/x/image/webp"
 	"golang.org/x/net/html"
 )
 
-// WebSearchTool is the Tool Type "web_search" (single web_search tool).
+// WebSearchTool is the Tool Type "web_search".
 type WebSearchTool struct {
 	engine         webSearchEngine
 	apiKey         string
@@ -72,6 +81,14 @@ func (p *WebSearchTool) BuiltinTools() []BuiltinTool {
 		searchEngineID: p.searchEngineID,
 		endpoint:       p.endpoint,
 		httpClient:     p.httpClient,
+	}, &imageSearchBuiltin{
+		engine:         p.engine,
+		apiKey:         p.apiKey,
+		searchEngineID: p.searchEngineID,
+		endpoint:       p.endpoint,
+		httpClient:     p.httpClient,
+	}, &imageDownloadBuiltin{
+		httpClient: p.httpClient,
 	}}
 }
 
@@ -89,6 +106,8 @@ const (
 	webSearchTimeout         = 20 * time.Second
 	webSearchMaxResponseSize = 2 * 1024 * 1024
 	webSearchUserAgent       = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"
+	imageSearchMaxImageSize  = 5 * 1024 * 1024
+	imageDownloadMaxSize     = 25 * 1024 * 1024
 )
 
 type webSearchEngine string
@@ -103,7 +122,10 @@ const (
 var (
 	webSearchHTTPClient          = &http.Client{Timeout: webSearchTimeout}
 	duckDuckGoHTMLSearchEndpoint = "https://html.duckduckgo.com/html"
+	duckDuckGoHomeEndpoint       = "https://duckduckgo.com/"
+	duckDuckGoImageEndpoint      = "https://duckduckgo.com/i.js"
 	bingHTMLSearchEndpoint       = "https://www.bing.com/search"
+	bingImageSearchEndpoint      = "https://www.bing.com/images/search"
 	googleJSONSearchEndpoint     = "https://www.googleapis.com/customsearch/v1"
 	baiduWebSearchEndpoint       = "https://qianfan.baidubce.com/v2/ai_search/web_search"
 )
@@ -141,10 +163,57 @@ type googleSearchResponse struct {
 		Link        string `json:"link"`
 		Snippet     string `json:"snippet"`
 		DisplayLink string `json:"displayLink"`
+		Image       struct {
+			ContextLink   string `json:"contextLink"`
+			ThumbnailLink string `json:"thumbnailLink"`
+			Width         int    `json:"width"`
+			Height        int    `json:"height"`
+		} `json:"image"`
 	} `json:"items"`
 	Error *struct {
 		Message string `json:"message"`
 	} `json:"error,omitempty"`
+}
+
+type imageSearchBuiltin struct {
+	engine         webSearchEngine
+	apiKey         string
+	searchEngineID string
+	endpoint       string
+	httpClient     *http.Client
+}
+
+type imageDownloadBuiltin struct {
+	httpClient *http.Client
+}
+
+type imageSearchResult struct {
+	ID           string `json:"id"`
+	Title        string `json:"title,omitempty"`
+	ImageURL     string `json:"imageUrl"`
+	ThumbnailURL string `json:"thumbnailUrl,omitempty"`
+	SourceURL    string `json:"sourceUrl,omitempty"`
+	Width        int    `json:"width,omitempty"`
+	Height       int    `json:"height,omitempty"`
+}
+
+type imageSearchPayload struct {
+	Query           string                   `json:"query"`
+	Provider        string                   `json:"provider"`
+	Count           int                      `json:"count"`
+	ExternalContent webSearchExternalContent `json:"externalContent"`
+	Results         []imageSearchResult      `json:"results"`
+}
+
+type duckDuckGoImageResponse struct {
+	Results []struct {
+		Title     string `json:"title"`
+		Image     string `json:"image"`
+		Thumbnail string `json:"thumbnail"`
+		URL       string `json:"url"`
+		Width     int    `json:"width"`
+		Height    int    `json:"height"`
+	} `json:"results"`
 }
 
 type baiduWebSearchRequest struct {
@@ -177,6 +246,159 @@ type baiduWebSearchResponse struct {
 
 func (w *webSearchBuiltin) GetName() string {
 	return "web_search"
+}
+
+func (t *imageSearchBuiltin) GetName() string {
+	return "image_search"
+}
+
+func (t *imageSearchBuiltin) GetDescription() string {
+	return `Search the web for images and inspect the returned thumbnails. Use this when visual comparison is needed before choosing an image. Returns image URLs, source pages, dimensions, and the actual thumbnails for visual analysis.`
+}
+
+func (t *imageSearchBuiltin) GetInputSchema() interface{} {
+	return (&webSearchBuiltin{}).GetInputSchema()
+}
+
+func (t *imageSearchBuiltin) Execute(ctx context.Context, arguments map[string]interface{}) (*protocol.CallToolResult, error) {
+	params, err := parseWebSearchArguments(arguments)
+	if err != nil {
+		return webSearchToolError(err.Error()), nil
+	}
+
+	results, provider, err := t.runImageSearch(ctx, params)
+	if err != nil {
+		return webSearchToolError(fmt.Sprintf("Image search failed: %s", err.Error())), nil
+	}
+
+	content := make([]protocol.Content, 0, len(results)+1)
+	visibleResults := make([]imageSearchResult, 0, len(results))
+	for _, result := range results {
+		imageURL := result.ThumbnailURL
+		if imageURL == "" {
+			imageURL = result.ImageURL
+		}
+		data, mimeType, width, height, err := downloadImage(ctx, imageURL, imageSearchMaxImageSize, t.httpClient)
+		if err != nil {
+			continue
+		}
+		if result.Width == 0 {
+			result.Width = width
+		}
+		if result.Height == 0 {
+			result.Height = height
+		}
+		result.ID = fmt.Sprintf("image_%d", len(visibleResults)+1)
+		visibleResults = append(visibleResults, result)
+		content = append(content, &protocol.ImageContent{
+			Type:     "image",
+			Data:     data,
+			MimeType: mimeType,
+		})
+	}
+	if len(visibleResults) == 0 {
+		return webSearchToolError("Image search failed: no image thumbnails could be downloaded"), nil
+	}
+
+	payload := imageSearchPayload{
+		Query:    params.Query,
+		Provider: provider,
+		Count:    len(visibleResults),
+		ExternalContent: webSearchExternalContent{
+			Untrusted: true,
+			Source:    "image_search",
+		},
+		Results: visibleResults,
+	}
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	content = append([]protocol.Content{
+		&protocol.TextContent{Type: "text", Text: string(payloadBytes)},
+	}, content...)
+	return &protocol.CallToolResult{Content: content}, nil
+}
+
+func (t *imageSearchBuiltin) runImageSearch(ctx context.Context, params webSearchParams) ([]imageSearchResult, string, error) {
+	switch t.engine {
+	case webSearchEngineGoogle:
+		results, err := runGoogleImageSearch(ctx, params, t.apiKey, t.searchEngineID, t.endpoint, t.httpClient)
+		return results, "google", err
+	case webSearchEngineBing:
+		results, err := runBingImageSearch(ctx, params, t.httpClient)
+		return results, "bing", err
+	case webSearchEngineDuckDuckGo:
+		results, err := runDuckDuckGoImageSearch(ctx, params, t.httpClient)
+		return results, "duckduckgo", err
+	default:
+		return nil, "", fmt.Errorf("image search is not supported by %s", t.engine)
+	}
+}
+
+func (t *imageDownloadBuiltin) GetName() string {
+	return "image_download"
+}
+
+func (t *imageDownloadBuiltin) GetDescription() string {
+	return `Download a selected HTTP(S) image to a local path. Use an imageUrl returned by image_search.`
+}
+
+func (t *imageDownloadBuiltin) GetInputSchema() interface{} {
+	return map[string]interface{}{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties": map[string]interface{}{
+			"url": map[string]interface{}{
+				"type":        "string",
+				"description": "Direct HTTP(S) image URL.",
+			},
+			"path": map[string]interface{}{
+				"type":        "string",
+				"description": "Local destination path.",
+			},
+		},
+		"required": []string{"url", "path"},
+	}
+}
+
+func (t *imageDownloadBuiltin) Execute(ctx context.Context, arguments map[string]interface{}) (*protocol.CallToolResult, error) {
+	imageURL := readWebSearchString(arguments, "url", "")
+	outputPath := readWebSearchString(arguments, "path", "")
+	if imageURL == "" {
+		return webSearchToolError("missing required parameter: url"), nil
+	}
+	if outputPath == "" {
+		return webSearchToolError("missing required parameter: path"), nil
+	}
+	parsed, err := url.Parse(imageURL)
+	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+		return webSearchToolError("url must use HTTP(S)"), nil
+	}
+
+	data, mimeType, width, height, err := downloadImage(ctx, imageURL, imageDownloadMaxSize, t.httpClient)
+	if err != nil {
+		return webSearchToolError(fmt.Sprintf("Image download failed: %s", err.Error())), nil
+	}
+	outputPath, err = filepath.Abs(outputPath)
+	if err != nil {
+		return webSearchToolError(fmt.Sprintf("Image download failed: %s", err.Error())), nil
+	}
+	if err := os.MkdirAll(filepath.Dir(outputPath), 0o755); err != nil {
+		return webSearchToolError(fmt.Sprintf("Image download failed: %s", err.Error())), nil
+	}
+	if err := os.WriteFile(outputPath, data, 0o644); err != nil {
+		return webSearchToolError(fmt.Sprintf("Image download failed: %s", err.Error())), nil
+	}
+
+	payload, _ := json.Marshal(map[string]interface{}{
+		"path":     outputPath,
+		"mimeType": mimeType,
+		"width":    width,
+		"height":   height,
+		"bytes":    len(data),
+	})
+	return webSearchToolText(string(payload), false), nil
 }
 
 func (t *webSearchBuiltin) GetDescription() string {
@@ -432,6 +654,149 @@ func runGoogleSearch(ctx context.Context, params webSearchParams, apiKey string,
 	return limitWebSearchResults(results, params.Count), nil
 }
 
+func runGoogleImageSearch(ctx context.Context, params webSearchParams, apiKey string, searchEngineID string, endpoint string, httpClient *http.Client) ([]imageSearchResult, error) {
+	if strings.TrimSpace(apiKey) == "" {
+		return nil, fmt.Errorf("Google search requires an API key in clientSecret")
+	}
+	if strings.TrimSpace(searchEngineID) == "" {
+		return nil, fmt.Errorf("Google search requires a search engine ID (cx) in clientId")
+	}
+
+	query := url.Values{}
+	query.Set("key", apiKey)
+	query.Set("cx", searchEngineID)
+	query.Set("q", params.Query)
+	query.Set("num", strconv.Itoa(params.Count))
+	query.Set("searchType", "image")
+	query.Set("safe", "active")
+	if params.Language != "" {
+		query.Set("hl", params.Language)
+	}
+	if params.Country != "" {
+		query.Set("gl", params.Country)
+	}
+
+	body, err := fetchWebSearchAPI(ctx, http.MethodGet, resolveWebSearchEndpoint(endpoint, googleJSONSearchEndpoint), query, nil, nil, httpClient)
+	if err != nil {
+		return nil, err
+	}
+	var response googleSearchResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, err
+	}
+	if response.Error != nil && response.Error.Message != "" {
+		return nil, fmt.Errorf("Google returned an error: %s", response.Error.Message)
+	}
+
+	results := make([]imageSearchResult, 0, len(response.Items))
+	for _, item := range response.Items {
+		if strings.TrimSpace(item.Link) == "" {
+			continue
+		}
+		results = append(results, imageSearchResult{
+			Title:        cleanWebSearchText(item.Title),
+			ImageURL:     strings.TrimSpace(item.Link),
+			ThumbnailURL: strings.TrimSpace(item.Image.ThumbnailLink),
+			SourceURL:    strings.TrimSpace(item.Image.ContextLink),
+			Width:        item.Image.Width,
+			Height:       item.Image.Height,
+		})
+	}
+	if len(results) == 0 {
+		return nil, fmt.Errorf("Google returned no image results")
+	}
+	return limitImageSearchResults(results, params.Count), nil
+}
+
+func runBingImageSearch(ctx context.Context, params webSearchParams, httpClient *http.Client) ([]imageSearchResult, error) {
+	query := url.Values{}
+	query.Set("q", params.Query)
+	query.Set("count", strconv.Itoa(params.Count))
+	query.Set("safeSearch", "Strict")
+	if params.Language != "" {
+		query.Set("setlang", params.Language)
+	}
+	if params.Country != "" {
+		query.Set("cc", params.Country)
+	}
+	body, err := fetchWebSearchHTML(ctx, bingImageSearchEndpoint, query, httpClient)
+	if err != nil {
+		return nil, err
+	}
+	results, err := parseBingImageHTML(body)
+	if err != nil {
+		return nil, err
+	}
+	if len(results) == 0 {
+		return nil, fmt.Errorf("Bing returned no image results")
+	}
+	return limitImageSearchResults(results, params.Count), nil
+}
+
+func runDuckDuckGoImageSearch(ctx context.Context, params webSearchParams, httpClient *http.Client) ([]imageSearchResult, error) {
+	form := url.Values{"q": []string{params.Query}}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, duckDuckGoHomeEndpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", webSearchUserAgent)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, webSearchMaxResponseSize+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(body) > webSearchMaxResponseSize {
+		return nil, fmt.Errorf("response body exceeds %d bytes", webSearchMaxResponseSize)
+	}
+	tokenMatch := regexp.MustCompile(`vqd=["']?([0-9-]+)`).FindSubmatch(body)
+	if len(tokenMatch) < 2 {
+		return nil, fmt.Errorf("DuckDuckGo image token was not found")
+	}
+
+	query := url.Values{}
+	query.Set("q", params.Query)
+	query.Set("vqd", string(tokenMatch[1]))
+	query.Set("o", "json")
+	query.Set("f", ",,,")
+	query.Set("p", "1")
+	if params.Country != "" && params.Language != "" {
+		query.Set("l", fmt.Sprintf("%s-%s", params.Country, params.Language))
+	}
+	data, err := fetchWebSearchAPI(ctx, http.MethodGet, duckDuckGoImageEndpoint, query, nil, map[string]string{
+		"Referer": duckDuckGoHomeEndpoint,
+	}, httpClient)
+	if err != nil {
+		return nil, err
+	}
+	var response duckDuckGoImageResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, err
+	}
+	results := make([]imageSearchResult, 0, len(response.Results))
+	for _, item := range response.Results {
+		if strings.TrimSpace(item.Image) == "" {
+			continue
+		}
+		results = append(results, imageSearchResult{
+			Title:        cleanWebSearchText(item.Title),
+			ImageURL:     strings.TrimSpace(item.Image),
+			ThumbnailURL: strings.TrimSpace(item.Thumbnail),
+			SourceURL:    strings.TrimSpace(item.URL),
+			Width:        item.Width,
+			Height:       item.Height,
+		})
+	}
+	if len(results) == 0 {
+		return nil, fmt.Errorf("DuckDuckGo returned no image results")
+	}
+	return limitImageSearchResults(results, params.Count), nil
+}
+
 func runBaiduSearch(ctx context.Context, params webSearchParams, apiKey string, endpoint string, httpClient *http.Client) ([]webSearchResult, error) {
 	if strings.TrimSpace(apiKey) == "" {
 		return nil, fmt.Errorf("Baidu search requires an API key in clientSecret")
@@ -659,6 +1024,40 @@ func parseBingHTML(body string) ([]webSearchResult, error) {
 	return results, nil
 }
 
+func parseBingImageHTML(body string) ([]imageSearchResult, error) {
+	root, err := html.Parse(strings.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	nodes := findHTMLNodes(root, func(n *html.Node) bool {
+		return n.Type == html.ElementNode && n.Data == "a" && htmlNodeHasClass(n, "iusc")
+	})
+	results := make([]imageSearchResult, 0, len(nodes))
+	for _, node := range nodes {
+		var metadata struct {
+			Title        string `json:"t"`
+			ImageURL     string `json:"murl"`
+			ThumbnailURL string `json:"turl"`
+			SourceURL    string `json:"purl"`
+			Width        int    `json:"mw"`
+			Height       int    `json:"mh"`
+		}
+		raw := stdhtml.UnescapeString(htmlAttribute(node, "m"))
+		if raw == "" || json.Unmarshal([]byte(raw), &metadata) != nil || metadata.ImageURL == "" {
+			continue
+		}
+		results = append(results, imageSearchResult{
+			Title:        cleanWebSearchText(metadata.Title),
+			ImageURL:     metadata.ImageURL,
+			ThumbnailURL: metadata.ThumbnailURL,
+			SourceURL:    metadata.SourceURL,
+			Width:        metadata.Width,
+			Height:       metadata.Height,
+		})
+	}
+	return results, nil
+}
+
 func parseGoogleSearchResponse(response googleSearchResponse) []webSearchResult {
 	results := make([]webSearchResult, 0, len(response.Items))
 	for _, item := range response.Items {
@@ -838,6 +1237,58 @@ func limitWebSearchResults(results []webSearchResult, count int) []webSearchResu
 		return results
 	}
 	return results[:count]
+}
+
+func limitImageSearchResults(results []imageSearchResult, count int) []imageSearchResult {
+	if len(results) <= count {
+		return results
+	}
+	return results[:count]
+}
+
+func downloadImage(ctx context.Context, rawURL string, limit int64, httpClient *http.Client) ([]byte, string, int, int, error) {
+	parsed, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+		return nil, "", 0, 0, fmt.Errorf("invalid HTTP(S) image URL")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, parsed.String(), nil)
+	if err != nil {
+		return nil, "", 0, 0, err
+	}
+	req.Header.Set("User-Agent", webSearchUserAgent)
+	req.Header.Set("Accept", "image/*")
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, "", 0, 0, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, "", 0, 0, fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+	if resp.ContentLength > limit {
+		return nil, "", 0, 0, fmt.Errorf("image exceeds %d bytes", limit)
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, limit+1))
+	if err != nil {
+		return nil, "", 0, 0, err
+	}
+	if int64(len(data)) > limit {
+		return nil, "", 0, 0, fmt.Errorf("image exceeds %d bytes", limit)
+	}
+	config, format, err := image.DecodeConfig(bytes.NewReader(data))
+	if err != nil {
+		return nil, "", 0, 0, fmt.Errorf("cannot decode image: %w", err)
+	}
+	mimeType := map[string]string{
+		"jpeg": "image/jpeg",
+		"png":  "image/png",
+		"gif":  "image/gif",
+		"webp": "image/webp",
+	}[format]
+	if mimeType == "" {
+		return nil, "", 0, 0, fmt.Errorf("unsupported image format %q", format)
+	}
+	return data, mimeType, config.Width, config.Height, nil
 }
 
 func resolveWebSearchSiteName(rawURL string) string {

--- a/web/src/Setting.js
+++ b/web/src/Setting.js
@@ -439,11 +439,23 @@ export function getToolFunctions(tool) {
     }];
   }
   if (type === "web_search") {
-    return [{
-      name: "web_search",
-      description: "Search the web using the configured search engine",
-      testContent: JSON.stringify({tool: "web_search", arguments: {query: "OpenAgent web search", count: 3, language: "en", country: "us"}}, null, 2),
-    }];
+    return [
+      {
+        name: "web_search",
+        description: "Search the web using the configured search engine",
+        testContent: JSON.stringify({tool: "web_search", arguments: {query: "OpenAgent web search", count: 3, language: "en", country: "us"}}, null, 2),
+      },
+      {
+        name: "image_search",
+        description: "Search for images and return thumbnails for visual analysis",
+        testContent: JSON.stringify({tool: "image_search", arguments: {query: "OpenAgent", count: 3, language: "en", country: "us"}}, null, 2),
+      },
+      {
+        name: "image_download",
+        description: "Download a selected image URL to a local path",
+        testContent: JSON.stringify({tool: "image_download", arguments: {url: "https://example.com/image.png", path: "/tmp/image.png"}}, null, 2),
+      },
+    ];
   }
   if (type === "shell") {
     return [{

--- a/web/src/Setting.js
+++ b/web/src/Setting.js
@@ -450,11 +450,6 @@ export function getToolFunctions(tool) {
         description: "Search for images and return thumbnails for visual analysis",
         testContent: JSON.stringify({tool: "image_search", arguments: {query: "OpenAgent", count: 3, language: "en", country: "us"}}, null, 2),
       },
-      {
-        name: "image_download",
-        description: "Download a selected image URL to a local path",
-        testContent: JSON.stringify({tool: "image_download", arguments: {url: "https://example.com/image.png", path: "/tmp/image.png"}}, null, 2),
-      },
     ];
   }
   if (type === "shell") {


### PR DESCRIPTION
## Summary
- Add `image_search` as a web search builtin tool
- Support image search across configured search providers
- Return image result metadata plus downloaded thumbnails for vision-capable models
- Pass image search outputs through the tool-call loop as image attachments