### PR TITLE
feat: pass compatibleProvider for Local embedding provider

### DIFF
--- a/embedding/provider.go
+++ b/embedding/provider.go
@@ -31,7 +31,7 @@ type EmbeddingProvider interface {
 	QueryVector(text string, ctx context.Context, lang string) ([]float32, *EmbeddingResult, error)
 }
 
-func GetEmbeddingProvider(typ string, subType string, clientId string, clientSecret string, providerUrl string, apiVersion string, pricePerThousandTokens float64, currency string, lang string) (EmbeddingProvider, error) {
+func GetEmbeddingProvider(typ string, subType string, clientId string, clientSecret string, providerUrl string, apiVersion string, compatibleProvider string, pricePerThousandTokens float64, currency string, lang string) (EmbeddingProvider, error) {
 	var p EmbeddingProvider
 	var err error
 	if typ == "OpenAI" {
@@ -47,7 +47,7 @@ func GetEmbeddingProvider(typ string, subType string, clientId string, clientSec
 	} else if typ == "Ollama" {
 		p, err = NewLocalEmbeddingProvider("Custom", "custom-embedding", "randomString", providerUrl, subType, pricePerThousandTokens, currency)
 	} else if typ == "Local" {
-		p, err = NewLocalEmbeddingProvider(typ, subType, clientSecret, providerUrl, subType, pricePerThousandTokens, currency)
+		p, err = NewLocalEmbeddingProvider(typ, subType, clientSecret, providerUrl, compatibleProvider, pricePerThousandTokens, currency)
 	} else if typ == "Azure" {
 		p, err = NewAzureEmbeddingProvider(typ, subType, clientId, clientSecret, providerUrl, apiVersion)
 	} else if typ == "MiniMax" {

--- a/object/provider.go
+++ b/object/provider.go
@@ -351,7 +351,7 @@ func (p *Provider) GetVideoProvider(lang string) (video.VideoProvider, error) {
 }
 
 func (p *Provider) GetEmbeddingProvider(lang string) (embedding.EmbeddingProvider, error) {
-	pProvider, err := embedding.GetEmbeddingProvider(p.Type, p.SubType, p.ClientId, p.ClientSecret, p.ProviderUrl, p.ApiVersion, p.InputPricePerThousandTokens, p.Currency, lang)
+	pProvider, err := embedding.GetEmbeddingProvider(p.Type, p.SubType, p.ClientId, p.ClientSecret, p.ProviderUrl, p.ApiVersion, p.CompatibleProvider, p.InputPricePerThousandTokens, p.Currency, lang)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

- Fix Local embedding provider construction by passing `compatibleProvider` instead of reusing `subType`
- Wire `Provider.CompatibleProvider` through `object.Provider.GetEmbeddingProvider()` into `embedding.GetEmbeddingProvider()`

## Problem

For Local embedding providers, `subType` is always `custom-embedding`, while the actual model name is stored in the `compatibleProvider` field (same pattern as Local model providers).

Previously, `GetEmbeddingProvider()` passed `subType` as both the subtype and the compatible provider when constructing a Local embedding provider. As a result, the API request used `custom-embedding` as the model name instead of the configured model (e.g. `text-embedding-3-small`), causing Local embedding to fail.

## Solution

- Add a `compatibleProvider` parameter to `embedding.GetEmbeddingProvider()`
- Pass `p.CompatibleProvider` from `object.Provider.GetEmbeddingProvider()`
- Use `compatibleProvider` when creating a Local embedding provider via `NewLocalEmbeddingProvider()`

This mirrors the existing behavior for Local model providers in `model/provider.go`.

## Test plan

- [ ] Configure an Embedding provider with type **Local**
- [ ] Set **Sub type** to `custom-embedding`
- [ ] Set **Compatible provider** to a valid model name exposed by the local endpoint (e.g. `text-embedding-3-small`)
- [ ] Set **Provider URL** and **Client secret** (auth token) for the local OpenAI-compatible endpoint
- [ ] Run a vector search / RAG flow and verify embeddings are generated successfully
- [ ] Confirm the request uses the compatible provider model name, not `custom-embedding`
- [x] `go build ./...`