### PR TITLE
fix: prevent cleanup job from deleting new chats with AI reply

### DIFF
--- a/controllers/message.go
+++ b/controllers/message.go
@@ -373,48 +373,50 @@ func (c *ApiController) AddMessage() {
 
 	if success && addMessageAfterSuccess {
 		chatId := util.GetId(message.Owner, message.Chat)
+		modelProvider := chat.ModelProvider
+		if modelProvider == "" {
+			// Fallback to store's model provider if chat doesn't have one
+			store, storeErr := object.ResolveStoreForChat(chat)
+			if storeErr == nil && store != nil {
+				modelProvider = store.ModelProvider
+			}
+		}
+		answerMessage := &object.Message{
+			Owner:         message.Owner,
+			Name:          fmt.Sprintf("message_%s", util.GetRandomName()),
+			CreatedTime:   util.GetCurrentTimeEx(message.CreatedTime),
+			Organization:  message.Organization,
+			Store:         chat.Store,
+			User:          message.User,
+			Chat:          message.Chat,
+			ReplyTo:       message.Name,
+			Author:        "AI",
+			Text:          "",
+			FileName:      message.FileName,
+			VectorScores:  []object.VectorScore{},
+			ModelProvider: modelProvider,
+		}
+		_, err = object.AddMessage(answerMessage)
+		if err != nil {
+			c.ResponseError(err.Error())
+			return
+		}
+
 		chat, err = object.GetChat(chatId)
 		if err != nil {
 			c.ResponseError(err.Error())
 			return
 		}
-		if chat != nil {
-			modelProvider := chat.ModelProvider
-			if modelProvider == "" {
-				// Fallback to store's model provider if chat doesn't have one
-				store, storeErr := object.ResolveStoreForChat(chat)
-				if storeErr == nil && store != nil {
-					modelProvider = store.ModelProvider
-				}
-			}
-			answerMessage := &object.Message{
-				Owner:         message.Owner,
-				Name:          fmt.Sprintf("message_%s", util.GetRandomName()),
-				CreatedTime:   util.GetCurrentTimeEx(message.CreatedTime),
-				Organization:  message.Organization,
-				Store:         chat.Store,
-				User:          message.User,
-				Chat:          message.Chat,
-				ReplyTo:       message.Name,
-				Author:        "AI",
-				Text:          "",
-				FileName:      message.FileName,
-				VectorScores:  []object.VectorScore{},
-				ModelProvider: modelProvider,
-			}
-			_, err = object.AddMessage(answerMessage)
-			if err != nil {
-				c.ResponseError(err.Error())
-				return
-			}
-
-			chat.IsUnread = true
-			chat.IsGenerating = true
-			_, err = object.UpdateChat(chatId, chat)
-			if err != nil {
-				c.ResponseError(err.Error())
-				return
-			}
+		if chat == nil {
+			c.ResponseError(fmt.Sprintf("chat:The chat: %s is not found", chatId))
+			return
+		}
+		chat.IsUnread = true
+		chat.IsGenerating = true
+		_, err = object.UpdateChat(chatId, chat)
+		if err != nil {
+			c.ResponseError(err.Error())
+			return
 		}
 	}
 

--- a/object/message_cleanup.go
+++ b/object/message_cleanup.go
@@ -86,7 +86,7 @@ func cleanupChats() error {
 		if chat.MessageCount == 0 || len(chatMessages) == 0 {
 			needDelete = true
 		} else if chat.MessageCount == 1 {
-			if chatMessages[0].Author == "AI" {
+			if len(chatMessages) == 1 && chatMessages[0].Author == "AI" {
 				needDelete = true
 			}
 		} else if chat.MessageCount == 2 {


### PR DESCRIPTION
## Problem

The chat cleanup job was incorrectly deleting chats that already contained both a user message and an AI reply.

When a new chat is created with a user message, an empty AI reply is added automatically. Due to a stale cached chat object, `MessageCount` was still `1` when the chat was updated. The cleanup job then treated these chats as having only a single AI message and deleted them.

## Changes

1. **`object/message_cleanup.go`** — When `MessageCount == 1`, delete the chat only if there is actually one message in the database (`len(chatMessages) == 1` and it is from AI).
2. **`controllers/message.go`** — Reload the chat after adding the auto AI message before updating it, so `MessageCount` reflects both messages.

## Test plan

- [ ] Create a new chat with a user message
- [ ] Verify the chat has 2 messages (user + AI placeholder)
- [ ] Run or wait for the cleanup job — the chat should not be deleted

**Review tip:** This PR is easier to review with **Hide whitespace changes** enabled. Most of the diff in `controllers/message.go` is indentation from moving the same block of code, not new logic.