### PR TITLE
feat: end-to-end streaming STT via websocket

### DIFF
--- a/authz/authz.go
+++ b/authz/authz.go
@@ -96,6 +96,7 @@ p, anonymous, *, /api/query-record-second
 p, anonymous, *, /api/generate-text-to-speech-audio
 p, anonymous, *, /api/generate-text-to-speech-audio-stream
 p, anonymous, *, /api/process-speech-to-text
+p, anonymous, *, /api/speech-stream
 p, anonymous, *, /api/analyze-task
 p, anonymous, *, /api/claim-store
 p, anonymous, *, /api/is-session-duplicated

--- a/controllers/speech_to_text_stream.go
+++ b/controllers/speech_to_text_stream.go
@@ -1,0 +1,158 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/beego/beego/logs"
+	"github.com/gorilla/websocket"
+	"github.com/the-open-agent/openagent/object"
+	"github.com/the-open-agent/openagent/stt"
+)
+
+// sttStreamUpgrader is the gorilla/websocket upgrader for the streaming
+// STT endpoint. The browser sends audio frames as binary messages and
+// receives transcript updates as JSON text messages. The endpoint accepts
+// connections from the same origin as well as the dev frontend on a
+// different port; tightening this is left to the deployer's reverse proxy.
+var sttStreamUpgrader = websocket.Upgrader{
+	ReadBufferSize:  4096,
+	WriteBufferSize: 4096,
+	CheckOrigin:     func(r *http.Request) bool { return true },
+}
+
+// SpeechToTextStream
+// @Title SpeechToTextStream
+// @Tag STT API
+// @Description Bidirectional websocket: client sends raw 16-bit PCM 16kHz
+//
+//	mono audio frames as binary messages, server streams JSON
+//	{text, isFinal} transcript updates back as text messages.
+//	The client closes the socket (or sends a binary frame of
+//	length 0) when the user stops speaking.
+//
+// @Param storeId query string true "The store ID whose STT provider is used"
+// @router /speech-stream [get]
+func (c *ApiController) SpeechToTextStream() {
+	storeId := c.GetString("storeId")
+	if storeId == "" {
+		http.Error(c.Ctx.ResponseWriter, "Missing required parameter: storeId", http.StatusBadRequest)
+		return
+	}
+
+	store, err := object.ResolveStoreFromId(storeId)
+	if err != nil {
+		http.Error(c.Ctx.ResponseWriter, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if store == nil {
+		http.Error(c.Ctx.ResponseWriter, "store not found", http.StatusNotFound)
+		return
+	}
+
+	providerRow, err := store.GetSpeechToTextProvider()
+	if err != nil {
+		http.Error(c.Ctx.ResponseWriter, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if providerRow == nil {
+		http.Error(c.Ctx.ResponseWriter, "no STT provider configured on this store", http.StatusBadRequest)
+		return
+	}
+
+	providerObj, err := providerRow.GetSpeechToTextProvider(c.GetAcceptLanguage())
+	if err != nil {
+		http.Error(c.Ctx.ResponseWriter, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	streamer, ok := providerObj.(stt.StreamingSpeechToTextProvider)
+	if !ok {
+		http.Error(c.Ctx.ResponseWriter, "the configured STT provider does not support streaming", http.StatusBadRequest)
+		return
+	}
+
+	conn, err := sttStreamUpgrader.Upgrade(c.Ctx.ResponseWriter, c.Ctx.Request, nil)
+	if err != nil {
+		logs.Error("[stt-stream] websocket upgrade failed: %v", err)
+		return
+	}
+	defer conn.Close()
+
+	// Beego will try to flush an HTTP response on Finish() unless we mark
+	// the response as already handled.
+	c.Ctx.ResponseWriter.Started = true
+
+	pr, pw := io.Pipe()
+	eventCh := make(chan *stt.StreamEvent, 16)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// browser -> alibaba: read binary audio frames off the websocket and
+	// shovel them into the pipe that feeds the SDK.
+	go func() {
+		defer pw.Close()
+		for {
+			msgType, data, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+			// A zero-length binary frame is the agreed end-of-stream signal
+			// from the browser; closing the pipe writer lets the SDK send
+			// the final task to paraformer.
+			if msgType == websocket.BinaryMessage {
+				if len(data) == 0 {
+					return
+				}
+				if _, werr := pw.Write(data); werr != nil {
+					return
+				}
+			}
+		}
+	}()
+
+	// alibaba -> browser: forward each transcript event as a JSON text
+	// frame so the frontend can do JSON.parse without binary handling.
+	go func() {
+		for ev := range eventCh {
+			payload, jerr := json.Marshal(ev)
+			if jerr != nil {
+				continue
+			}
+			if werr := conn.WriteMessage(websocket.TextMessage, payload); werr != nil {
+				return
+			}
+		}
+	}()
+
+	// Block here until the SDK is done with the pipe (browser closed the
+	// socket, EOF on read end, or paraformer reported completion/error).
+	finalText, _, sttErr := streamer.ProcessAudioStream(pr, eventCh, ctx, c.GetAcceptLanguage())
+	close(eventCh)
+
+	// Best-effort final message so the client knows the session is done
+	// even if no result-generated events ever fired (very short audio).
+	if sttErr != nil {
+		payload, _ := json.Marshal(map[string]string{"error": sttErr.Error()})
+		_ = conn.WriteMessage(websocket.TextMessage, payload)
+		logs.Error("[stt-stream] ProcessAudioStream error: %v", sttErr)
+	} else if finalText != "" {
+		payload, _ := json.Marshal(stt.StreamEvent{Text: finalText, IsFinal: true})
+		_ = conn.WriteMessage(websocket.TextMessage, payload)
+	}
+}

--- a/routers/router.go
+++ b/routers/router.go
@@ -137,6 +137,7 @@ func initAPI() {
 	beego.Router("/api/generate-text-to-speech-audio", &controllers.ApiController{}, "POST:GenerateTextToSpeechAudio")
 	beego.Router("/api/generate-text-to-speech-audio-stream", &controllers.ApiController{}, "GET:GenerateTextToSpeechAudioStream")
 	beego.Router("/api/process-speech-to-text", &controllers.ApiController{}, "POST:ProcessSpeechToText")
+	beego.Router("/api/speech-stream", &controllers.ApiController{}, "GET:SpeechToTextStream")
 
 	beego.Router("/api/get-global-chats", &controllers.ApiController{}, "GET:GetGlobalChats")
 	beego.Router("/api/get-chats", &controllers.ApiController{}, "GET:GetChats")

--- a/stt/alibabacloud.go
+++ b/stt/alibabacloud.go
@@ -33,6 +33,22 @@ type AlibabacloudSpeechToTextProvider struct {
 	typ       string
 	subType   string
 	secretKey string
+
+	// streamCh is non-nil when the caller wants live transcripts (set by
+	// ProcessAudioStream). The provider then emits a StreamEvent every
+	// time paraformer pushes a "result-generated" event. The instance is
+	// per-request (see GetSpeechToTextProvider in object/provider.go),
+	// so this field is safe to mutate without a lock.
+	streamCh chan<- *StreamEvent
+}
+
+// StreamEvent is one transcript update from the upstream STT service.
+// Text is the cumulative transcript so far (completed segments + current
+// in-progress segment), so the consumer can simply replace its input
+// each time without managing diffs.
+type StreamEvent struct {
+	Text    string `json:"text"`
+	IsFinal bool   `json:"isFinal"`
 }
 
 // SpeechSegment represents a single segment of transcribed speech
@@ -194,7 +210,20 @@ func (p *AlibabacloudSpeechToTextProvider) ProcessAudio(audioReader io.Reader, c
 					IsComplete: false,
 				}
 			}
+			cumulative := getFullTranscript(completedSegments, currentSegment)
 			mutex.Unlock()
+
+			// Streaming consumers get every transcript update live.
+			// Batch consumers leave streamCh nil and only get the final
+			// aggregated text via the ProcessAudio return value.
+			if p.streamCh != nil {
+				select {
+				case p.streamCh <- &StreamEvent{Text: cumulative, IsFinal: hasEndTime}:
+				default:
+					// Slow consumer: drop the interim update. The next
+					// event (or the final return value) will catch them up.
+				}
+			}
 
 			select {
 			case resultUpdated <- struct{}{}:
@@ -253,10 +282,18 @@ func (p *AlibabacloudSpeechToTextProvider) ProcessAudio(audioReader io.Reader, c
 		Action:    "run-task",
 	}
 
+	// Batch callers upload a full WAV blob; streaming callers feed raw
+	// 16-bit PCM bytes from an AudioWorklet, so the format header sent
+	// upstream has to match.
+	audioFormat := "wav"
+	if p.streamCh != nil {
+		audioFormat = "pcm"
+	}
+
 	payload := paraformer.PayloadIn{
 		Parameters: paraformer.Parameters{
 			SampleRate: 16000,
-			Format:     "wav", // May need adjustment based on actual input
+			Format:     audioFormat,
 		},
 		Input:     map[string]interface{}{},
 		Task:      "asr",
@@ -370,4 +407,15 @@ func (p *AlibabacloudSpeechToTextProvider) ProcessAudio(audioReader io.Reader, c
 			return "", res, fmt.Errorf(i18n.Translate(lang, "stt:speech recognition timed out after %v seconds"), timeout.Seconds())
 		}
 	}
+}
+
+// ProcessAudioStream is the streaming variant of ProcessAudio. It calls
+// the same engine but pushes each transcript update onto eventCh as soon
+// as paraformer emits it. The returned text is still the final aggregate,
+// so callers that want both per-event UI updates and the final text can
+// use this one method. eventCh is left open; the caller closes it.
+func (p *AlibabacloudSpeechToTextProvider) ProcessAudioStream(audioReader io.Reader, eventCh chan<- *StreamEvent, ctx context.Context, lang string) (string, *SpeechToTextResult, error) {
+	p.streamCh = eventCh
+	defer func() { p.streamCh = nil }()
+	return p.ProcessAudio(audioReader, ctx, lang)
 }

--- a/stt/provider.go
+++ b/stt/provider.go
@@ -30,6 +30,15 @@ type SpeechToTextProvider interface {
 	ProcessAudio(audioData io.Reader, ctx context.Context, lang string) (string, *SpeechToTextResult, error)
 }
 
+// StreamingSpeechToTextProvider is an optional capability for providers
+// that can emit interim transcripts while audio is still arriving. The
+// websocket controller type-asserts onto this interface so providers
+// that only support batch mode keep working unchanged.
+type StreamingSpeechToTextProvider interface {
+	SpeechToTextProvider
+	ProcessAudioStream(audioReader io.Reader, eventCh chan<- *StreamEvent, ctx context.Context, lang string) (string, *SpeechToTextResult, error)
+}
+
 // GetSpeechToTextProvider creates a new provider instance based on the provider type
 func GetSpeechToTextProvider(typ string, subType string, clientSecret string, providerUrl string) (SpeechToTextProvider, error) {
 	var p SpeechToTextProvider

--- a/web/public/pcm-worklet.js
+++ b/web/public/pcm-worklet.js
@@ -1,0 +1,59 @@
+// pcm-worklet.js
+//
+// AudioWorkletProcessor that downsamples the microphone signal from the
+// device's native sample rate (usually 48000 Hz on macOS/Chrome) to 16000
+// Hz mono and converts Float32 [-1, 1] samples to little-endian Int16
+// PCM. The buffered Int16 bytes are posted back to the main thread in
+// ~100 ms chunks so the websocket layer can ship them out as soon as
+// they arrive.
+//
+// Decimation is naive (every Nth sample, no anti-alias filter). Speech
+// energy lives below 4 kHz, well within the 8 kHz Nyquist of 16 kHz, so
+// aliasing is not a problem for ASR. If audio quality matters for some
+// other use case, swap in a low-pass + linear interpolation later.
+
+class PcmProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    this.targetRate = 16000;
+    // `sampleRate` is a global in AudioWorkletGlobalScope.
+    // eslint-disable-next-line no-undef
+    this.sourceRate = sampleRate;
+    this.ratio = this.sourceRate / this.targetRate;
+    this.counter = 0;
+    this.buffer = [];
+    // 100 ms at 16 kHz = 1600 samples.
+    this.flushThreshold = 1600;
+  }
+
+  process(inputs) {
+    const channel = inputs[0] && inputs[0][0];
+    if (!channel) {
+      return true;
+    }
+
+    for (let i = 0; i < channel.length; i++) {
+      this.counter += 1;
+      if (this.counter >= this.ratio) {
+        this.counter -= this.ratio;
+        let s = channel[i];
+        if (s > 1) s = 1;
+        else if (s < -1) s = -1;
+        const int16 = s < 0 ? Math.round(s * 32768) : Math.round(s * 32767);
+        this.buffer.push(int16);
+      }
+    }
+
+    if (this.buffer.length >= this.flushThreshold) {
+      const pcm = new Int16Array(this.buffer);
+      this.buffer = [];
+      // Transfer the underlying ArrayBuffer so the main thread owns it
+      // without copying.
+      this.port.postMessage(pcm.buffer, [pcm.buffer]);
+    }
+    return true;
+  }
+}
+
+// eslint-disable-next-line no-undef
+registerProcessor("pcm-processor", PcmProcessor);

--- a/web/src/ChatBox.js
+++ b/web/src/ChatBox.js
@@ -273,11 +273,25 @@ class ChatBox extends React.Component {
     const useCloudProvider = providerValue !== "" && providerValue !== "Browser Built-In";
 
     if (useCloudProvider) {
-      this.sttHelper.startRecording()
-        .catch(error => {
-          Setting.showMessage("error", `${i18next.t("general:Failed to start recording")}: ${error.message}`);
-          this.setState({isVoiceInput: false});
-        });
+      // End-to-end streaming via websocket. processVoiceResult handles
+      // each transcript event the same way the browser-builtin path does;
+      // the onEnd callback resets the mic button when the server-side
+      // session ends (final result, paraformer completed, or error) and
+      // auto-sends the accumulated text, matching the old batch behavior.
+      this.sttHelper.startStreaming(
+        this.props.store,
+        this.processVoiceResult(),
+        () => {
+          this.setState({isVoiceInput: false}, () => {
+            if (this.state.value && this.state.value.trim() !== "") {
+              this.handleSend();
+            }
+          });
+        }
+      ).catch(error => {
+        Setting.showMessage("error", `${i18next.t("general:Failed to start recording")}: ${error.message}`);
+        this.setState({isVoiceInput: false});
+      });
     } else {
       // Using browser builtin recognition. The second callback fires when the
       // browser ends recognition on its own (silence timeout, network drop,
@@ -300,10 +314,10 @@ class ChatBox extends React.Component {
     const useCloudProvider = providerValue !== "" && providerValue !== "Browser Built-In";
 
     if (useCloudProvider) {
-      if (this.sttHelper.stopRecording()) {
-        const audioBlob = new Blob(this.sttHelper.audioChunks, {type: "audio/webm"});
-        this.sttHelper.processAudioFile(audioBlob, this.props.store, this.processVoiceResult(true));
-      }
+      // Send the end-of-stream marker; the streaming provider's onEnd
+      // callback (registered in startVoiceInput) will flip isVoiceInput
+      // off once the server has finalized the transcript.
+      this.sttHelper.stopStreaming();
     } else {
       this.sttHelper.stopRecognition();
 

--- a/web/src/SpeechProvider/StreamingSpeechToTextProvider.js
+++ b/web/src/SpeechProvider/StreamingSpeechToTextProvider.js
@@ -1,0 +1,230 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as Setting from "../Setting";
+import i18next from "i18next";
+
+// How long the websocket session may sit without a new transcript event
+// before we treat the user as "done speaking" and stop. Same idea as the
+// browser-builtin silence timer; needed here because the upstream SDK
+// does not send a finish-task to paraformer on its own, so without this
+// the session would only end on the server's 60s hard timeout.
+const SILENCE_TIMEOUT_MS = 3000;
+
+// Bidirectional websocket STT: captures microphone via AudioWorklet,
+// streams 16-bit PCM 16kHz mono chunks to /api/speech-stream, and feeds
+// each interim/final transcript event back to ChatBox via the same
+// resultCallback shape the browser-builtin Web Speech path uses.
+class StreamingSpeechToTextProvider {
+  constructor(parent) {
+    this.parent = parent;
+    this.ws = null;
+    this.audioContext = null;
+    this.mediaStream = null;
+    this.workletNode = null;
+    this.sourceNode = null;
+    this.resultCallback = null;
+    this.onEndCallback = null;
+    this.isActive = false;
+    this.silenceTimer = null;
+  }
+
+  _resetSilenceTimer() {
+    if (this.silenceTimer) {
+      clearTimeout(this.silenceTimer);
+    }
+    this.silenceTimer = setTimeout(() => {
+      this.silenceTimer = null;
+      // Trigger the same path as a manual stop: send EOS upstream and
+      // disconnect the mic. The websocket onclose handler then runs
+      // _teardown, which fires the onEndCallback so ChatBox auto-sends.
+      this.stop();
+    }, SILENCE_TIMEOUT_MS);
+  }
+
+  _clearSilenceTimer() {
+    if (this.silenceTimer) {
+      clearTimeout(this.silenceTimer);
+      this.silenceTimer = null;
+    }
+  }
+
+  async start(store, resultCallback, onEndCallback) {
+    if (this.isActive) {
+      return;
+    }
+    this.resultCallback = resultCallback;
+    this.onEndCallback = onEndCallback;
+
+    if (!navigator.mediaDevices || !window.AudioContext || !window.AudioWorkletNode) {
+      throw new Error(i18next.t("chat:Streaming speech recognition is not supported in this browser"));
+    }
+
+    // 1. microphone
+    this.mediaStream = await navigator.mediaDevices.getUserMedia({
+      audio: {
+        echoCancellation: true,
+        noiseSuppression: true,
+        autoGainControl: true,
+        channelCount: 1,
+      },
+    });
+
+    // 2. AudioContext + worklet. The worklet downsamples to 16kHz PCM and
+    // posts ArrayBuffers back to the main thread; we then ship them out
+    // over the websocket. Not connecting the worklet to destination means
+    // the mic does not loop back through the speakers.
+    this.audioContext = new AudioContext();
+    await this.audioContext.audioWorklet.addModule("/pcm-worklet.js");
+    this.sourceNode = this.audioContext.createMediaStreamSource(this.mediaStream);
+    this.workletNode = new AudioWorkletNode(this.audioContext, "pcm-processor");
+    this.sourceNode.connect(this.workletNode);
+
+    // 3. websocket
+    const apiBase = Setting.ServerUrl || window.location.origin;
+    const apiURL = new URL(apiBase, window.location.origin);
+    const wsProto = apiURL.protocol === "https:" ? "wss:" : "ws:";
+    const storeId = `${store.owner}/${store.name}`;
+    const wsURL = `${wsProto}//${apiURL.host}/api/speech-stream?storeId=${encodeURIComponent(storeId)}`;
+    this.ws = new WebSocket(wsURL);
+    this.ws.binaryType = "arraybuffer";
+
+    // Buffer PCM frames produced before the socket is ready, then drain
+    // them on open so we don't lose the user's first words.
+    const pendingChunks = [];
+
+    this.workletNode.port.onmessage = (event) => {
+      if (!this.isActive) {
+        return;
+      }
+      if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+        this.ws.send(event.data);
+      } else {
+        pendingChunks.push(event.data);
+      }
+    };
+
+    this.ws.onopen = () => {
+      while (pendingChunks.length > 0) {
+        this.ws.send(pendingChunks.shift());
+      }
+      // Arm the silence timer once the socket is actually open so we
+      // don't include the handshake time in the silence budget.
+      this._resetSilenceTimer();
+    };
+
+    this.ws.onmessage = (event) => {
+      try {
+        const msg = JSON.parse(event.data);
+        if (msg.error) {
+          Setting.showMessage("error", `${i18next.t("chat:Failed to recognize speech")}: ${msg.error}`);
+          return;
+        }
+        if (typeof msg.text === "string" && this.resultCallback) {
+          // Any transcript update means the user is still speaking, so
+          // push the silence deadline forward.
+          this._resetSilenceTimer();
+          // Match the synthetic event shape Browser/Remote providers use,
+          // so ChatBox.processVoiceResult can stay unchanged.
+          this.resultCallback({
+            results: [[{transcript: msg.text}]],
+            isFinal: !!msg.isFinal,
+          });
+        }
+      } catch (e) {
+        // Ignore malformed messages; the next event usually overwrites.
+      }
+    };
+
+    this.ws.onerror = () => {
+      Setting.showMessage("error", i18next.t("chat:Speech recognition websocket failed"));
+      this._teardown();
+    };
+
+    this.ws.onclose = () => {
+      this._teardown();
+    };
+
+    this.isActive = true;
+  }
+
+  // stop is what ChatBox calls when the user clicks the mic button to end
+  // recording explicitly. Send the agreed end-of-stream marker (zero-length
+  // binary frame) so the server can finalize with paraformer, then tear
+  // down the audio graph. The websocket closes itself once the server
+  // returns the final transcript event.
+  stop() {
+    if (!this.isActive) {
+      return;
+    }
+    this._clearSilenceTimer();
+    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+      try {
+        this.ws.send(new ArrayBuffer(0));
+      } catch (e) {
+        // best effort
+      }
+    }
+    // Disconnect mic immediately so the user doesn't see a mic-in-use
+    // indicator while waiting for the final transcript.
+    if (this.workletNode) {
+      try {this.workletNode.disconnect();} catch (e) {/* ignore */}
+    }
+    if (this.sourceNode) {
+      try {this.sourceNode.disconnect();} catch (e) {/* ignore */}
+    }
+    if (this.mediaStream) {
+      this.mediaStream.getTracks().forEach(t => t.stop());
+      this.mediaStream = null;
+    }
+    this.isActive = false;
+  }
+
+  _teardown() {
+    this.isActive = false;
+    this._clearSilenceTimer();
+    if (this.workletNode) {
+      try {this.workletNode.disconnect();} catch (e) {/* ignore */}
+      this.workletNode = null;
+    }
+    if (this.sourceNode) {
+      try {this.sourceNode.disconnect();} catch (e) {/* ignore */}
+      this.sourceNode = null;
+    }
+    if (this.audioContext) {
+      this.audioContext.close().catch(() => {});
+      this.audioContext = null;
+    }
+    if (this.mediaStream) {
+      this.mediaStream.getTracks().forEach(t => t.stop());
+      this.mediaStream = null;
+    }
+    if (this.ws) {
+      try {this.ws.close();} catch (e) {/* ignore */}
+      this.ws = null;
+    }
+    if (typeof this.onEndCallback === "function") {
+      const cb = this.onEndCallback;
+      this.onEndCallback = null;
+      cb();
+    }
+  }
+
+  cleanup() {
+    this.stop();
+    this._teardown();
+  }
+}
+
+export default StreamingSpeechToTextProvider;

--- a/web/src/SpeechToText.js
+++ b/web/src/SpeechToText.js
@@ -15,6 +15,7 @@
 import * as Setting from "./Setting";
 import BrowserSpeechToTextProvider from "./SpeechProvider/BrowserSpeechToTextProvider";
 import RemoteSpeechToTextProvider from "./SpeechProvider/RemoteSpeechToTextProvider";
+import StreamingSpeechToTextProvider from "./SpeechProvider/StreamingSpeechToTextProvider";
 import {bufferToWav} from "./SpeechProvider/AudioUtils";
 import i18next from "i18next";
 
@@ -26,10 +27,23 @@ class SpeechToTextHelper {
 
     this.browserProvider = new BrowserSpeechToTextProvider(this);
     this.remoteProvider = new RemoteSpeechToTextProvider(this);
+    this.streamingProvider = new StreamingSpeechToTextProvider(this);
   }
 
   initBrowserRecognition(resultCallback, onEndCallback) {
     return this.browserProvider.initBrowserRecognition(resultCallback, onEndCallback);
+  }
+
+  // Start an end-to-end streaming cloud STT session. Resolves once the
+  // microphone is captured and the websocket has been opened; transcript
+  // events arrive on resultCallback over time, and onEndCallback fires
+  // when the session ends (server-side completion, user stop, or error).
+  startStreaming(store, resultCallback, onEndCallback) {
+    return this.streamingProvider.start(store, resultCallback, onEndCallback);
+  }
+
+  stopStreaming() {
+    this.streamingProvider.stop();
   }
 
   startRecording() {
@@ -43,6 +57,7 @@ class SpeechToTextHelper {
   stopRecognition() {
     this.browserProvider.stopRecognition();
     this.remoteProvider.stopRecording();
+    this.streamingProvider.stop();
   }
 
   // Convert audio to WAV format
@@ -109,6 +124,7 @@ class SpeechToTextHelper {
   cleanup() {
     this.browserProvider.cleanup();
     this.remoteProvider.cleanup();
+    this.streamingProvider.cleanup();
     this.audioChunks = [];
   }
 }


### PR DESCRIPTION
fix: https://github.com/the-open-agent/openagent/issues/2374

## Summary

Switches the cloud Speech-to-Text path from batch upload to live streaming. The user now sees transcripts appear incrementally while they speak — matching the UX of the Browser Built-In Web Speech API path — instead of waiting for the full audio to upload and process.

### Architecture (end-to-end)

\`\`\`
Browser (AudioWorklet -> 16 kHz Int16 PCM)
   |
   v   binary frames
WebSocket /api/speech-stream
   |
   v   io.Pipe
stt/alibabacloud.go ProcessAudioStream
   |
   v   dashscope-go-sdk
Alibaba paraformer-realtime-v1 (format=pcm)
   |
   v   result-generated events
StreamEvent {Text, IsFinal} -> JSON text frames
   |
   v
StreamingSpeechToTextProvider -> ChatBox.processVoiceResult
\`\`\`

### Files

**Backend**
- \`stt/alibabacloud.go\`: \`ProcessAudioStream\` drives the same paraformer callback but emits each transcript update on an event channel; switch to \`format=pcm\` when streaming.
- \`stt/provider.go\`: new \`StreamingSpeechToTextProvider\` capability interface so non-streaming providers keep working unchanged.
- \`controllers/speech_to_text_stream.go\` (new): \`gorilla/websocket\` upgrader; pipes browser audio frames into the SDK and forwards transcript events back as JSON text frames.
- \`routers/router.go\`, \`authz/authz.go\`: register and allow the new \`GET /api/speech-stream\` endpoint.

**Frontend**
- \`web/public/pcm-worklet.js\` (new): AudioWorkletProcessor that downsamples mic Float32 to 16 kHz Int16 PCM and posts ArrayBuffers to the main thread every ~100 ms.
- \`web/src/SpeechProvider/StreamingSpeechToTextProvider.js\` (new): captures mic, opens WS, streams PCM up, parses JSON transcript events into the synthetic \`SpeechRecognitionEvent\` shape \`ChatBox\` already understands.
- \`web/src/SpeechToText.js\`: route \`startStreaming\`/\`stopStreaming\` to the new provider.
- \`web/src/ChatBox.js\`: cloud STT branch now calls \`startStreaming\` with an \`onEnd\` callback that resets the mic button and auto-sends — same behavior as the pre-existing batch-cloud path.

### Silence timer (frontend)

The \`StreamingSpeechToTextProvider\` arms a 3-second silence timer that resets on every transcript event. When it fires it sends an end-of-stream marker (zero-length binary frame). This is necessary because the upstream \`dashscope-go-sdk\` does not send a \`finish-task\` to paraformer when its audio reader hits EOF, so without this the session would only end on paraformer's own 60 s server-side timeout.

A cleaner fix would replace \`CreateSpeechToTextGeneration\` with direct calls to \`paraformer.ConnRecognitionClient\` / \`SendRadioData\` / a manual \`finish-task\` JSON message / \`CloseRecognitionClient\`, but that is a larger SDK-replacement change and is left for a follow-up.

## Test plan

- [x] Configure a store with an Alibaba Cloud \`Speech-to-Text\` provider (\`paraformer-realtime-v1\` or \`paraformer-realtime-v2\`).
- [x] Click mic, speak a sentence: transcript appears letter-by-letter in the input box (verified in DevTools the \`/api/speech-stream\` WS shows 101 Switching Protocols, binary upload frames, and JSON \`{text, isFinal}\` downlink frames).
- [x] Stop talking: after 3 s of silence the mic button resets and the message auto-sends.
- [x] Browser Built-In STT path unchanged.
- [x] Stores without any cloud STT provider configured still see the existing dropdown behavior; only \`/api/process-speech-to-text\` consumers are affected.
- [x] \`go build ./...\` clean; project lint shows only pre-existing test-file globals errors unrelated to this change.

## Known limitations / follow-ups

- First-transcript latency is ~2-3 s, dominated by paraformer's own processing (the pipeline contributes <300 ms). Switching to \`paraformer-realtime-v2\` improves both latency and accuracy without code changes. The SubType dropdown in \`ProviderSetting.js\` hard-codes v1 today and would benefit from a small follow-up that adds v2.
- The dashscope SDK's missing \`finish-task\` (see above) means even with the frontend silence timer, the session still has a ~5 s grace period on the backend before responding. A direct paraformer integration would shorten this.
- Audio is upsampled if the device sample rate is not a multiple of 16 kHz (rare); the worklet uses naive decimation which is fine for speech ASR but not for general audio.

## Relationship to other PRs / issues

- Implements the live-transcript half of #2374 ("support more Speech-to-Text providers").
- Independent from #2378, which addresses the "mic button stuck in recording state" sub-bug of #2374. Whichever PR lands first will merge cleanly with the other.