### PR TITLE
fix: hide internal tool-call placeholder text

### DIFF
--- a/model/mcp.go
+++ b/model/mcp.go
@@ -195,7 +195,7 @@ func QueryTextWithTools(p ModelProvider, question string, writer io.Writer, hist
 			serverName, toolName := mcp.GetServerNameAndToolNameFromId(toolCall.Function.Name)
 
 			messages = append(messages, &RawMessage{
-				Text:             "Call result from " + toolCall.Function.Name,
+				Text:             "",
 				Author:           "AI",
 				ReasoningContent: toolSession.ToolMessages.ReasoningContent,
 				ToolCall:         toolCall,


### PR DESCRIPTION
Remove the visible `Call result from <tool>` placeholder from assistant tool-call messages