### PR TITLE
fix: set alpha channel when mixing colors in MixColor

### DIFF
--- a/util/color.go
+++ b/util/color.go
@@ -29,6 +29,10 @@ func MixColor(c1 color.RGBA, c2 color.RGBA, t float64) color.RGBA {
 		R: mixChannel(c1.R, c2.R, t),
 		G: mixChannel(c1.G, c2.G, t),
 		B: mixChannel(c1.B, c2.B, t),
+		// Alpha is linear (not gamma-encoded), so blend it linearly. Without
+		// setting A the result defaulted to 0, making every mixed color fully
+		// transparent.
+		A: uint8(math.Round((1-t)*float64(c1.A) + t*float64(c2.A))),
 	}
 	return res
 }

--- a/util/color_test.go
+++ b/util/color_test.go
@@ -1,0 +1,45 @@
+// Copyright 2025 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"image/color"
+	"testing"
+)
+
+func TestMixColorPreservesAlpha(t *testing.T) {
+	c1 := color.RGBA{R: 0, G: 0, B: 0, A: 0xff}
+	c2 := color.RGBA{R: 255, G: 255, B: 255, A: 0xff}
+
+	res := MixColor(c1, c2, 0.5)
+	if res.A != 0xff {
+		t.Fatalf("MixColor of two opaque colors must stay opaque, got A=%d", res.A)
+	}
+}
+
+func TestMixColorBlendsAlpha(t *testing.T) {
+	c1 := color.RGBA{R: 10, G: 20, B: 30, A: 0}
+	c2 := color.RGBA{R: 40, G: 50, B: 60, A: 200}
+
+	if got := MixColor(c1, c2, 0).A; got != 0 {
+		t.Fatalf("MixColor with t=0 should keep c1 alpha (0), got A=%d", got)
+	}
+	if got := MixColor(c1, c2, 1).A; got != 200 {
+		t.Fatalf("MixColor with t=1 should keep c2 alpha (200), got A=%d", got)
+	}
+	if got := MixColor(c1, c2, 0.5).A; got != 100 {
+		t.Fatalf("MixColor with t=0.5 should blend alpha to 100, got A=%d", got)
+	}
+}


### PR DESCRIPTION
### Bug

`util.MixColor` constructs its result `color.RGBA` without ever setting the `A` field:

```go
res := color.RGBA{
    R: mixChannel(c1.R, c2.R, t),
    G: mixChannel(c1.G, c2.G, t),
    B: mixChannel(c1.B, c2.B, t),
}
```

A zero-value `color.RGBA` has `A == 0`, i.e. fully transparent. So no matter what
two colors you pass in, the mixed color is always completely transparent — mixing
two opaque colors yields an invisible color.

### Fix

Blend the alpha channel as well. Alpha is linear (not gamma-encoded like the RGB
channels), so it is interpolated linearly between the two inputs. Mixing two
opaque colors now stays opaque, and partial alphas interpolate as expected.

### Verification

Added `util/color_test.go` covering the alpha output, then:

```
$ go test ./util/ -run TestMixColor -v
=== RUN   TestMixColorPreservesAlpha
--- PASS: TestMixColorPreservesAlpha (0.00s)
=== RUN   TestMixColorBlendsAlpha
--- PASS: TestMixColorBlendsAlpha (0.00s)
PASS
ok  	github.com/the-open-agent/openagent/util
```

Before the fix both tests fail with `got A=0`. The full `go test ./util/` package
also passes.
