### PR TITLE
fix: use correct paraformer STT's completion event names

### DIFF
--- a/stt/alibabacloud.go
+++ b/stt/alibabacloud.go
@@ -242,7 +242,10 @@ func (p *AlibabacloudSpeechToTextProvider) ProcessAudio(audioReader io.Reader, c
 				}
 			}
 
-		case "completed":
+		// Paraformer's actual completion event name is "task-finished".
+		// "completed" was a leftover that never matched anything; kept
+		// as a tolerated alias in case some model variant uses it.
+		case "task-finished", "completed":
 			mutex.Lock()
 			recognitionDone = true
 			res.AudioDurationSeconds = totalDuration
@@ -254,7 +257,9 @@ func (p *AlibabacloudSpeechToTextProvider) ProcessAudio(audioReader io.Reader, c
 				// Channel buffer full, ignore
 			}
 
-		case "error":
+		// Likewise paraformer's failure event is "task-failed"; keep
+		// "error" for compatibility with any older/other event shape.
+		case "task-failed", "error":
 			message := "unknown error"
 			if msg, hasMsg := header["message"].(string); hasMsg {
 				message = msg


### PR DESCRIPTION
## Summary

The streaming callback in `stt/alibabacloud.go` was switching on event names `"completed"` and `"error"`, but these never appear in paraformer's wire protocol — the real event names are `"task-finished"` (success) and `"task-failed"` (error). As a result `recognitionDone` was never set on the success path; the session worked only because `ProcessAudio`'s `apiCallDone` + `timeoutTimer` grace path returned the already-streamed partial transcript regardless.

Switches the cases to `"task-finished"` / `"task-failed"` while keeping the old strings as tolerated aliases in case some model variant emits them.

## Test plan
- [ ] Verify long-form streaming STT (paraformer-realtime-v1) still works end-to-end
- [ ] Manually stop a recording and confirm the session ends quickly via task-finished