### PR TITLE
fix: Use local static assets for built-in icons and logos

### DIFF
--- a/conf/conf.go
+++ b/conf/conf.go
@@ -102,16 +102,8 @@ func GetConfigString(key string) string {
 
 	res := beego.AppConfig.String(key)
 	if res == "" {
-		if key == "staticBaseUrl" {
-			res = "https://cdn.openagentai.org"
-		} else if key == "logConfig" {
+		if key == "logConfig" {
 			res = "{\"filename\": \"logs/openagent.log\", \"maxdays\":99999, \"perm\":\"0770\"}"
-		}
-	}
-
-	if key == "staticBaseUrl" {
-		if strings.HasSuffix(beego.AppConfig.String("casdoorEndpoint"), ".casdoor.net") && res == "https://cdn.openagentai.org" {
-			res = "https://cdn.casibase.com"
 		}
 	}
 

--- a/embed.go
+++ b/embed.go
@@ -40,6 +40,7 @@ var _embeddedConf embed.FS
 //go:embed web/build/static/css/*.css
 //go:embed web/build/static/js/*.js web/build/static/js/*.txt
 //go:embed web/build/static/media
+//go:embed web/build/img web/build/icon web/build/flag-icons
 var _embeddedWeb embed.FS
 
 //go:embed skills

--- a/object/init.go
+++ b/object/init.go
@@ -30,16 +30,99 @@ func InitDb() {
 	// Load the built-in site first so that site.ParentDbName overrides
 	// app.conf before any other initialization reads conf or uses providerAdapter.
 	initBuiltInSite()
+	normalizeBuiltInSiteStaticAssets()
 	if site, err := GetBuiltInSiteWithSecret(); err == nil && site != nil {
 		SyncSiteToConf(site)
 		RefreshProviderAdapter()
 	}
 	modelProviderName, embeddingProviderName, ttsProviderName, sttProviderName, imageProviderName := initBuiltInProviders()
 	initBuiltInStore(modelProviderName, embeddingProviderName, ttsProviderName, sttProviderName, imageProviderName)
+	normalizeBuiltInStoreStaticAssets()
 	initSkillsFromFolder()
 	initBuiltInTools()
 	InitUsers()
 	go printStartupStats()
+}
+
+var oldDefaultStaticAssetUrls = map[string]string{
+	"https://cdn.openagentai.org":                                 "",
+	"https://cdn.openagentai.org/img/openagent.png":               "/img/openagent.png",
+	"https://cdn.openagentai.org/img/openagent-logo_1900x450.png": "/img/openagent-logo_1900x450.png",
+	"https://cdn.casibase.com/img/casibase.png":                   "/img/openagent.png",
+	"https://cdn.casibase.org/img/casibase-logo_1200x256.png":     "/img/openagent-logo_1900x450.png",
+}
+
+func normalizeDefaultStaticAssetUrl(url string) (string, bool) {
+	res, ok := oldDefaultStaticAssetUrls[url]
+	return res, ok
+}
+
+func normalizeDefaultStaticAssetHtml(html string) (string, bool) {
+	res := html
+	for oldUrl, newUrl := range oldDefaultStaticAssetUrls {
+		if oldUrl == "" {
+			continue
+		}
+		res = strings.ReplaceAll(res, oldUrl, newUrl)
+	}
+	return res, res != html
+}
+
+func normalizeBuiltInSiteStaticAssets() {
+	site := &Site{Owner: "admin", Name: "site-built-in"}
+	existed, err := adapter.engine.Get(site)
+	if err != nil {
+		panic(err)
+	}
+	if !existed {
+		return
+	}
+
+	cols := []string{}
+	if faviconUrl, ok := normalizeDefaultStaticAssetUrl(site.FaviconUrl); ok {
+		site.FaviconUrl = faviconUrl
+		cols = append(cols, "favicon_url")
+	}
+	if logoUrl, ok := normalizeDefaultStaticAssetUrl(site.LogoUrl); ok {
+		site.LogoUrl = logoUrl
+		cols = append(cols, "logo_url")
+	}
+	if footerHtml, ok := normalizeDefaultStaticAssetHtml(site.FooterHtml); ok {
+		site.FooterHtml = footerHtml
+		cols = append(cols, "footer_html")
+	}
+	if staticBaseUrl, ok := normalizeDefaultStaticAssetUrl(site.StaticBaseUrl); ok {
+		site.StaticBaseUrl = staticBaseUrl
+		cols = append(cols, "static_base_url")
+	}
+	if len(cols) == 0 {
+		return
+	}
+
+	_, err = adapter.engine.Where("owner = ? AND name = ?", site.Owner, site.Name).Cols(cols...).Update(site)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func normalizeBuiltInStoreStaticAssets() {
+	stores := []*Store{}
+	err := adapter.engine.Where("avatar in (?, ?)", "https://cdn.openagentai.org/img/openagent.png", "https://cdn.casibase.com/img/casibase.png").Find(&stores)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, store := range stores {
+		avatar, ok := normalizeDefaultStaticAssetUrl(store.Avatar)
+		if !ok {
+			continue
+		}
+		store.Avatar = avatar
+		_, err = adapter.engine.Where("owner = ? AND name = ?", store.Owner, store.Name).Cols("avatar").Update(store)
+		if err != nil {
+			panic(err)
+		}
+	}
 }
 
 func printStartupStats() {
@@ -100,7 +183,7 @@ func initBuiltInStore(modelProviderName string, embeddingProviderName string, tt
 		CreatedTime:          util.GetCurrentTime(),
 		DisplayName:          "Built-in Store",
 		Title:                "AI Assistant",
-		Avatar:               "https://cdn.openagentai.org/img/openagent.png",
+		Avatar:               "/img/openagent.png",
 		StorageProvider:      "provider-storage-built-in",
 		StorageSubpath:       "store-built-in",
 		ImageProvider:        imageProviderName,
@@ -657,11 +740,11 @@ func initBuiltInSite() {
 		DisplayName:   "Built-in Site",
 		ThemeColor:    "#404040",
 		HtmlTitle:     "OpenAgent",
-		FaviconUrl:    "https://cdn.openagentai.org/img/openagent.png",
-		LogoUrl:       "https://cdn.openagentai.org/img/openagent-logo_1900x450.png",
+		FaviconUrl:    "/img/openagent.png",
+		LogoUrl:       "/img/openagent-logo_1900x450.png",
 		NavbarHtml:    "",
-		FooterHtml:    `<a target="_blank" href="https://github.com/the-open-agent/openagent" rel="noreferrer"><img style="padding-bottom: 3px;" height="30" alt="OpenAgent" src="https://cdn.openagentai.org/img/openagent-logo_1900x450.png" /></a>`,
-		StaticBaseUrl: "https://cdn.openagentai.org",
+		FooterHtml:    `<a target="_blank" href="https://github.com/the-open-agent/openagent" rel="noreferrer"><img style="padding-bottom: 3px;" height="30" alt="OpenAgent" src="/img/openagent-logo_1900x450.png" /></a>`,
+		StaticBaseUrl: "",
 		NavItems:      builtInNavItems,
 
 		CasdoorEndpoint:     conf.GetConfigString("casdoorEndpoint"),

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -8,12 +8,12 @@
       name="description"
       content="Web site created using create-react-app"
     />
-    <link rel="apple-touch-icon" href="https://cdn.openagentai.org/img/openagent.png" />
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/img/openagent.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="https://cdn.openagentai.org/site/openagent/manifest.json" />
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/web/public/manifest.json
+++ b/web/public/manifest.json
@@ -3,9 +3,9 @@
   "name": "OpenAgent",
   "icons": [
     {
-      "src": "favicon.ico",
-      "sizes": "64x64 32x32 24x24 16x16",
-      "type": "image/x-icon"
+      "src": "img/openagent.png",
+      "sizes": "512x512",
+      "type": "image/png"
     }
   ],
   "start_url": ".",

--- a/web/src/App.less
+++ b/web/src/App.less
@@ -60,7 +60,7 @@ img {
 }
 
 .language-box {
-  background: url("https://cdn.openagentai.org/img/muti_language.svg");
+  background: url("/img/muti_language.svg");
   background-size: 25px, 25px;
   background-position: center;
   background-repeat: no-repeat;

--- a/web/src/Provider.js
+++ b/web/src/Provider.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React, {useState} from "react";
+import React from "react";
 import {Tooltip} from "antd";
 import * as Setting from "./Setting";
 
@@ -29,47 +29,13 @@ export function getProviderUrl(provider) {
   return "";
 }
 
-function getDefaultLogoURL(provider) {
-  const otherProviderInfo = Setting.getOtherProviderInfo();
-  if (!provider || !otherProviderInfo[provider.category] || !otherProviderInfo[provider.category][provider.type]) {
-    return "";
-  }
-
-  const logoPath = otherProviderInfo[provider.category][provider.type].logo;
-  if (!logoPath) {
-    return "";
-  }
-
-  // Extract the path after StaticBaseUrl and prepend the default CDN URL
-  const defaultCdnUrl = "https://cdn.openagentai.org";
-  const pathMatch = logoPath.match(/\/img\/.+$/);
-  if (pathMatch) {
-    return `${defaultCdnUrl}${pathMatch[0]}`;
-  }
-  return "";
-}
-
 export function ProviderLogo({provider, width = 36, height = 36}) {
-  const [imgSrc, setImgSrc] = useState(Setting.getProviderLogoURL(provider));
-  const [hasError, setHasError] = useState(false);
-
-  const handleError = () => {
-    if (!hasError) {
-      const fallbackUrl = getDefaultLogoURL(provider);
-      if (fallbackUrl && fallbackUrl !== imgSrc) {
-        setImgSrc(fallbackUrl);
-        setHasError(true);
-      }
-    }
-  };
-
   return (
     <img
       width={width}
       height={height}
-      src={imgSrc}
+      src={Setting.getProviderLogoURL(provider)}
       alt={provider.type}
-      onError={handleError}
     />
   );
 }

--- a/web/src/Setting.js
+++ b/web/src/Setting.js
@@ -16,7 +16,7 @@ import i18next from "i18next";
 import {createFromIconfontCN} from "@ant-design/icons";
 
 export const IconFont = createFromIconfontCN({
-  scriptUrl: "https://cdn.open-ct.com/icon/iconfont.js",
+  scriptUrl: "/icon/iconfont.js",
 });
 import Sdk from "casdoor-js-sdk";
 import * as StoreBackend from "./backend/StoreBackend";

--- a/web/src/ThemeSetting.js
+++ b/web/src/ThemeSetting.js
@@ -458,8 +458,8 @@ export function getHtmlTitle(storeHtmlTitle) {
 }
 
 export function getFaviconUrl(themes, storeFaviconUrl) {
-  const defaultFaviconUrl = "https://cdn.casibase.com/static/favicon.png";
-  let faviconUrl = Conf.FaviconUrl;
+  const defaultFaviconUrl = `${Conf.StaticBaseUrl}/img/openagent.png`;
+  let faviconUrl = Conf.FaviconUrl || defaultFaviconUrl;
   if (storeFaviconUrl && storeFaviconUrl !== defaultFaviconUrl) {
     faviconUrl = storeFaviconUrl;
   }
@@ -478,13 +478,10 @@ export function getStoreIconUrl(store) {
 }
 
 export function getLogo(themes, storeLogoUrl) {
-  const defaultLogoUrl = "https://cdn.openagentai.org/img/openagent-logo_1900x450.png";
+  const defaultLogoUrl = `${Conf.StaticBaseUrl}/img/openagent-logo_1900x450.png`;
   let logoUrl = Conf.LogoUrl || defaultLogoUrl;
   if (storeLogoUrl && storeLogoUrl !== defaultLogoUrl) {
     logoUrl = storeLogoUrl;
-  }
-  if (Conf.StaticBaseUrl) {
-    logoUrl = logoUrl.replace("https://cdn.openagentai.org", Conf.StaticBaseUrl);
   }
   if (themes.includes("dark")) {
     return logoUrl.replace(/\.png$/, "_white.png");
@@ -498,7 +495,6 @@ export function getNavbarHtml(themes, storeNavbarHtml) {
   if (storeNavbarHtml) {
     navbarHtml = storeNavbarHtml;
   }
-  navbarHtml = navbarHtml.replace("https://cdn.openagentai.org", Conf.StaticBaseUrl);
   if (themes.includes("dark")) {
     return navbarHtml.replace(/(\.png)/g, "_white$1");
   } else {
@@ -510,8 +506,7 @@ export function getFooterHtml(themes, storeFooterHtml, site) {
   const logoUrl = getLogo("", site?.logoUrl);
   const defaultFooterHtml = `<a target="_blank" href="https://github.com/the-open-agent/openagent" rel="noreferrer"><img style="padding-bottom: 3px;" height="30" alt="OpenAgent" src="${logoUrl}" /></a>`;
   const isDefaultFooter = !storeFooterHtml || storeFooterHtml.includes("/img/openagent-logo_1900x450.png");
-  let footerHtml = isDefaultFooter ? (Conf.FooterHtml || defaultFooterHtml) : storeFooterHtml;
-  footerHtml = footerHtml.replace("https://cdn.openagentai.org", Conf.StaticBaseUrl);
+  const footerHtml = isDefaultFooter ? (Conf.FooterHtml || defaultFooterHtml) : storeFooterHtml;
   if (themes.includes("dark")) {
     return footerHtml.replace(/(\.png)/g, "_white$1");
   } else {

--- a/web/src/chat/MessageItem.js
+++ b/web/src/chat/MessageItem.js
@@ -170,7 +170,7 @@ const MessageItem = ({
   }, [message.author, avatar, account, message]);
 
   const handleAvatarError = () => {
-    setAvatarSrc("https://cdn.openagentai.org/gravatar/error.png");
+    setAvatarSrc(null);
   };
 
   const renderMessageContent = () => {


### PR DESCRIPTION
## Summary

This PR switches built-in OpenAgent icons and logos from external CDN URLs to local static assets, preventing broken images when the app runs without internet access.

## Changes

- Use local `/img/...` paths for built-in site favicon, logo, footer logo, and built-in store avatar.
- Remove the default CDN value for `staticBaseUrl`.
- Load iconfont from local `/icon/iconfont.js`.
- Replace frontend hardcoded CDN asset references with local paths.
- Include `img`, `icon`, and `flag-icons` in embedded frontend builds.
- Migrate known old default CDN asset URLs to local paths without changing custom user-provided URLs.