### PR TITLE
fix: auto-end voice recording on silence so mic button resets

### DIFF
--- a/web/src/ChatBox.js
+++ b/web/src/ChatBox.js
@@ -279,8 +279,13 @@ class ChatBox extends React.Component {
           this.setState({isVoiceInput: false});
         });
     } else {
-      // Using browser builtin recognition
-      const recognition = this.sttHelper.initBrowserRecognition(this.processVoiceResult());
+      // Using browser builtin recognition. The second callback fires when the
+      // browser ends recognition on its own (silence timeout, network drop,
+      // tab switch, mobile Safari time cap) so the mic button can reset.
+      const recognition = this.sttHelper.initBrowserRecognition(
+        this.processVoiceResult(),
+        () => this.setState({isVoiceInput: false})
+      );
 
       if (!recognition) {
         Setting.showMessage("error", i18next.t("chat:Speech recognition not supported in this browser"));

--- a/web/src/SpeechProvider/BrowserSpeechToTextProvider.js
+++ b/web/src/SpeechProvider/BrowserSpeechToTextProvider.js
@@ -16,14 +16,45 @@ import * as Setting from "../Setting";
 import {showMessage} from "../Setting";
 import i18next from "i18next";
 
+// How long the recognition session can sit without producing any result
+// (interim or final) before we treat the user as "done speaking" and stop
+// the session. Reset by every onresult event.
+const SILENCE_TIMEOUT_MS = 6000;
+
 class BrowserSpeechToTextProvider {
   constructor(parent) {
     this.parent = parent;
     this.recognition = null;
     this.lastCallback = null;  // Store the callback for use when stopping
+    this.onEndCallback = null;
+    this.silenceTimer = null;
   }
 
-  initBrowserRecognition(resultCallback) {
+  _resetSilenceTimer() {
+    if (this.silenceTimer) {
+      clearTimeout(this.silenceTimer);
+    }
+    this.silenceTimer = setTimeout(() => {
+      this.silenceTimer = null;
+      if (this.recognition) {
+        // graceful stop → triggers onend → triggers onEndCallback → UI resets
+        try {
+          this.recognition.stop();
+        } catch (e) {
+          // stop() can throw if already stopping; safe to ignore.
+        }
+      }
+    }, SILENCE_TIMEOUT_MS);
+  }
+
+  _clearSilenceTimer() {
+    if (this.silenceTimer) {
+      clearTimeout(this.silenceTimer);
+      this.silenceTimer = null;
+    }
+  }
+
+  initBrowserRecognition(resultCallback, onEndCallback) {
     // Initialize Web Speech API recognition
     const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
 
@@ -38,14 +69,23 @@ class BrowserSpeechToTextProvider {
     }
 
     this.recognition = new SpeechRecognition();
+    // continuous=true keeps the mic open across short pauses, so the user
+    // can string several sentences together. The silence timer below is
+    // what ultimately ends the session — after SILENCE_TIMEOUT_MS of no
+    // results, recognition.stop() fires onend and the UI resets.
     this.recognition.continuous = true;
     this.recognition.interimResults = true;
     this.recognition.lang = Setting.getLanguage();
 
     // Store the callback for use when stopping
     this.lastCallback = resultCallback;
+    this.onEndCallback = onEndCallback;
 
     this.recognition.onresult = (event) => {
+      // Any result (interim or final) means the user is still actively
+      // speaking, so push the silence deadline forward.
+      this._resetSilenceTimer();
+
       if (resultCallback && typeof resultCallback === "function") {
         // Check if the last result is final
         const results = event.results;
@@ -68,8 +108,24 @@ class BrowserSpeechToTextProvider {
       }
     };
 
+    // Browsers end recognition on their own (our silence timer, network
+    // drop, tab switch, mobile Safari ~60s cap) even when continuous is true.
+    // Without surfacing onend, callers can't reset their "recording" UI state
+    // and the mic button stays stuck.
+    this.recognition.onend = () => {
+      this._clearSilenceTimer();
+      if (typeof this.onEndCallback === "function") {
+        const cb = this.onEndCallback;
+        this.onEndCallback = null;
+        cb();
+      }
+    };
+
     try {
       this.recognition.start();
+      // Arm the silence timer right away so that if the user clicks the mic
+      // but never speaks, the session still self-terminates.
+      this._resetSilenceTimer();
       return this.recognition;
     } catch (error) {
       Setting.showMessage("error", `${i18next.t("chat:Failed to recognize speech")}: ${error.message}`);
@@ -102,6 +158,12 @@ class BrowserSpeechToTextProvider {
             this.lastCallback = null;
           }
         }
+
+        // User-initiated stop already updates UI in stopVoiceInput; suppress
+        // the onend callback so we don't double-fire setState. Also cancel
+        // any pending silence timer.
+        this.onEndCallback = null;
+        this._clearSilenceTimer();
 
         // Now abort the recognition
         this.recognition.abort();

--- a/web/src/SpeechToText.js
+++ b/web/src/SpeechToText.js
@@ -28,8 +28,8 @@ class SpeechToTextHelper {
     this.remoteProvider = new RemoteSpeechToTextProvider(this);
   }
 
-  initBrowserRecognition(resultCallback) {
-    return this.browserProvider.initBrowserRecognition(resultCallback);
+  initBrowserRecognition(resultCallback, onEndCallback) {
+    return this.browserProvider.initBrowserRecognition(resultCallback, onEndCallback);
   }
 
   startRecording() {


### PR DESCRIPTION
## Problem

The browser Web Speech API used by `BrowserSpeechToTextProvider` was configured with `continuous=true` and only listened to `onresult` / `onerror`. After the user stopped speaking, the recognition session stayed alive — `onend` never fired on its own — so `isVoiceInput` in `ChatBox` stayed `true` and the mic button was stuck on the "recording" wave animation until the user manually clicked it.

## Fix

Three coordinated changes:

- **`BrowserSpeechToTextProvider`**: keep `continuous=true` so the user can pause briefly between sentences, but install a 6-second silence timer that resets on every `onresult`. When the timer fires, `recognition.stop()` is called, which triggers `onend`. The `onend` handler invokes an `onEndCallback` supplied by the caller. `stopRecognition` (user-initiated) clears the callback and timer first so the `abort()` → `onend` path doesn't double-fire `setState`.
- **`SpeechToText`** (wrapper): forward the new `onEndCallback` argument through to the browser provider — without this the caller's callback was silently dropped.
- **`ChatBox`**: pass `() => setState({isVoiceInput: false})` as the `onEndCallback` so the mic icon naturally resets when the silence timer (or any other `onend` cause: network drop, tab switch, mobile time cap) ends the session.

## Follow-up to #2377

PR #2377 was merged then rolled back by the maintainer; the original approach only hooked `onend` without the silence timer or the wrapper passthrough, so the actual mic-stuck scenario was not covered. Opening this as a new PR since GitHub doesn't allow reopening a merged-then-reverted PR.

## Test plan

- [x] Click mic, say a sentence, stop talking → mic button auto-resets after ~6s of silence
- [x] Click mic, say a sentence, immediately say another within 6s → recognition stays active, both sentences captured
- [x] Click mic without speaking → session self-terminates after 6s
- [x] Click mic, say a sentence, click the wave to stop manually → mic resets immediately, no double-flicker
- [x] Network drop / tab switch during recording → `onend` fires from the browser side, UI resets

Related to #2374 (covers the "mic button stuck after silence" subcase; other voice-input concerns in the issue are not addressed here).