### PR TITLE
feat: embed default static assets for offline release binaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,18 @@ jobs:
           node-version: 22
           cache: 'yarn'
           cache-dependency-path: ./web/yarn.lock
-      - run: yarn install && CI=false yarn run build
+      - run: yarn install
+        working-directory: ./web
+      - name: Prepare embedded web static assets
+        if: github.repository == 'the-open-agent/openagent' && github.event_name == 'push'
+        run: ./scripts/prepare-embedded-web-assets.sh
+      - name: Build embedded frontend
+        if: github.repository == 'the-open-agent/openagent' && github.event_name == 'push'
+        run: CI=false REACT_APP_EMBED_STATIC_ASSETS=true yarn run build
+        working-directory: ./web
+      - name: Build frontend
+        if: github.repository != 'the-open-agent/openagent' || github.event_name != 'push'
+        run: CI=false yarn run build
         working-directory: ./web
       - name: Upload build artifacts
         if: github.repository == 'the-open-agent/openagent' && github.event_name == 'push'

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,11 @@ openagent
 vendor/
 node_modules/
 tool/pptx-worker/worker.bundle.mjs
+web/public/flag-icons/
+web/public/gravatar/
+web/public/icon/
+web/public/img/
+web/public/site/
 
 data/**
 !data/template/

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -28,6 +28,7 @@ import (
 var (
 	siteConfigOverrides = map[string]string{}
 	siteConfigMu        sync.RWMutex
+	embeddedWebAssets   bool
 )
 
 func SetSiteOverrides(overrides map[string]string) {
@@ -36,6 +37,10 @@ func SetSiteOverrides(overrides map[string]string) {
 	for k, v := range overrides {
 		siteConfigOverrides[k] = v
 	}
+}
+
+func SetEmbeddedWebAssetsEnabled(enabled bool) {
+	embeddedWebAssets = enabled
 }
 
 const FrontendBaseDir = "../openagent"
@@ -218,6 +223,7 @@ func GetWebConfig() *WebConfig {
 	config.IsDemoMode = GetConfigBool("isDemoMode")
 
 	config.ThemeDefault.ColorPrimary = GetDefaultColorPrimary()
+	NormalizeEmbeddedWebConfig(config)
 
 	return config
 }

--- a/conf/embedded_assets.go
+++ b/conf/embedded_assets.go
@@ -1,0 +1,79 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conf
+
+import "strings"
+
+var defaultStaticBaseUrls = []string{
+	"https://cdn.openagentai.org",
+	"https://cdn.casibase.com",
+}
+
+func NormalizeEmbeddedWebConfig(config *WebConfig) {
+	if config == nil || !embeddedWebAssets {
+		return
+	}
+
+	config.StaticBaseUrl = NormalizeEmbeddedStaticBaseUrl(config.StaticBaseUrl)
+	config.FaviconUrl = NormalizeEmbeddedAssetUrl(config.FaviconUrl)
+	config.LogoUrl = NormalizeEmbeddedAssetUrl(config.LogoUrl)
+	config.NavbarHtml = NormalizeEmbeddedAssetHtml(config.NavbarHtml)
+	config.FooterHtml = NormalizeEmbeddedAssetHtml(config.FooterHtml)
+}
+
+func NormalizeEmbeddedStaticBaseUrl(value string) string {
+	if !embeddedWebAssets {
+		return value
+	}
+
+	trimmedValue := strings.TrimRight(value, "/")
+	for _, baseUrl := range defaultStaticBaseUrls {
+		if trimmedValue == baseUrl {
+			return ""
+		}
+	}
+	return value
+}
+
+func NormalizeEmbeddedAssetHtml(value string) string {
+	if !embeddedWebAssets || value == "" {
+		return value
+	}
+
+	result := value
+	result = strings.ReplaceAll(result, "https://cdn.casibase.com/static/favicon.png", "/img/openagent.png")
+	for _, baseUrl := range defaultStaticBaseUrls {
+		result = strings.ReplaceAll(result, baseUrl+"/", "/")
+	}
+	return result
+}
+
+func NormalizeEmbeddedAssetUrl(value string) string {
+	if !embeddedWebAssets || value == "" {
+		return value
+	}
+
+	if value == "https://cdn.casibase.com/static/favicon.png" {
+		return "/img/openagent.png"
+	}
+
+	for _, baseUrl := range defaultStaticBaseUrls {
+		prefix := baseUrl + "/"
+		if strings.HasPrefix(value, prefix) {
+			return "/" + strings.TrimPrefix(value, prefix)
+		}
+	}
+	return value
+}

--- a/embed.go
+++ b/embed.go
@@ -40,6 +40,10 @@ var _embeddedConf embed.FS
 //go:embed web/build/static/css/*.css
 //go:embed web/build/static/js/*.js web/build/static/js/*.txt
 //go:embed web/build/static/media
+//go:embed web/build/img
+//go:embed web/build/flag-icons
+//go:embed web/build/gravatar
+//go:embed web/build/icon
 var _embeddedWeb embed.FS
 
 //go:embed skills

--- a/embedsupport/setup.go
+++ b/embedsupport/setup.go
@@ -20,7 +20,11 @@
 // executable.
 package embedsupport
 
-import "io/fs"
+import (
+	"io/fs"
+
+	"github.com/the-open-agent/openagent/conf"
+)
 
 var (
 	webFS        fs.FS
@@ -31,12 +35,13 @@ var (
 
 // Setup must be called at the very start of main(), before any config values
 // are read or HTTP requests are served.
-func Setup(conf, web, skills, ocrService, pptxWorker fs.FS) {
+func Setup(confFS, web, skills, ocrService, pptxWorker fs.FS) {
 	webFS = web
 	skillsFS = skills
 	ocrServiceFS = ocrService
 	pptxWorkerFS = pptxWorker
-	setupConf(conf)
+	setupConf(confFS)
+	conf.SetEmbeddedWebAssetsEnabled(web != nil)
 }
 
 // WebFS returns the embedded web/build filesystem, or nil if not available.

--- a/object/site.go
+++ b/object/site.go
@@ -111,8 +111,21 @@ func GetBuiltInSite() (*Site, error) {
 	site, err := GetSite("admin/site-built-in")
 	if site != nil {
 		site.ClientSecret = ""
+		NormalizeEmbeddedSiteAssets(site)
 	}
 	return site, err
+}
+
+func NormalizeEmbeddedSiteAssets(site *Site) {
+	if site == nil {
+		return
+	}
+
+	site.StaticBaseUrl = conf.NormalizeEmbeddedStaticBaseUrl(site.StaticBaseUrl)
+	site.FaviconUrl = conf.NormalizeEmbeddedAssetUrl(site.FaviconUrl)
+	site.LogoUrl = conf.NormalizeEmbeddedAssetUrl(site.LogoUrl)
+	site.NavbarHtml = conf.NormalizeEmbeddedAssetHtml(site.NavbarHtml)
+	site.FooterHtml = conf.NormalizeEmbeddedAssetHtml(site.FooterHtml)
 }
 
 func GetBuiltInSiteWithSecret() (*Site, error) {

--- a/routers/static_filter.go
+++ b/routers/static_filter.go
@@ -115,6 +115,10 @@ func StaticFilter(ctx *context.Context) {
 			}
 			makeGzipResponse(ctx.ResponseWriter, ctx.Request, fallback)
 		} else if embedsupport.WebFS() != nil {
+			err := util.AppendWebConfigCookie(ctx)
+			if err != nil {
+				fmt.Println(err)
+			}
 			embedsupport.ServeEmbedded(ctx.ResponseWriter, ctx.Request, urlPath)
 		} else {
 			ctx.ResponseWriter.Header().Set("Content-Type", "text/html; charset=utf-8")

--- a/scripts/prepare-embedded-web-assets.sh
+++ b/scripts/prepare-embedded-web-assets.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+STATIC_REPO_URL="${STATIC_REPO_URL:-https://github.com/the-open-agent/static.git}"
+STATIC_REPO_DIR="${STATIC_REPO_DIR:-}"
+ICONFONT_URL="${ICONFONT_URL:-https://cdn.open-ct.com/icon/iconfont.js}"
+
+if [[ -z "${STATIC_REPO_DIR}" ]]; then
+  TMP_DIR="$(mktemp -d)"
+  trap 'rm -rf "${TMP_DIR}"' EXIT
+  STATIC_REPO_DIR="${TMP_DIR}/static"
+  git clone --depth 1 "${STATIC_REPO_URL}" "${STATIC_REPO_DIR}"
+fi
+
+require_path() {
+  local path="$1"
+  if [[ ! -e "${path}" ]]; then
+    echo "missing required embedded static asset: ${path}" >&2
+    exit 1
+  fi
+}
+
+PUBLIC_DIR="${ROOT_DIR}/web/public"
+
+require_path "${STATIC_REPO_DIR}/img"
+require_path "${STATIC_REPO_DIR}/flag-icons"
+require_path "${STATIC_REPO_DIR}/gravatar"
+
+rm -rf "${PUBLIC_DIR}/img" "${PUBLIC_DIR}/flag-icons" "${PUBLIC_DIR}/gravatar" "${PUBLIC_DIR}/icon"
+cp -R "${STATIC_REPO_DIR}/img" "${PUBLIC_DIR}/img"
+cp -R "${STATIC_REPO_DIR}/flag-icons" "${PUBLIC_DIR}/flag-icons"
+cp -R "${STATIC_REPO_DIR}/gravatar" "${PUBLIC_DIR}/gravatar"
+mkdir -p "${PUBLIC_DIR}/icon"
+curl -fsSL "${ICONFONT_URL}" -o "${PUBLIC_DIR}/icon/iconfont.js"
+
+sed -i \
+  -e 's#https://cdn.openagentai.org/img/openagent.png#/img/openagent.png#g' \
+  -e 's#https://cdn.openagentai.org/site/openagent/manifest.json#/manifest.json#g' \
+  "${PUBLIC_DIR}/index.html"

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -8,12 +8,12 @@
       name="description"
       content="Web site created using create-react-app"
     />
-    <link rel="apple-touch-icon" href="https://cdn.openagentai.org/img/openagent.png" />
+    <link rel="apple-touch-icon" href="/img/openagent.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="https://cdn.openagentai.org/site/openagent/manifest.json" />
+    <link rel="manifest" href="/manifest.json" />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/web/src/Provider.js
+++ b/web/src/Provider.js
@@ -40,11 +40,10 @@ function getDefaultLogoURL(provider) {
     return "";
   }
 
-  // Extract the path after StaticBaseUrl and prepend the default CDN URL
-  const defaultCdnUrl = "https://cdn.openagentai.org";
+  const defaultStaticBaseUrl = process.env.REACT_APP_EMBED_STATIC_ASSETS === "true" ? "" : "https://cdn.openagentai.org";
   const pathMatch = logoPath.match(/\/img\/.+$/);
   if (pathMatch) {
-    return `${defaultCdnUrl}${pathMatch[0]}`;
+    return `${defaultStaticBaseUrl}${pathMatch[0]}`;
   }
   return "";
 }

--- a/web/src/Setting.js
+++ b/web/src/Setting.js
@@ -15,8 +15,12 @@
 import i18next from "i18next";
 import {createFromIconfontCN} from "@ant-design/icons";
 
+const iconfontScriptUrl = process.env.REACT_APP_EMBED_STATIC_ASSETS === "true"
+  ? "/icon/iconfont.js"
+  : "https://cdn.open-ct.com/icon/iconfont.js";
+
 export const IconFont = createFromIconfontCN({
-  scriptUrl: "https://cdn.open-ct.com/icon/iconfont.js",
+  scriptUrl: iconfontScriptUrl,
 });
 import Sdk from "casdoor-js-sdk";
 import * as StoreBackend from "./backend/StoreBackend";

--- a/web/src/ThemeSetting.js
+++ b/web/src/ThemeSetting.js
@@ -48,6 +48,10 @@ export function getDefaultAiAvatar() {
   return `${StaticBaseUrl}/img/openagent.png`;
 }
 
+export function getAvatarFallback() {
+  return `${StaticBaseUrl}/gravatar/error.png`;
+}
+
 export function getUserAvatar(message, account) {
   if (message.author === "AI") {
     return getDefaultAiAvatar();

--- a/web/src/chat/MessageItem.js
+++ b/web/src/chat/MessageItem.js
@@ -170,7 +170,7 @@ const MessageItem = ({
   }, [message.author, avatar, account, message]);
 
   const handleAvatarError = () => {
-    setAvatarSrc("https://cdn.openagentai.org/gravatar/error.png");
+    setAvatarSrc(Setting.getAvatarFallback());
   };
 
   const renderMessageContent = () => {


### PR DESCRIPTION
fix: https://github.com/the-open-agent/openagent/issues/2350

## Summary

This PR makes official GitHub Release binaries built with `-tags embed` include the default static assets needed for offline UI rendering.

The release workflow now prepares static assets before building the frontend artifact, copies only selected assets from `the-open-agent/static` into `web/public`, downloads `iconfont.js` at build time, and embeds the resulting `web/build` assets into the single binary.

Local development behavior is unchanged:
- `yarn start` still uses the existing CDN defaults.
- normal local `yarn build` still uses the existing CDN defaults.

## Changes

- Add `scripts/prepare-embedded-web-assets.sh` for release-only static asset preparation.
- Update GitHub Actions so official push frontend artifacts use `REACT_APP_EMBED_STATIC_ASSETS=true`.
- Embed copied public asset directories from `web/build`:
  - `img`
  - `flag-icons`
  - `gravatar`
  - `icon`
- Download `iconfont.js` during release preparation and serve it locally as `/icon/iconfont.js` in embedded releases.
- Normalize only known default CDN URLs in embedded mode:
  - `https://cdn.openagentai.org`
  - `https://cdn.casibase.com`
- Keep custom CDN/static URLs unchanged.
- Normalize built-in site asset URLs only in API responses, without mutating persisted DB values.
- Replace hard-coded external defaults for avatar fallback, provider fallback, and iconfont in embedded release builds.
- Keep MinIO's existing hard-coded external logo URL unchanged.
- Ignore transient synced `web/public` asset directories.
- Add focused tests for embedded static asset URL normalization.

## Verification

- `go test ./conf`
- `CI=false yarn run build`
- `REACT_APP_EMBED_STATIC_ASSETS=true CI=false yarn run build`
- `bash -n scripts/prepare-embedded-web-assets.sh`

## Notes

`iconfont.js` is downloaded during the release preparation step, then embedded into the release binary. Runtime offline usage does not depend on the CDN.