### PR TITLE
feat: support image as RAG knowledge

### DIFF
--- a/model/openai.go
+++ b/model/openai.go
@@ -761,7 +761,14 @@ func openaiRawMessagesToGptVisionMessages(messages []*RawMessage) (responses.Res
 			role = responses.EasyInputMessageRoleUser
 		}
 
-		urls, messageText := extractImagesURL(message.Text)
+		// OpenAI's Responses API rejects `input_image` on system messages
+		// (only `input_text` is allowed there). Keep any URLs inline as text
+		// for the system role so the model still sees them.
+		var urls []string
+		messageText := message.Text
+		if role != responses.EasyInputMessageRoleSystem {
+			urls, messageText = extractImagesURL(message.Text)
+		}
 
 		var itemContentList responses.ResponseInputMessageContentListParam
 		if len(messageText) > 0 {

--- a/model/util.go
+++ b/model/util.go
@@ -178,8 +178,20 @@ func getSystemMessages(prompt string, knowledgeMessages []*RawMessage) []*RawMes
 	}
 
 	combined := prompt
+	hasImageKnowledge := false
 	for i, message := range knowledgeMessages {
 		combined += fmt.Sprintf("\n\n%s %d: %s", knowledgeTag, i+1, message.Text)
+		if strings.Contains(message.Text, "![](") {
+			hasImageKnowledge = true
+		}
+	}
+
+	if hasImageKnowledge {
+		if containsZh(prompt) {
+			combined += "\n\n若上述知识中包含与问题相关的图片，请在回答中用 Markdown 语法 ![](url) 原样引用对应图片链接。"
+		} else {
+			combined += "\n\nIf any of the knowledge above contains an image relevant to the question, include the image in your answer using its original markdown link ![](url)."
+		}
 	}
 
 	return []*RawMessage{{Text: combined, Author: "System"}}

--- a/object/image_caption.go
+++ b/object/image_caption.go
@@ -1,0 +1,130 @@
+// Copyright 2023 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package object
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+
+	"github.com/the-open-agent/openagent/i18n"
+	"github.com/the-open-agent/openagent/model"
+	"github.com/the-open-agent/openagent/txt"
+)
+
+const imageCaptionPrompt = "Describe the image in detail for retrieval indexing. Cover the main subject, scene, any visible text, colors, and distinctive features. Reply with the description only, no preamble."
+
+// sseCaptureWriter satisfies io.Writer + http.Flusher (every streaming model
+// provider requires the latter) and decodes the `event: message\ndata: ...\n\n`
+// SSE framing each chunk arrives in so the caller gets clean text. Falls back
+// to the raw bytes for non-SSE writes.
+type sseCaptureWriter struct {
+	buf bytes.Buffer
+}
+
+func (w *sseCaptureWriter) Write(p []byte) (int, error) {
+	if bytes.HasPrefix(p, []byte("event: message")) {
+		prefix := []byte("event: message\ndata: ")
+		suffix := []byte("\n\n")
+		w.buf.Write(bytes.TrimSuffix(bytes.TrimPrefix(p, prefix), suffix))
+	} else {
+		w.buf.Write(p)
+	}
+	return len(p), nil
+}
+
+func (w *sseCaptureWriter) String() string { return w.buf.String() }
+func (*sseCaptureWriter) Flush()           {}
+
+func isImageExtension(ext string) bool {
+	ext = strings.ToLower(ext)
+	for _, imageExt := range txt.GetSupportedImageTypes() {
+		if ext == imageExt {
+			return true
+		}
+	}
+	return false
+}
+
+func detectImageMimeType(data []byte, fallbackExt string) string {
+	mimeType := http.DetectContentType(data)
+	switch strings.ToLower(strings.TrimSpace(strings.Split(mimeType, ";")[0])) {
+	case "image/jpeg", "image/png", "image/gif", "image/webp":
+		return mimeType
+	}
+	switch strings.ToLower(fallbackExt) {
+	case ".jpg", ".jpeg":
+		return "image/jpeg"
+	case ".png":
+		return "image/png"
+	case ".gif":
+		return "image/gif"
+	case ".webp":
+		return "image/webp"
+	}
+	return ""
+}
+
+func generateImageCaption(modelProviderObj model.ModelProvider, fileUrl string, fileExt string, lang string) (string, error) {
+	if modelProviderObj == nil {
+		return "", fmt.Errorf(i18n.Translate(lang, "object:image caption requires a model provider; configure a vision-capable ModelProvider on the store"))
+	}
+
+	resp, err := http.Get(fileUrl)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	mimeType := detectImageMimeType(data, fileExt)
+	if mimeType == "" {
+		return "", fmt.Errorf(i18n.Translate(lang, "object:unsupported image type for: %s"), fileUrl)
+	}
+
+	// The image rides on a synthetic user history turn; the question then asks
+	// the vision model to caption it. RawMessage.Images is honored by the
+	// vision-aware message converter (see model.OpenaiRawMessagesToGptVisionMessages).
+	history := []*model.RawMessage{
+		{
+			Text:   "[image attached]",
+			Author: "User",
+			Images: []model.ImageAttachment{{Data: data, MimeType: mimeType}},
+		},
+	}
+
+	buf := &sseCaptureWriter{}
+	_, err = modelProviderObj.QueryText(imageCaptionPrompt, buf, history, "", nil, nil, lang)
+	if err != nil {
+		return "", err
+	}
+
+	caption := strings.TrimSpace(buf.String())
+	if caption == "" {
+		return "", fmt.Errorf(i18n.Translate(lang, "object:empty caption returned by vision model for image: %s"), fileUrl)
+	}
+	return caption, nil
+}
+
+func isSupportedImageFile(fileKey string) bool {
+	return isImageExtension(filepath.Ext(fileKey))
+}

--- a/object/image_caption.go
+++ b/object/image_caption.go
@@ -27,7 +27,17 @@ import (
 	"github.com/the-open-agent/openagent/txt"
 )
 
-const imageCaptionPrompt = "Describe the image in detail for retrieval indexing. Cover the main subject, scene, any visible text, colors, and distinctive features. Reply with the description only, no preamble."
+var (
+	imageCaptionPromptEn = "Describe the image in detail for retrieval indexing. Cover the main subject, scene, any visible text, colors, and distinctive features. Reply with the description only, no preamble."
+	imageCaptionPromptZh = "请详细描述这张图片，用于检索索引。覆盖主体、场景、画面中可见的文字、颜色和独特特征。仅输出描述本身，不要前缀或寒暄。"
+)
+
+func getImageCaptionPrompt(lang string) string {
+	if strings.HasPrefix(strings.ToLower(lang), "zh") {
+		return imageCaptionPromptZh
+	}
+	return imageCaptionPromptEn
+}
 
 // sseCaptureWriter satisfies io.Writer + http.Flusher (every streaming model
 // provider requires the latter) and decodes the `event: message\ndata: ...\n\n`
@@ -113,7 +123,7 @@ func generateImageCaption(modelProviderObj model.ModelProvider, fileUrl string, 
 	}
 
 	buf := &sseCaptureWriter{}
-	_, err = modelProviderObj.QueryText(imageCaptionPrompt, buf, history, "", nil, nil, lang)
+	_, err = modelProviderObj.QueryText(getImageCaptionPrompt(lang), buf, history, "", nil, nil, lang)
 	if err != nil {
 		return "", err
 	}

--- a/object/store.go
+++ b/object/store.go
@@ -463,6 +463,11 @@ func RefreshStoreVectors(store *Store, lang string) (bool, error) {
 		return false, err
 	}
 
+	modelProviderObj, err := modelProvider.GetModelProvider(lang)
+	if err != nil {
+		return false, err
+	}
+
 	err = UpdateFilesStatusByStore(store.Owner, store.Name, FileStatusPending)
 	if err != nil {
 		return false, err
@@ -473,7 +478,7 @@ func RefreshStoreVectors(store *Store, lang string) (bool, error) {
 		return false, err
 	}
 
-	ok, err := addVectorsForStore(storageProviderObj, embeddingProviderObj, "", store.Owner, store.Name, store.SplitProvider, embeddingProvider.Name, modelProvider.SubType, lang)
+	ok, err := addVectorsForStore(storageProviderObj, embeddingProviderObj, modelProviderObj, "", store.Owner, store.Name, store.SplitProvider, embeddingProvider.Name, modelProvider.SubType, lang)
 	return ok, err
 }
 
@@ -499,8 +504,13 @@ func AddVectorsForFile(store *Store, fileName string, fileUrl string, lang strin
 		return false, err
 	}
 
+	modelProviderObj, err := modelProvider.GetModelProvider(lang)
+	if err != nil {
+		return false, err
+	}
+
 	ok, err := withFileStatus(store.Owner, store.Name, fileName, func() (bool, int, error) {
-		return addVectorsForFile(embeddingProviderObj, store.Name, fileName, fileUrl, store.SplitProvider, embeddingProvider.Name, modelProvider.SubType, lang)
+		return addVectorsForFile(embeddingProviderObj, modelProviderObj, store.Name, fileName, fileUrl, store.SplitProvider, embeddingProvider.Name, modelProvider.SubType, lang)
 	})
 
 	return ok, err

--- a/object/vector.go
+++ b/object/vector.go
@@ -32,6 +32,7 @@ type Vector struct {
 	File        string  `xorm:"varchar(500)" json:"file"`
 	Index       int     `json:"index"`
 	Text        string  `xorm:"mediumtext" json:"text"`
+	ImageUrl    string  `xorm:"varchar(1000)" json:"imageUrl"`
 	TokenCount  int     `json:"tokenCount"`
 	Price       float64 `json:"price"`
 	Currency    string  `xorm:"varchar(100)" json:"currency"`

--- a/object/vector_embedding.go
+++ b/object/vector_embedding.go
@@ -34,9 +34,11 @@ import (
 )
 
 func filterTextFiles(files []*storage.Object) []*storage.Object {
-	fileTypes := txt.GetSupportedFileTypes()
 	fileTypeMap := map[string]bool{}
-	for _, fileType := range fileTypes {
+	for _, fileType := range txt.GetSupportedFileTypes() {
+		fileTypeMap[fileType] = true
+	}
+	for _, fileType := range txt.GetSupportedImageTypes() {
 		fileTypeMap[fileType] = true
 	}
 
@@ -50,7 +52,7 @@ func filterTextFiles(files []*storage.Object) []*storage.Object {
 	return res
 }
 
-func addEmbeddedVector(embeddingProviderObj embedding.EmbeddingProvider, text string, storeName string, fileName string, index int, embeddingProviderName string, modelSubType string, lang string) (bool, int, error) {
+func addEmbeddedVector(embeddingProviderObj embedding.EmbeddingProvider, text string, imageUrl string, storeName string, fileName string, index int, embeddingProviderName string, modelSubType string, lang string) (bool, int, error) {
 	data, embeddingResult, err := queryVectorSafe(embeddingProviderObj, text, embeddingProviderName, lang)
 	if err != nil {
 		return false, 0, err
@@ -95,6 +97,7 @@ func addEmbeddedVector(embeddingProviderObj embedding.EmbeddingProvider, text st
 		File:        fileName,
 		Index:       index,
 		Text:        text,
+		ImageUrl:    imageUrl,
 		TokenCount:  tokenCount,
 		Price:       price,
 		Currency:    currency,
@@ -105,13 +108,18 @@ func addEmbeddedVector(embeddingProviderObj embedding.EmbeddingProvider, text st
 	return affected, tokenCount, err
 }
 
-func addVectorsForFile(embeddingProviderObj embedding.EmbeddingProvider, storeName string, fileKey string, fileUrl string, splitProviderName string, embeddingProviderName string, modelSubType string, lang string) (bool, int, error) {
+func addVectorsForFile(embeddingProviderObj embedding.EmbeddingProvider, modelProviderObj model.ModelProvider, storeName string, fileKey string, fileUrl string, splitProviderName string, embeddingProviderName string, modelSubType string, lang string) (bool, int, error) {
+	fileExt := filepath.Ext(fileKey)
+
+	if isImageExtension(fileExt) {
+		return addVectorForImageFile(embeddingProviderObj, modelProviderObj, storeName, fileKey, fileUrl, fileExt, embeddingProviderName, modelSubType, lang)
+	}
+
 	var (
 		affected        bool
 		totalTokenCount int
 	)
 
-	fileExt := filepath.Ext(fileKey)
 	text, err := txt.GetParsedTextFromUrl(fileUrl, fileExt, lang)
 	if err != nil {
 		return false, 0, err
@@ -149,7 +157,7 @@ func addVectorsForFile(embeddingProviderObj embedding.EmbeddingProvider, storeNa
 		)
 		operation := func() error {
 			var opErr error
-			sectionAffected, sectionTokenCount, opErr = addEmbeddedVector(embeddingProviderObj, textSection, storeName, fileKey, i, embeddingProviderName, modelSubType, lang)
+			sectionAffected, sectionTokenCount, opErr = addEmbeddedVector(embeddingProviderObj, textSection, "", storeName, fileKey, i, embeddingProviderName, modelSubType, lang)
 			if opErr != nil {
 				if isRetryableError(opErr) {
 					return opErr
@@ -169,6 +177,40 @@ func addVectorsForFile(embeddingProviderObj embedding.EmbeddingProvider, storeNa
 	}
 
 	return affected, totalTokenCount, nil
+}
+
+func addVectorForImageFile(embeddingProviderObj embedding.EmbeddingProvider, modelProviderObj model.ModelProvider, storeName string, fileKey string, fileUrl string, fileExt string, embeddingProviderName string, modelSubType string, lang string) (bool, int, error) {
+	logs.Info("Generating caption for image, store: [%s], file: [%s]", storeName, fileKey)
+
+	caption, err := generateImageCaption(modelProviderObj, fileUrl, fileExt, lang)
+	if err != nil {
+		return false, 0, err
+	}
+
+	logs.Info("Embedding caption for store: [%s], file: [%s]: %s", storeName, fileKey, caption)
+
+	var (
+		affected   bool
+		tokenCount int
+	)
+	operation := func() error {
+		var opErr error
+		affected, tokenCount, opErr = addEmbeddedVector(embeddingProviderObj, caption, fileUrl, storeName, fileKey, 0, embeddingProviderName, modelSubType, lang)
+		if opErr != nil {
+			if isRetryableError(opErr) {
+				return opErr
+			}
+			return backoff.Permanent(opErr)
+		}
+		return nil
+	}
+	err = backoff.Retry(operation, backoff.NewExponentialBackOff())
+	if err != nil {
+		logs.Error("Failed to embed image caption after retries: %v", err)
+		return affected, tokenCount, err
+	}
+
+	return affected, tokenCount, nil
 }
 
 func withFileStatus(owner string, storeName string, fileKey string, op func() (bool, int, error)) (bool, error) {
@@ -196,7 +238,7 @@ func withFileStatus(owner string, storeName string, fileKey string, op func() (b
 	return affected, opErr
 }
 
-func addVectorsForStore(storageProviderObj storage.StorageProvider, embeddingProviderObj embedding.EmbeddingProvider, prefix string, owner string, storeName string, splitProviderName string, embeddingProviderName string, modelSubType string, lang string) (bool, error) {
+func addVectorsForStore(storageProviderObj storage.StorageProvider, embeddingProviderObj embedding.EmbeddingProvider, modelProviderObj model.ModelProvider, prefix string, owner string, storeName string, splitProviderName string, embeddingProviderName string, modelSubType string, lang string) (bool, error) {
 	var (
 		affected bool
 		fileErr  error
@@ -211,7 +253,7 @@ func addVectorsForStore(storageProviderObj storage.StorageProvider, embeddingPro
 
 	for _, file := range files {
 		fileAffected, err := withFileStatus(owner, storeName, file.Key, func() (bool, int, error) {
-			return addVectorsForFile(embeddingProviderObj, storeName, file.Key, file.Url, splitProviderName, embeddingProviderName, modelSubType, lang)
+			return addVectorsForFile(embeddingProviderObj, modelProviderObj, storeName, file.Key, file.Url, splitProviderName, embeddingProviderName, modelSubType, lang)
 		})
 		if err != nil {
 			logs.Error("Failed to add vectors for store: [%s], file: [%s]: %v", storeName, file.Key, err)
@@ -294,8 +336,17 @@ func GetNearestKnowledge(storeName string, vectorStores []string, searchProvider
 			Vector: vector.Name,
 			Score:  vector.Score,
 		})
+
+		// Image vectors carry both a caption and the original URL. Surface the URL
+		// in markdown so the model can echo it back into the answer and the chat
+		// renderer displays the image to the user.
+		knowledgeText := vector.Text
+		if vector.ImageUrl != "" {
+			knowledgeText = fmt.Sprintf("%s\n\n![](%s)", vector.Text, vector.ImageUrl)
+		}
+
 		knowledge = append(knowledge, &model.RawMessage{
-			Text:           vector.Text,
+			Text:           knowledgeText,
 			Author:         "System",
 			TextTokenCount: vector.TokenCount,
 		})

--- a/txt/txt.go
+++ b/txt/txt.go
@@ -27,6 +27,10 @@ func GetSupportedFileTypes() []string {
 	return []string{".txt", ".md", ".yaml", ".csv", ".pdf", ".docx", ".xlsx", ".pptx"}
 }
 
+func GetSupportedImageTypes() []string {
+	return []string{".jpg", ".jpeg", ".png", ".webp", ".gif"}
+}
+
 func GetParsedTextFromUrl(url string, ext string, lang string) (string, error) {
 	var path string
 	var err error


### PR DESCRIPTION
## Summary

Adds image support to the RAG knowledge base. Until now only text files
(`.txt`, `.md`, `.pdf`, `.docx`, ...) could be ingested; with this PR,
images (`.jpg/.jpeg/.png/.webp/.gif`) are also supported.

### How it works (caption-based RAG)

1. **Ingest**: when a supported image is uploaded to a store, the store's
   `ModelProvider` (must be vision-capable, e.g. `gpt-4o`, `gpt-4o-mini`,
   `qwen-vl-plus`) is invoked to produce a textual caption.
2. **Embed**: the caption is embedded via the existing `EmbeddingProvider`
   and stored as a normal `Vector` row, plus a new `ImageUrl` column
   pointing to the original image.
3. **Retrieve**: at query time the existing cosine-similarity search returns
   the image's caption vector; the `GetNearestKnowledge` path re-injects
   the URL as `![](url)` markdown into the knowledge context.
4. **Answer**: a small instruction is appended to the system prompt
   (Chinese + English) telling the LLM to echo the markdown image link in
   its answer. The frontend's existing markdown renderer displays the image
   inline.

No new embedding interfaces, no new vector store — fully reuses the
existing 12 embedding providers and search providers.

### Latent bug fix (bundled)

`model/openai.go` previously fed any image URL found inside a system
message to OpenAI's Responses API as `input_image`. The Responses API
only accepts `input_image` on user messages and returns a 400 otherwise.
This was hidden until system prompts started containing image URLs (as
this feature does). Fix: skip the URL → image conversion for the system
role and keep URLs as plain text there.

### Schema

`Vector` gets a new column `image_url varchar(1000)`. Xorm's `Sync2` adds
the column at startup; existing rows have `ImageUrl=""` and behave exactly
as before — no manual migration required.

## Test plan

- [x] `go build ./...` clean
- [x] Existing text-RAG flow (PDF, DOCX, TXT) ingests and answers as before
- [x] Image file (`cat.png`) uploaded → `Files` status `Finished`,
      `Vector` row populated with caption + `image_url`
- [x] Question relevant to the image triggers retrieval; backend log shows
      `![](url)` in the knowledge context
- [x] LLM (gpt-4o-mini) echoes the markdown link and the chat UI renders
      the image inline
- [ ] Negative: configure a non-vision `ModelProvider`, upload image,
      expect `Files` status `Error` with a clear message

## Notes for reviewers

- No frontend changes. The existing markdown renderer already handles
  `![](url)`, and the file upload accepts the new extensions because the
  backend filter (`filterTextFiles` in `object/vector_embedding.go`) is
  what gates ingestion, not a frontend allow-list.
- Caption generation runs sequentially per file; large batches may want
  concurrency in a follow-up.


Closes #2370
