### PR TITLE
feat: Support SmartArt text editing in PPT template fill

### DIFF
--- a/office/constants.go
+++ b/office/constants.go
@@ -40,6 +40,8 @@ const (
 	RelationshipTypeNotesSlide      = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/notesSlide"
 	RelationshipTypeNotesMaster     = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/notesMaster"
 	RelationshipTypeChart           = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart"
+	RelationshipTypeDiagramData     = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/diagramData"
+	RelationshipTypeDiagramDrawing  = "http://schemas.microsoft.com/office/2007/relationships/diagramDrawing"
 	RelationshipTypeEmbeddedPackage = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/package"
 	RelationshipTypeTheme           = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme"
 	RelationshipTypeImage           = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"

--- a/office/template_analyze.go
+++ b/office/template_analyze.go
@@ -79,6 +79,13 @@ func Analyze(pkg *Package, sourcePPTX string) (*Library, error) {
 				"image_edits": []interface{}{map[string]interface{}{
 					"image_id": "s01_img5", "image_path": "https://example.com/image.png",
 				}},
+				"smartart_edits": []interface{}{map[string]interface{}{
+					"smartart_id": "s01_sa4",
+					"nodes": []interface{}{
+						map[string]interface{}{"node_id": "s01_sa4_n01", "text": "替换后的节点文字"},
+						map[string]interface{}{"node_id": "s01_sa4_n02", "paragraphs": []string{"第一行", "第二行"}},
+					},
+				}},
 			}},
 		},
 	}
@@ -106,6 +113,10 @@ func Analyze(pkg *Package, sourcePPTX string) (*Library, error) {
 		if err != nil {
 			return nil, err
 		}
+		smartArts, err := analyzeSmartArts(pkg, slide, ref, objectByID)
+		if err != nil {
+			return nil, err
+		}
 		var textParts []string
 		for _, slot := range slots {
 			if slot.Text != "" {
@@ -116,7 +127,7 @@ func Analyze(pkg *Package, sourcePPTX string) (*Library, error) {
 		library.Slides = append(library.Slides, SlideLibraryItem{
 			SlideIndex: ref.Index, PageType: classifyPageType(ref.Index, len(refs), slideText, len(slots)),
 			TextSummary: truncateRunes(slideText, 500), Slots: slots, Tables: tables, Charts: charts,
-			Images: images, Objects: objects,
+			Images: images, SmartArts: smartArts, Objects: objects,
 		})
 	}
 	library.SlideCount = len(library.Slides)

--- a/office/template_apply.go
+++ b/office/template_apply.go
@@ -160,6 +160,9 @@ func applyPlanUnchecked(pkg *Package, plan *Plan, library *Library, options Appl
 		if err := cloneSlidePrivateParts(pkg, slideRels, newSlidePart, types, allocator); err != nil {
 			return err
 		}
+		if err := applySmartArtEdits(pkg, slide, slideRels, item.SourceSlide, newSlidePart, item.SmartArtEdits); err != nil {
+			return err
+		}
 		if err := applyImageEdits(pkg, slide, slideRels, types, allocator, item.SourceSlide, newSlidePart, item.ImageEdits); err != nil {
 			return err
 		}

--- a/office/template_check.go
+++ b/office/template_check.go
@@ -43,6 +43,7 @@ func CheckPlan(library *Library, plan *Plan) *CheckReport {
 		checkTables(report, planIndex+1, source, item.TableEdits)
 		checkCharts(report, planIndex+1, source, item.ChartEdits)
 		checkImages(report, planIndex+1, source, item.ImageEdits)
+		checkSmartArts(report, planIndex+1, source, item.SmartArtEdits)
 	}
 	return report
 }

--- a/office/template_smartart.go
+++ b/office/template_smartart.go
@@ -1,0 +1,581 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+
+package office
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type smartArtNodeRef struct {
+	ModelID string
+	PresIDs []string
+	Index   int
+	Text    string
+}
+
+type smartArtPresCandidate struct {
+	ID    string
+	Index int
+	Score int
+}
+
+func analyzeSmartArts(pkg *Package, slide *xmlNode, ref slideRef, objectByID map[string]*SlideObject) ([]SmartArtInfo, error) {
+	rels, err := pkg.Relationships(ref.PartName)
+	if err != nil {
+		return nil, err
+	}
+	byID := make(map[string]Relationship, len(rels.Items))
+	for _, rel := range rels.Items {
+		byID[rel.ID] = rel
+	}
+
+	frames := smartArtFrames(slide)
+	result := make([]SmartArtInfo, 0, len(frames))
+	for order, frame := range frames {
+		shapeID, shapeName := shapeIdentity(frame, order+1)
+		info := SmartArtInfo{
+			SmartArtID: fmt.Sprintf("s%02d_sa%s", ref.Index, shapeID),
+			ShapeID:    shapeID,
+			ShapeName:  shapeName,
+			Editable:   true,
+		}
+		if object := objectByID[shapeID]; object != nil {
+			info.Geometry = object.Geometry
+		} else {
+			info.Geometry = containerGeometry(frame)
+		}
+
+		dataRelID := smartArtRelIDs(frame).attr(nsOfficeRels, "dm")
+		rel, ok := byID[dataRelID]
+		if !ok || rel.Type != RelationshipTypeDiagramData || rel.Mode != TargetInternal {
+			info.Editable = false
+			info.Reason = "diagram data relationship not found"
+			result = append(result, info)
+			continue
+		}
+		dataPart, err := ResolveTarget(ref.PartName, rel.Target)
+		if err != nil || !pkg.HasPart(dataPart) {
+			info.Editable = false
+			info.Reason = "diagram data part not found"
+			result = append(result, info)
+			continue
+		}
+		dataRoot, err := pkg.xmlPart(dataPart)
+		if err != nil {
+			info.Editable = false
+			info.Reason = "diagram data part cannot be parsed"
+			result = append(result, info)
+			continue
+		}
+		drawingRoot, _, err := smartArtDrawingRoot(pkg, ref.PartName, rels, dataRoot)
+		if err != nil {
+			info.Editable = false
+			info.Reason = "diagram drawing part cannot be resolved: " + err.Error()
+			result = append(result, info)
+			continue
+		}
+		nodes := smartArtNodeRefs(dataRoot, drawingRoot)
+		if len(nodes) == 0 {
+			info.Editable = false
+			info.Reason = "editable SmartArt nodes not found"
+		}
+		for index, node := range nodes {
+			info.Nodes = append(info.Nodes, SmartArtNodeInfo{
+				NodeID:         fmt.Sprintf("s%02d_sa%s_n%02d", ref.Index, shapeID, index+1),
+				Text:           node.Text,
+				ParagraphCount: max(len(strings.Split(node.Text, "\n")), 1),
+				Editable:       true,
+				modelID:        node.ModelID,
+				presIDs:        node.PresIDs,
+			})
+		}
+		result = append(result, info)
+	}
+	return result, nil
+}
+
+func smartArtFrames(root *xmlNode) []*xmlNode {
+	var result []*xmlNode
+	for _, frame := range root.descendants(nsPresentation, "graphicFrame") {
+		data := frame.firstDescendant(nsDrawingML, "graphicData")
+		if data != nil && data.attr("", "uri") == "http://schemas.openxmlformats.org/drawingml/2006/diagram" && smartArtRelIDs(frame) != nil {
+			result = append(result, frame)
+		}
+	}
+	return result
+}
+
+func smartArtRelIDs(frame *xmlNode) *xmlNode {
+	return frame.firstDescendant(nsDiagram, "relIds")
+}
+
+func smartArtNodeRefs(dataRoot, drawingRoot *xmlNode) []smartArtNodeRef {
+	textShapeIDs := smartArtDrawingTextShapeIDs(drawingRoot)
+	candidatesByContent := map[string][]smartArtPresCandidate{}
+	presAttrs := map[string]*xmlNode{}
+	for _, pt := range dataRoot.descendants(nsDiagram, "pt") {
+		if pt.attr("", "type") != "pres" {
+			continue
+		}
+		prSet := pt.child(nsDiagram, "prSet")
+		if prSet == nil {
+			continue
+		}
+		contentID := prSet.attr("", "presAssocID")
+		if contentID == "" {
+			continue
+		}
+		presID := pt.attr("", "modelId")
+		if presID == "" {
+			continue
+		}
+		presAttrs[presID] = prSet
+		candidatesByContent[contentID] = append(candidatesByContent[contentID], smartArtPresCandidate{
+			ID:    presID,
+			Index: smartArtPresStyleIndex(prSet),
+			Score: smartArtPresScore(prSet, textShapeIDs[presID]),
+		})
+	}
+	for _, cxn := range dataRoot.descendants(nsDiagram, "cxn") {
+		if cxn.attr("", "type") != "presOf" {
+			continue
+		}
+		contentID, presID := cxn.attr("", "srcId"), cxn.attr("", "destId")
+		if contentID == "" || presID == "" || presAttrs[presID] == nil {
+			continue
+		}
+		prSet := presAttrs[presID]
+		candidatesByContent[contentID] = append(candidatesByContent[contentID], smartArtPresCandidate{
+			ID:    presID,
+			Index: smartArtPresStyleIndex(prSet),
+			Score: smartArtPresScore(prSet, textShapeIDs[presID]),
+		})
+	}
+
+	var nodes []smartArtNodeRef
+	contentOrder := 0
+	for _, pt := range dataRoot.descendants(nsDiagram, "pt") {
+		modelID := pt.attr("", "modelId")
+		if modelID == "" || pt.attr("", "type") != "" {
+			continue
+		}
+		candidates := smartArtBestPresCandidates(candidatesByContent[modelID])
+		if len(candidates) == 0 {
+			contentOrder++
+			continue
+		}
+		index := contentOrder
+		if candidates[0].Index >= 0 {
+			index = candidates[0].Index
+		}
+		nodes = append(nodes, smartArtNodeRef{
+			ModelID: modelID,
+			PresIDs: smartArtCandidateIDs(candidates),
+			Index:   index,
+			Text:    strings.Join(paragraphTexts(pt.child(nsDiagram, "t")), "\n"),
+		})
+		contentOrder++
+	}
+	sort.SliceStable(nodes, func(i, j int) bool {
+		return nodes[i].Index < nodes[j].Index
+	})
+	return nodes
+}
+
+func smartArtDrawingTextShapeIDs(root *xmlNode) map[string]bool {
+	result := map[string]bool{}
+	if root == nil {
+		return result
+	}
+	for _, shape := range root.descendants(nsDiagram2008, "sp") {
+		modelID := shape.attr("", "modelId")
+		if modelID != "" && shape.child(nsDiagram2008, "txBody") != nil {
+			result[modelID] = true
+		}
+	}
+	return result
+}
+
+func smartArtPresStyleIndex(prSet *xmlNode) int {
+	raw := prSet.attr("", "presStyleIdx")
+	value, err := strconv.Atoi(raw)
+	if err != nil {
+		return -1
+	}
+	return value
+}
+
+func smartArtPresScore(prSet *xmlNode, hasDrawingText bool) int {
+	score := 0
+	if hasDrawingText {
+		score += 100
+	}
+	presName := prSet.attr("", "presName")
+	styleLabel := prSet.attr("", "presStyleLbl")
+	if styleLabel == "node1" {
+		score += 60
+	}
+	if presName == "node" {
+		score += 50
+	}
+	if strings.HasSuffix(presName, "Tx") || strings.Contains(strings.ToLower(presName), "text") {
+		score += 25
+	}
+	lowerName := strings.ToLower(presName)
+	lowerLabel := strings.ToLower(styleLabel)
+	if strings.Contains(lowerName, "dummy") || strings.Contains(lowerName, "space") ||
+		strings.Contains(lowerName, "arrow") || strings.Contains(lowerName, "trans") {
+		score -= 80
+	}
+	if strings.Contains(lowerLabel, "revtx") || strings.Contains(lowerLabel, "trans") {
+		score -= 40
+	}
+	return score
+}
+
+func smartArtBestPresCandidates(candidates []smartArtPresCandidate) []smartArtPresCandidate {
+	if len(candidates) == 0 {
+		return nil
+	}
+	unique := make([]smartArtPresCandidate, 0, len(candidates))
+	seen := map[string]bool{}
+	for _, candidate := range candidates {
+		if candidate.ID == "" || seen[candidate.ID] {
+			continue
+		}
+		seen[candidate.ID] = true
+		unique = append(unique, candidate)
+	}
+	sort.SliceStable(unique, func(i, j int) bool {
+		if unique[i].Score != unique[j].Score {
+			return unique[i].Score > unique[j].Score
+		}
+		return unique[i].Index < unique[j].Index
+	})
+	if len(unique) == 0 || unique[0].Score <= 0 {
+		return nil
+	}
+	bestScore := unique[0].Score
+	var result []smartArtPresCandidate
+	for _, candidate := range unique {
+		if candidate.Score != bestScore {
+			break
+		}
+		result = append(result, candidate)
+	}
+	return result
+}
+
+func smartArtCandidateIDs(candidates []smartArtPresCandidate) []string {
+	result := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		result = append(result, candidate.ID)
+	}
+	return result
+}
+
+func checkSmartArts(report *CheckReport, planIndex int, slide *SlideLibraryItem, edits []SmartArtEdit) {
+	for _, edit := range edits {
+		smartArt, selector := findSmartArt(slide, edit)
+		if smartArt == nil {
+			if !edit.Optional {
+				addCheck(report, "ERROR", CheckResult{
+					"plan_slide": planIndex, "source_slide": slide.SlideIndex, "selector": selector,
+					"message": "SmartArt target not found in slide library",
+				})
+			}
+			continue
+		}
+		if !smartArt.Editable {
+			addCheck(report, "ERROR", CheckResult{
+				"plan_slide": planIndex, "source_slide": slide.SlideIndex, "smartart_id": smartArt.SmartArtID,
+				"message": "SmartArt is not editable: " + smartArt.Reason,
+			})
+			continue
+		}
+		for index, node := range edit.Nodes {
+			target := smartArtNodeByEdit(smartArt, node, index)
+			if target == nil {
+				if !node.Optional {
+					addCheck(report, "ERROR", CheckResult{
+						"plan_slide": planIndex, "source_slide": slide.SlideIndex, "smartart_id": smartArt.SmartArtID,
+						"node_id": node.NodeID, "message": "SmartArt node target not found",
+					})
+				}
+				continue
+			}
+			addCheck(report, "OK", CheckResult{
+				"plan_slide": planIndex, "source_slide": slide.SlideIndex, "smartart_id": smartArt.SmartArtID,
+				"node_id": target.NodeID, "message": "SmartArt node target is valid",
+			})
+		}
+	}
+}
+
+func findSmartArt(slide *SlideLibraryItem, edit SmartArtEdit) (*SmartArtInfo, string) {
+	for _, selector := range []struct{ key, value string }{{"smartart_id", edit.SmartArtID}, {"shape_id", edit.ShapeID}, {"shape_name", edit.ShapeName}} {
+		if selector.value == "" {
+			continue
+		}
+		for index := range slide.SmartArts {
+			item := &slide.SmartArts[index]
+			if (selector.key == "smartart_id" && item.SmartArtID == selector.value) ||
+				(selector.key == "shape_id" && item.ShapeID == selector.value) ||
+				(selector.key == "shape_name" && item.ShapeName == selector.value) {
+				return item, selector.key + ":" + selector.value
+			}
+		}
+		return nil, selector.key + ":" + selector.value
+	}
+	return nil, ""
+}
+
+func smartArtNodeByEdit(info *SmartArtInfo, edit SmartArtNodeEdit, index int) *SmartArtNodeInfo {
+	if edit.NodeID != "" {
+		for nodeIndex := range info.Nodes {
+			if info.Nodes[nodeIndex].NodeID == edit.NodeID {
+				return &info.Nodes[nodeIndex]
+			}
+		}
+		return nil
+	}
+	if index >= 0 && index < len(info.Nodes) {
+		return &info.Nodes[index]
+	}
+	return nil
+}
+
+func applySmartArtEdits(pkg *Package, slide *xmlNode, rels *Relationships, sourceSlide int, slidePart string, edits []SmartArtEdit) error {
+	if len(edits) == 0 {
+		return nil
+	}
+	frames := smartArtFrames(slide)
+	maps := map[string]*xmlNode{}
+	for order, frame := range frames {
+		id, name := shapeIdentity(frame, order+1)
+		maps[fmt.Sprintf("smartart_id:s%02d_sa%s", sourceSlide, id)] = frame
+		maps["shape_id:"+id] = frame
+		if name != "" {
+			maps["shape_name:"+name] = frame
+		}
+	}
+
+	var missing []string
+	for _, edit := range edits {
+		selectors := smartArtSelectors(edit)
+		var frame *xmlNode
+		for _, selector := range selectors {
+			if frame == nil {
+				frame = maps[selector]
+			}
+		}
+		if frame == nil {
+			if !edit.Optional {
+				missing = append(missing, selectorLabel(selectors))
+			}
+			continue
+		}
+		if err := applySmartArtEdit(pkg, frame, rels, sourceSlide, slidePart, edit); err != nil {
+			return err
+		}
+	}
+	if len(missing) != 0 {
+		return fmt.Errorf("missing SmartArt target(s) on slide %d: %s", sourceSlide, strings.Join(missing, "; "))
+	}
+	return nil
+}
+
+func applySmartArtEdit(pkg *Package, frame *xmlNode, rels *Relationships, sourceSlide int, slidePart string, edit SmartArtEdit) error {
+	shapeID, _ := shapeIdentity(frame, 0)
+	relIDs := smartArtRelIDs(frame)
+	if relIDs == nil {
+		return fmt.Errorf("SmartArt %s on slide %d is missing diagram relationship IDs", shapeID, sourceSlide)
+	}
+	dataPart, err := relatedPartByID(slidePart, rels, relIDs.attr(nsOfficeRels, "dm"), RelationshipTypeDiagramData)
+	if err != nil {
+		return fmt.Errorf("SmartArt %s on slide %d: %w", shapeID, sourceSlide, err)
+	}
+	dataRoot, err := pkg.xmlPart(dataPart)
+	if err != nil {
+		return err
+	}
+	drawingRoot, drawingPart, err := smartArtDrawingRoot(pkg, slidePart, rels, dataRoot)
+	if err != nil {
+		return fmt.Errorf("SmartArt %s on slide %d: %w", shapeID, sourceSlide, err)
+	}
+	nodeRefs := smartArtNodeRefs(dataRoot, drawingRoot)
+	if len(nodeRefs) == 0 {
+		return fmt.Errorf("SmartArt %s on slide %d has no editable nodes", shapeID, sourceSlide)
+	}
+
+	var missing []string
+	for index, nodeEdit := range edit.Nodes {
+		nodeIndex := index
+		if nodeEdit.NodeID != "" {
+			nodeIndex = smartArtNodeIndex(sourceSlide, shapeID, nodeEdit.NodeID, len(nodeRefs))
+		}
+		if nodeIndex < 0 || nodeIndex >= len(nodeRefs) {
+			if !nodeEdit.Optional {
+				missing = append(missing, nodeEdit.NodeID)
+			}
+			continue
+		}
+		text := smartArtEditText(nodeEdit)
+		ref := nodeRefs[nodeIndex]
+		if !setSmartArtDataText(dataRoot, ref.ModelID, text) {
+			return fmt.Errorf("SmartArt %s on slide %d: node data not found: %s", shapeID, sourceSlide, ref.ModelID)
+		}
+		if drawingRoot != nil {
+			for _, presID := range ref.PresIDs {
+				setSmartArtDrawingText(drawingRoot, presID, text)
+			}
+		}
+	}
+	if len(missing) != 0 {
+		return fmt.Errorf("missing SmartArt node target(s) on slide %d: %s", sourceSlide, strings.Join(missing, "; "))
+	}
+
+	data, err := marshalXML(dataRoot)
+	if err != nil {
+		return err
+	}
+	if err := pkg.SetPart(dataPart, data); err != nil {
+		return err
+	}
+	if drawingRoot != nil {
+		data, err := marshalXML(drawingRoot)
+		if err != nil {
+			return err
+		}
+		if err := pkg.SetPart(drawingPart, data); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func relatedPartByID(owner string, rels *Relationships, id, relType string) (string, error) {
+	rel, ok := rels.Find(id)
+	if !ok || rel.Type != relType || rel.Mode != TargetInternal {
+		return "", fmt.Errorf("relationship %s not found", id)
+	}
+	partName, err := ResolveTarget(owner, rel.Target)
+	if err != nil {
+		return "", err
+	}
+	return partName, nil
+}
+
+func smartArtDrawingRoot(pkg *Package, slidePart string, rels *Relationships, dataRoot *xmlNode) (*xmlNode, string, error) {
+	ext := dataRoot.firstDescendant(nsDiagram2008, "dataModelExt")
+	if ext == nil || ext.attr("", "relId") == "" {
+		return nil, "", nil
+	}
+	partName, err := relatedPartByID(slidePart, rels, ext.attr("", "relId"), RelationshipTypeDiagramDrawing)
+	if err != nil {
+		return nil, "", err
+	}
+	root, err := pkg.xmlPart(partName)
+	if err != nil {
+		return nil, "", err
+	}
+	return root, partName, nil
+}
+
+func smartArtNodeIndex(sourceSlide int, shapeID, nodeID string, count int) int {
+	prefix := fmt.Sprintf("s%02d_sa%s_n", sourceSlide, shapeID)
+	if !strings.HasPrefix(nodeID, prefix) {
+		return -1
+	}
+	value, err := strconv.Atoi(strings.TrimPrefix(nodeID, prefix))
+	if err != nil || value < 1 || value > count {
+		return -1
+	}
+	return value - 1
+}
+
+func setSmartArtDataText(dataRoot *xmlNode, modelID, text string) bool {
+	for _, pt := range dataRoot.descendants(nsDiagram, "pt") {
+		if pt.attr("", "modelId") != modelID {
+			continue
+		}
+		prSet := pt.child(nsDiagram, "prSet")
+		if prSet == nil {
+			prSet = element(nsDiagram, "prSet")
+			pt.Children = append([]*xmlNode{prSet}, pt.Children...)
+		}
+		prSet.removeAttr("", "phldr")
+		body := pt.child(nsDiagram, "t")
+		if body == nil {
+			body = element(nsDiagram, "t")
+			pt.Children = append(pt.Children, body)
+		}
+		setSmartArtTextBody(body, strings.Split(text, "\n"))
+		return true
+	}
+	return false
+}
+
+func setSmartArtDrawingText(drawingRoot *xmlNode, presID, text string) bool {
+	for _, shape := range drawingRoot.descendants(nsDiagram2008, "sp") {
+		if shape.attr("", "modelId") != presID {
+			continue
+		}
+		body := shape.child(nsDiagram2008, "txBody")
+		if body == nil {
+			return false
+		}
+		setSmartArtTextBody(body, strings.Split(text, "\n"))
+		return true
+	}
+	return false
+}
+
+func setSmartArtTextBody(body *xmlNode, lines []string) {
+	if len(lines) == 0 {
+		lines = []string{""}
+	}
+	templates := body.children(nsDrawingML, "p")
+	if len(templates) == 0 {
+		templates = []*xmlNode{element(nsDrawingML, "p")}
+	}
+	for index := range templates {
+		templates[index] = templates[index].clone()
+	}
+	body.removeChildren(nsDrawingML, "p")
+	for index, line := range lines {
+		paragraph := templates[min(index, len(templates)-1)].clone()
+		setParagraphText(paragraph, line)
+		body.Children = append(body.Children, paragraph)
+	}
+}
+
+func smartArtEditText(edit SmartArtNodeEdit) string {
+	if edit.Paragraphs != nil {
+		return strings.Join(edit.Paragraphs, "\n")
+	}
+	return edit.Text
+}
+
+func smartArtSelectors(value SmartArtEdit) []string {
+	var result []string
+	if value.SmartArtID != "" {
+		result = append(result, "smartart_id:"+value.SmartArtID)
+	}
+	if value.ShapeID != "" {
+		result = append(result, "shape_id:"+value.ShapeID)
+	}
+	if value.ShapeName != "" {
+		result = append(result, "shape_name:"+value.ShapeName)
+	}
+	return result
+}

--- a/office/template_types.go
+++ b/office/template_types.go
@@ -105,6 +105,26 @@ type ImageInfo struct {
 	Geometry    Geometry `json:"geometry"`
 }
 
+type SmartArtNodeInfo struct {
+	NodeID         string `json:"node_id"`
+	Text           string `json:"text"`
+	ParagraphCount int    `json:"paragraph_count"`
+	Editable       bool   `json:"editable"`
+	Reason         string `json:"reason,omitempty"`
+	modelID        string
+	presIDs        []string
+}
+
+type SmartArtInfo struct {
+	SmartArtID string             `json:"smartart_id"`
+	ShapeID    string             `json:"shape_id"`
+	ShapeName  string             `json:"shape_name"`
+	Geometry   Geometry           `json:"geometry"`
+	Editable   bool               `json:"editable"`
+	Reason     string             `json:"reason,omitempty"`
+	Nodes      []SmartArtNodeInfo `json:"nodes"`
+}
+
 type SlideObject struct {
 	ShapeID   string   `json:"shape_id"`
 	ShapeName string   `json:"shape_name"`
@@ -115,14 +135,15 @@ type SlideObject struct {
 }
 
 type SlideLibraryItem struct {
-	SlideIndex  int           `json:"slide_index"`
-	PageType    string        `json:"page_type"`
-	TextSummary string        `json:"text_summary"`
-	Slots       []TextSlot    `json:"slots"`
-	Tables      []TableInfo   `json:"tables"`
-	Charts      []ChartInfo   `json:"charts"`
-	Images      []ImageInfo   `json:"images"`
-	Objects     []SlideObject `json:"objects"`
+	SlideIndex  int            `json:"slide_index"`
+	PageType    string         `json:"page_type"`
+	TextSummary string         `json:"text_summary"`
+	Slots       []TextSlot     `json:"slots"`
+	Tables      []TableInfo    `json:"tables"`
+	Charts      []ChartInfo    `json:"charts"`
+	Images      []ImageInfo    `json:"images"`
+	SmartArts   []SmartArtInfo `json:"smartarts"`
+	Objects     []SlideObject  `json:"objects"`
 }
 
 type Canvas struct {
@@ -180,6 +201,21 @@ type ChartEdit struct {
 	Optional   bool          `json:"optional,omitempty"`
 }
 
+type SmartArtNodeEdit struct {
+	NodeID     string   `json:"node_id,omitempty"`
+	Text       string   `json:"text,omitempty"`
+	Paragraphs []string `json:"paragraphs,omitempty"`
+	Optional   bool     `json:"optional,omitempty"`
+}
+
+type SmartArtEdit struct {
+	SmartArtID string             `json:"smartart_id,omitempty"`
+	ShapeID    string             `json:"shape_id,omitempty"`
+	ShapeName  string             `json:"shape_name,omitempty"`
+	Nodes      []SmartArtNodeEdit `json:"nodes"`
+	Optional   bool               `json:"optional,omitempty"`
+}
+
 type PlanSlide struct {
 	SourceSlide        int             `json:"source_slide"`
 	Purpose            string          `json:"purpose,omitempty"`
@@ -187,6 +223,7 @@ type PlanSlide struct {
 	TableEdits         []TableEdit     `json:"table_edits,omitempty"`
 	ChartEdits         []ChartEdit     `json:"chart_edits,omitempty"`
 	ImageEdits         []ImageEdit     `json:"image_edits,omitempty"`
+	SmartArtEdits      []SmartArtEdit  `json:"smartart_edits,omitempty"`
 	Notes              string          `json:"notes,omitempty"`
 	SpeakerNotes       string          `json:"speaker_notes,omitempty"`
 	Transition         json.RawMessage `json:"transition,omitempty"`

--- a/office/xmlnode.go
+++ b/office/xmlnode.go
@@ -27,6 +27,8 @@ import (
 const (
 	nsDrawingML     = "http://schemas.openxmlformats.org/drawingml/2006/main"
 	nsChart         = "http://schemas.openxmlformats.org/drawingml/2006/chart"
+	nsDiagram       = "http://schemas.openxmlformats.org/drawingml/2006/diagram"
+	nsDiagram2008   = "http://schemas.microsoft.com/office/drawing/2008/diagram"
 	nsPresentation  = "http://schemas.openxmlformats.org/presentationml/2006/main"
 	nsOfficeRels    = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
 	nsSpreadsheetML = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
@@ -101,6 +103,8 @@ type namespaceDeclaration struct {
 var preferredNamespacePrefixes = map[string]string{
 	nsDrawingML:     "a",
 	nsChart:         "c",
+	nsDiagram:       "dgm",
+	nsDiagram2008:   "dsp",
 	nsPresentation:  "p",
 	nsOfficeRels:    "r",
 	nsSpreadsheetML: "x",
@@ -267,6 +271,17 @@ func (n *xmlNode) setAttr(space, local, value string) {
 		}
 	}
 	n.Attr = append(n.Attr, xml.Attr{Name: xml.Name{Space: space, Local: local}, Value: value})
+}
+
+func (n *xmlNode) removeAttr(space, local string) {
+	kept := n.Attr[:0]
+	for _, item := range n.Attr {
+		if item.Name.Space == space && item.Name.Local == local {
+			continue
+		}
+		kept = append(kept, item)
+	}
+	n.Attr = kept
 }
 
 func (n *xmlNode) child(space, local string) *xmlNode {

--- a/skills/powerpoint/SKILL.md
+++ b/skills/powerpoint/SKILL.md
@@ -5,7 +5,7 @@ description: Create designed, editable PowerPoint .pptx presentations with PptxG
 
 # PowerPoint
 
-Use this skill whenever a PowerPoint deck is involved. For new decks, pass a trusted PptxGenJS build script directly to the `pptx_write` tool.
+Use this skill whenever a PowerPoint deck is involved. For new decks, pass a trusted PptxGenJS build script directly to the `pptx_write` tool. For filling or editing an existing template, call `pptx_template_analyze` first and then `pptx_template_fill` with the exact IDs returned by analysis.
 
 ## Workflow
 
@@ -14,6 +14,12 @@ Use this skill whenever a PowerPoint deck is involved. For new decks, pass a tru
 3. In the script, add slides directly with PptxGenJS. Do not generate HTML for this workflow.
 4. Call `pptx_write` with `path`, `script`, optional `assets_dir`, and optional `data`.
 5. Verify the result with `pptx_read`; for visual QA, convert the PPTX to images if the environment has LibreOffice and Poppler.
+
+## Template Workflow
+
+- Use `pptx_template_analyze` when the user provides a `.pptx` template or wants to preserve existing layouts, charts, images, tables, or SmartArt.
+- Build a `template_fill_pptx_plan.v1` plan from the returned slide IDs and object IDs, then call `pptx_template_fill`.
+- For SmartArt, use `smartarts[*].smartart_id` and `smartarts[*].nodes[*].node_id` in `smartart_edits`. This edits existing node text only; it does not create, delete, or relayout SmartArt nodes.
 
 ## Script Creation
 

--- a/tool/office_ppt_template.go
+++ b/tool/office_ppt_template.go
@@ -59,7 +59,7 @@ func (t *pptxTemplateAnalyzeBuiltin) GetName() string { return "pptx_template_an
 func (t *pptxTemplateAnalyzeBuiltin) GetDescription() string {
 	return `Analyze a user-provided PowerPoint template before filling it.
 - template (required): local .pptx path or an HTTP(S) URL from a chat attachment.
-Returns template_fill_pptx_library.v1 JSON with slide types, text slot IDs, image IDs, table IDs, chart IDs, geometry, capacity metrics, and a plan contract. Use the returned IDs to build a template_fill_pptx_plan.v1 plan, then call pptx_template_fill.`
+Returns template_fill_pptx_library.v1 JSON with slide types, text slot IDs, image IDs, table IDs, chart IDs, SmartArt IDs and node IDs, geometry, capacity metrics, and a plan contract. Use the returned IDs to build a template_fill_pptx_plan.v1 plan, then call pptx_template_fill.`
 }
 
 func (t *pptxTemplateAnalyzeBuiltin) GetInputSchema() interface{} {
@@ -107,11 +107,12 @@ func (t *pptxTemplateFillBuiltin) GetName() string { return "pptx_template_fill"
 
 func (t *pptxTemplateFillBuiltin) GetDescription() string {
 	return `Create a new PowerPoint file by deterministically filling and reusing slides from an existing template.
-- Call pptx_template_analyze first and use its exact slide, slot, table, chart, and image IDs.
+- Call pptx_template_analyze first and use its exact slide, slot, table, chart, image, SmartArt, and SmartArt node IDs.
 - template: local .pptx path or HTTP(S) chat attachment URL.
 - path: exact output .pptx path; relative paths resolve to the user's Documents folder.
-- plan: template_fill_pptx_plan.v1 object. Slides may be selected, repeated, and reordered. Each slide supports replacements, table_edits, chart_edits, image_edits, and notes.
+- plan: template_fill_pptx_plan.v1 object. Slides may be selected, repeated, and reordered. Each slide supports replacements, table_edits, chart_edits, image_edits, smartart_edits, and notes.
 - image_edits: each edit needs an image_id and image_path (local PNG/JPEG path or HTTP(S) URL). Only PNG and JPEG are supported. Replacing an image preserves the template picture frame's position, size, rotation, cropping, and styles without recomputing the aspect ratio.
+- smartart_edits: each edit targets an existing SmartArt from analysis by smartart_id, shape_id, or shape_name and replaces existing node text by node_id or array order. The first version keeps node count, layout, colors, and style unchanged. Empty text intentionally clears a node.
 - Do not insert manual line breaks into titles unless they are intentional; single-line template titles are auto-fitted by default.
 - Keep replacement text concise and respect capacity warnings. New text/image or text/text collisions are validation errors: shorten the content or choose another template slide.
 - transition defaults to "keep", preserving source transitions and object animations.
@@ -212,6 +213,43 @@ func (t *pptxTemplateFillBuiltin) GetInputSchema() interface{} {
 											),
 										},
 										"required": []string{"image_id", "image_path"},
+									},
+								},
+								"smartart_edits": map[string]interface{}{
+									"type": "array",
+									"items": map[string]interface{}{
+										"type": "object",
+										"properties": map[string]interface{}{
+											"smartart_id": stringProperty("SmartArt ID from template analysis. Prefer this selector when available."),
+											"shape_id":    stringProperty("Optional SmartArt shape ID from template analysis."),
+											"shape_name":  stringProperty("Optional SmartArt shape name from template analysis."),
+											"optional": map[string]interface{}{
+												"type":        "boolean",
+												"description": "Skip this SmartArt edit if the target is absent. Defaults to false.",
+												"default":     false,
+											},
+											"nodes": map[string]interface{}{
+												"type": "array",
+												"items": map[string]interface{}{
+													"type": "object",
+													"properties": map[string]interface{}{
+														"node_id": stringProperty("Optional SmartArt node ID from analysis. If omitted, nodes are matched by array order."),
+														"text":    stringProperty("Replacement node text. An empty string clears the node."),
+														"paragraphs": map[string]interface{}{
+															"type":        "array",
+															"description": "Optional replacement paragraphs. Overrides text when present; an empty array clears the node.",
+															"items":       map[string]interface{}{"type": "string"},
+														},
+														"optional": map[string]interface{}{
+															"type":        "boolean",
+															"description": "Skip this node edit if the node is absent. Defaults to false.",
+															"default":     false,
+														},
+													},
+												},
+											},
+										},
+										"required": []string{"nodes"},
 									},
 								},
 								"notes":      stringProperty("Speaker notes for the generated slide."),
@@ -351,7 +389,7 @@ func compactPptxCheckReport(report *office.CheckReport) *office.CheckReport {
 		}
 		result := office.CheckResult{}
 		for _, key := range []string{
-			"status", "plan_slide", "source_slide", "slot_id", "table_id", "chart_id", "image_id", "selector",
+			"status", "plan_slide", "source_slide", "slot_id", "table_id", "chart_id", "image_id", "smartart_id", "node_id", "selector",
 			"new_text", "message", "estimated_font_scale_percent", "capacity_visual_width", "collisions",
 			"category_axis_font_size_pt", "category_label_area_percent", "category_labels_fit",
 			"longest_category", "longest_category_visual_width", "suggested_max_visual_width",
@@ -398,6 +436,8 @@ func pptxCheckSuggestion(item office.CheckResult) string {
 			return "Shorten the longest category label; the chart already uses the maximum label area and minimum 8pt axis font."
 		}
 		return "Make every chart series contain exactly one value for each category."
+	case strings.Contains(message, "SmartArt"):
+		return "Re-run pptx_template_analyze and use an exact SmartArt ID and node ID from the returned library."
 	case status == "WARN":
 		return "Shorten this text or choose a larger slot to avoid very small rendered text."
 	default:


### PR DESCRIPTION
## Summary

- Add SmartArt analysis to PPT template libraries, including SmartArt IDs, shape metadata, geometry, and editable node IDs.
- Add `smartart_edits` support to template fill plans for replacing existing SmartArt node text.
- Update SmartArt diagram data and diagram drawing cache so PowerPoint opens with rendered text already in sync.
- Expose SmartArt edit fields in the tool schema and update the PowerPoint skill so agents can use `pptx_template_analyze` -> `pptx_template_fill`.

## Scope

This supports editing text in existing SmartArt nodes only. It preserves the template SmartArt node count, layout, colors, and style. It does not create, delete, or relayout SmartArt nodes.