### PR TITLE
fix: reset mic button when browser ends voice recognition

### DIFF
--- a/web/src/ChatBox.js
+++ b/web/src/ChatBox.js
@@ -279,8 +279,13 @@ class ChatBox extends React.Component {
           this.setState({isVoiceInput: false});
         });
     } else {
-      // Using browser builtin recognition
-      const recognition = this.sttHelper.initBrowserRecognition(this.processVoiceResult());
+      // Using browser builtin recognition. The second callback fires when the
+      // browser ends recognition on its own (silence timeout, network drop,
+      // tab switch, mobile Safari time cap) so the mic button can reset.
+      const recognition = this.sttHelper.initBrowserRecognition(
+        this.processVoiceResult(),
+        () => this.setState({isVoiceInput: false})
+      );
 
       if (!recognition) {
         Setting.showMessage("error", i18next.t("chat:Speech recognition not supported in this browser"));

--- a/web/src/SpeechProvider/BrowserSpeechToTextProvider.js
+++ b/web/src/SpeechProvider/BrowserSpeechToTextProvider.js
@@ -23,7 +23,7 @@ class BrowserSpeechToTextProvider {
     this.lastCallback = null;  // Store the callback for use when stopping
   }
 
-  initBrowserRecognition(resultCallback) {
+  initBrowserRecognition(resultCallback, onEndCallback) {
     // Initialize Web Speech API recognition
     const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
 
@@ -44,6 +44,7 @@ class BrowserSpeechToTextProvider {
 
     // Store the callback for use when stopping
     this.lastCallback = resultCallback;
+    this.onEndCallback = onEndCallback;
 
     this.recognition.onresult = (event) => {
       if (resultCallback && typeof resultCallback === "function") {
@@ -65,6 +66,18 @@ class BrowserSpeechToTextProvider {
     this.recognition.onerror = (event) => {
       if (event.error !== "aborted") {
         Setting.showMessage("error", `${i18next.t("chat:Failed to recognize speech")}: ${event.error}`);
+      }
+    };
+
+    // Browsers end recognition on their own (silence timeout, network drop,
+    // tab switch, mobile Safari ~60s cap) even when continuous is true. Without
+    // surfacing onend, callers can't reset their "recording" UI state and the
+    // mic button stays stuck.
+    this.recognition.onend = () => {
+      if (typeof this.onEndCallback === "function") {
+        const cb = this.onEndCallback;
+        this.onEndCallback = null;
+        cb();
       }
     };
 
@@ -102,6 +115,10 @@ class BrowserSpeechToTextProvider {
             this.lastCallback = null;
           }
         }
+
+        // User-initiated stop already updates UI in stopVoiceInput; suppress
+        // the onend callback so we don't double-fire setState.
+        this.onEndCallback = null;
 
         // Now abort the recognition
         this.recognition.abort();


### PR DESCRIPTION
## Problem

`BrowserSpeechToTextProvider` only listened to `onresult` and `onerror` on the Web Speech API recognition object. When the browser ended recognition on its own — silence timeout (Chrome ~5–8s of quiet), network drop, tab switch, mobile Safari's ~60s cap, etc. — there was no signal back to React. `ChatBox` kept `isVoiceInput=true` and the mic button stayed stuck in the "recording" state until the user manually clicked it.

## Fix

- `BrowserSpeechToTextProvider.initBrowserRecognition` now takes a second `onEndCallback` argument and wires it to the `recognition.onend` event.
- `ChatBox.startVoiceInput` passes `() => setState({isVoiceInput: false})` so the mic button resets naturally when the browser ends recognition.
- User-initiated stop (`stopRecognition`) clears the callback before calling `recognition.abort()` to avoid double-firing `setState` (the existing `stopVoiceInput` path already updates UI state).

Two files, +25 / -3 lines. No frontend dependency or backend change.

## Test plan

- [x] Start voice input in chat → mic button shows recording state
- [x] Stop talking for ~8 seconds → browser fires `onend` → mic button resets to idle automatically
- [x] Click mic button to stop manually → button resets exactly once (no double state flicker)
- [x] Switch to a different browser tab while recording → `onend` fires → button resets when returning
- [x] Remote / cloud STT provider path is unchanged (only the `else` branch in `startVoiceInput` is touched)

Related to #2374 (addresses the specific "mic button stays in recording state after browser auto-stops" issue; #2374 may include other voice-input concerns not covered here)
