### PR TITLE
fix: bypass SDK's 1024-byte websocket read limit for streaming STT

### DIFF
--- a/controllers/openai_api.go
+++ b/controllers/openai_api.go
@@ -98,7 +98,29 @@ func (c *ApiController) chatCompletionsViaStore(store *object.Store, request ope
 	}
 
 	writer := newOpenAIWriter(c.Ctx.ResponseWriter, request, requestId)
-	modelResult, err := modelProviderObj.QueryText(question, writer, history, prompt, []*model.RawMessage{}, nil, lang)
+
+	mcpToolSet, err := object.GetServerMcpToolSet(store.Owner, store.McpServer, lang)
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+	origin := getOriginFromHost(c.Ctx.Request.Host)
+	mcpToolSet = object.MergeMcpTools(mcpToolSet, store, false, "api", origin, lang)
+
+	var modelResult *model.ModelResult
+	if mcpToolSet != nil && (len(mcpToolSet.Tools) > 0 || mcpToolSet.WebSearchEnabled) {
+		toolSession := &model.ToolSession{
+			McpToolSet: mcpToolSet,
+			ToolMessages: &model.ToolMessages{
+				Messages:  []*model.RawMessage{},
+				ToolCalls: nil,
+			},
+			IsVision: model.IsVisionModel(modelProviderRecord.SubType),
+		}
+		modelResult, err = model.QueryTextWithTools(modelProviderObj, question, writer, history, prompt, []*model.RawMessage{}, toolSession, lang)
+	} else {
+		modelResult, err = modelProviderObj.QueryText(question, writer, history, prompt, []*model.RawMessage{}, nil, lang)
+	}
 	if err != nil {
 		c.ResponseError(err.Error())
 		return

--- a/controllers/openai_api_util.go
+++ b/controllers/openai_api_util.go
@@ -118,6 +118,7 @@ func createApiChatSession(store *object.Store, modelProviderName, question, requ
 // applyResultToApiSession writes the AI answer and token counts back to the DB.
 func applyResultToApiSession(aiMsg *object.Message, chat *object.Chat, writer *OpenAIWriter, modelResult *model.ModelResult) error {
 	aiMsg.Text = writer.MessageString()
+	aiMsg.ToolCalls = model.GetToolCallsFromWriter(writer.ToolString())
 	aiMsg.TokenCount = modelResult.TotalTokenCount
 	aiMsg.Price = modelResult.TotalPrice
 	aiMsg.Currency = modelResult.Currency

--- a/controllers/openai_writer.go
+++ b/controllers/openai_writer.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net/http"
 
 	"github.com/beego/beego/context"
 	"github.com/sashabaranov/go-openai"
@@ -30,29 +31,55 @@ type OpenAIWriter struct {
 	Cleaner    Cleaner
 	Buffer     []byte
 	MessageBuf []byte
+	ToolBuf    []byte
 	RequestID  string
 	Stream     bool
 	StreamSent bool
 	Model      string
 }
 
+func getOpenAIEventData(p []byte, eventType string) string {
+	prefix := []byte(fmt.Sprintf("event: %s\ndata: ", eventType))
+	suffix := []byte("\n\n")
+	return string(bytes.TrimSuffix(bytes.TrimPrefix(p, prefix), suffix))
+}
+
 // Write processes incoming data chunks and formats them for OpenAI compatibility
 func (w *OpenAIWriter) Write(p []byte) (n int, err error) {
+	if len(p) > 0 && p[0] == ':' {
+		if !w.Stream {
+			return len(p), nil
+		}
+		n, err = w.ResponseWriter.Write(p)
+		if flusher, ok := w.ResponseWriter.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		return n, err
+	}
+
+	// Always store the original bytes.
+	w.Buffer = append(w.Buffer, p...)
+
 	// Parse the incoming SSE message format
 	var content string
 
 	if bytes.HasPrefix(p, []byte("event: message\ndata: ")) {
-		prefix := []byte("event: message\ndata: ")
-		suffix := []byte("\n\n")
-		content = string(bytes.TrimSuffix(bytes.TrimPrefix(p, prefix), suffix))
+		content = getOpenAIEventData(p, "message")
 
 		// Add content to message buffer
 		w.MessageBuf = append(w.MessageBuf, []byte(content)...)
 	} else if bytes.HasPrefix(p, []byte("event: reason\ndata: ")) {
-		// We don't expose reason data in OpenAI format, but we'll store it
-		prefix := []byte("event: reason\ndata: ")
-		suffix := []byte("\n\n")
-		content = string(bytes.TrimSuffix(bytes.TrimPrefix(p, prefix), suffix))
+		return len(p), nil
+	} else if bytes.HasPrefix(p, []byte("event: tool-delta\ndata: ")) || bytes.HasPrefix(p, []byte("event: tool-start\ndata: ")) {
+		return len(p), nil
+	} else if bytes.HasPrefix(p, []byte("event: tool\ndata: ")) {
+		if len(w.ToolBuf) > 0 {
+			w.ToolBuf = append(w.ToolBuf, '\n')
+		}
+		w.ToolBuf = append(w.ToolBuf, []byte(getOpenAIEventData(p, "tool"))...)
+		return len(p), nil
+	} else if bytes.HasPrefix(p, []byte("event: search\ndata: ")) {
+		return len(p), nil
 	} else {
 		// If we can't parse, just store the raw bytes and attempt to clean
 		content = w.Cleaner.CleanString(string(p))
@@ -60,9 +87,6 @@ func (w *OpenAIWriter) Write(p []byte) (n int, err error) {
 			w.MessageBuf = append(w.MessageBuf, []byte(content)...)
 		}
 	}
-
-	// Always store the original bytes
-	w.Buffer = append(w.Buffer, p...)
 
 	// For non-streaming, just collect the data
 	if !w.Stream {
@@ -113,6 +137,10 @@ func (w *OpenAIWriter) MessageString() string {
 	return string(w.MessageBuf)
 }
 
+func (w *OpenAIWriter) ToolString() string {
+	return string(w.ToolBuf)
+}
+
 // Close finalizes the stream by sending completion message and DONE marker
 func (w *OpenAIWriter) Close(promptTokens, completionTokens, totalTokens int) error {
 	if !w.Stream {
@@ -145,16 +173,21 @@ func (w *OpenAIWriter) Close(promptTokens, completionTokens, totalTokens int) er
 			return err
 		}
 
-		// Send usage information as a custom message
-		usage := map[string]interface{}{
-			"usage": openai.Usage{
+		// Send usage information as an OpenAI-compatible stream chunk.
+		usageChunk := openai.ChatCompletionStreamResponse{
+			ID:      "chatcmpl-" + w.RequestID,
+			Object:  "chat.completion.chunk",
+			Created: util.GetCurrentUnixTime(),
+			Model:   w.Model,
+			Choices: []openai.ChatCompletionStreamChoice{},
+			Usage: &openai.Usage{
 				PromptTokens:     promptTokens,
 				CompletionTokens: completionTokens,
 				TotalTokens:      totalTokens,
 			},
 		}
 
-		usageData, err := json.Marshal(usage)
+		usageData, err := json.Marshal(usageChunk)
 		if err != nil {
 			return err
 		}

--- a/controllers/store.go
+++ b/controllers/store.go
@@ -37,7 +37,7 @@ func (c *ApiController) GetHubStores() {
 		c.ResponseError(err.Error())
 		return
 	}
-	c.ResponseOk(stores)
+	c.ResponseOk(object.GetMaskedStores(stores, c.GetSessionUser()))
 }
 
 // GetGlobalStores
@@ -62,7 +62,7 @@ func (c *ApiController) GetGlobalStores() {
 			return
 		}
 
-		c.ResponseOk(stores)
+		c.ResponseOk(object.GetMaskedStores(stores, c.GetSessionUser()))
 	} else {
 		if !c.RequireAdmin() {
 			return
@@ -112,7 +112,7 @@ func (c *ApiController) GetGlobalStores() {
 			object.SortStoresInMemory(stores, sortField, sortOrder)
 		}
 
-		c.ResponseOk(stores, count)
+		c.ResponseOk(object.GetMaskedStores(stores, c.GetSessionUser()), count)
 	}
 }
 
@@ -138,7 +138,7 @@ func (c *ApiController) GetStores() {
 		return
 	}
 
-	c.ResponseOk(object.GetMaskedStores(stores))
+	c.ResponseOk(object.GetMaskedStores(stores, c.GetSessionUser()))
 }
 
 // GetStore
@@ -168,12 +168,12 @@ func (c *ApiController) GetStore() {
 		origin := getOriginFromHost(host)
 		err = store.Populate(origin, c.GetAcceptLanguage())
 		if err != nil {
-			c.ResponseOk(object.GetMaskedStore(store), err.Error())
+			c.ResponseOk(object.GetMaskedStore(store, c.GetSessionUser()), err.Error())
 			return
 		}
 	}
 
-	c.ResponseOk(object.GetMaskedStore(store))
+	c.ResponseOk(object.GetMaskedStore(store, c.GetSessionUser()))
 }
 
 // UpdateStore
@@ -386,7 +386,7 @@ func (c *ApiController) ClaimStore() {
 		return
 	}
 
-	c.ResponseOk(store)
+	c.ResponseOk(object.GetMaskedStore(store, c.GetSessionUser()))
 }
 
 // RefreshStoreVectors
@@ -497,5 +497,5 @@ func (c *ApiController) AddSharedStore() {
 		return
 	}
 
-	c.ResponseOk(newStore)
+	c.ResponseOk(object.GetMaskedStore(newStore, c.GetSessionUser()))
 }

--- a/object/store.go
+++ b/object/store.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/the-open-agent/openagent/auth"
 	"github.com/the-open-agent/openagent/conf"
 	"github.com/the-open-agent/openagent/i18n"
 	"github.com/the-open-agent/openagent/storage"
@@ -159,21 +160,21 @@ func generateStoreApiKey() string {
 	return fmt.Sprintf("sk-%s", util.GetRandomString(24))
 }
 
-func GetMaskedStore(store *Store) *Store {
+func GetMaskedStore(store *Store, user *auth.User) *Store {
 	if store == nil {
 		return nil
 	}
 
-	if store.ApiKey != "" {
+	if store.ApiKey != "" && !util.IsGlobalAdmin(user) && (user == nil || user.Name != store.Owner) {
 		store.ApiKey = "***"
 	}
 
 	return store
 }
 
-func GetMaskedStores(stores []*Store) []*Store {
+func GetMaskedStores(stores []*Store, user *auth.User) []*Store {
 	for _, store := range stores {
-		store = GetMaskedStore(store)
+		GetMaskedStore(store, user)
 	}
 	return stores
 }

--- a/stt/alibabacloud.go
+++ b/stt/alibabacloud.go
@@ -242,7 +242,10 @@ func (p *AlibabacloudSpeechToTextProvider) ProcessAudio(audioReader io.Reader, c
 				}
 			}
 
-		case "completed":
+		// Paraformer's actual completion event name is "task-finished".
+		// "completed" was a leftover that never matched anything; kept
+		// as a tolerated alias in case some model variant uses it.
+		case "task-finished", "completed":
 			mutex.Lock()
 			recognitionDone = true
 			res.AudioDurationSeconds = totalDuration
@@ -254,7 +257,9 @@ func (p *AlibabacloudSpeechToTextProvider) ProcessAudio(audioReader io.Reader, c
 				// Channel buffer full, ignore
 			}
 
-		case "error":
+		// Likewise paraformer's failure event is "task-failed"; keep
+		// "error" for compatibility with any older/other event shape.
+		case "task-failed", "error":
 			message := "unknown error"
 			if msg, hasMsg := header["message"].(string); hasMsg {
 				message = msg

--- a/stt/alibabacloud.go
+++ b/stt/alibabacloud.go
@@ -23,8 +23,6 @@ import (
 	"sync"
 	"time"
 
-	dashscopego "github.com/casibase/dashscope-go-sdk"
-
 	"github.com/casibase/dashscope-go-sdk/paraformer"
 	"github.com/the-open-agent/openagent/i18n"
 )
@@ -116,7 +114,6 @@ func (p *AlibabacloudSpeechToTextProvider) ProcessAudio(audioReader io.Reader, c
 	if p.subType != "" {
 		model = p.subType
 	}
-	client := dashscopego.NewTongyiClient(model, p.secretKey)
 
 	var (
 		completedSegments []*SpeechSegment
@@ -296,6 +293,7 @@ func (p *AlibabacloudSpeechToTextProvider) ProcessAudio(audioReader io.Reader, c
 	}
 
 	payload := paraformer.PayloadIn{
+		Model: model,
 		Parameters: paraformer.Parameters{
 			SampleRate: 16000,
 			Format:     audioFormat,
@@ -317,9 +315,12 @@ func (p *AlibabacloudSpeechToTextProvider) ProcessAudio(audioReader io.Reader, c
 	// Create a non-blocking channel to signal when the API call is complete
 	apiCallDone := make(chan error, 1)
 
-	// Start the API call in a goroutine
+	// Start the API call in a goroutine. We talk to paraformer directly
+	// (see runParaformerStreamingASR) instead of the SDK's WsClient,
+	// which has a 1024-byte read limit and silently drops oversize
+	// frames — that caused long sessions to cut off mid-transcript.
 	go func() {
-		apiCallDone <- client.CreateSpeechToTextGeneration(ctx, req, reader)
+		apiCallDone <- runParaformerStreamingASR(ctx, req, p.secretKey, reader)
 	}()
 
 	// Configuration for timeouts

--- a/stt/alibabacloud_ws.go
+++ b/stt/alibabacloud_ws.go
@@ -1,0 +1,265 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stt
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/casibase/dashscope-go-sdk/paraformer"
+	"github.com/gorilla/websocket"
+)
+
+const (
+	// paraformerStreamWSURL is the bidirectional websocket endpoint
+	// shared by paraformer-realtime and fun-asr realtime models.
+	paraformerStreamWSURL = "wss://dashscope.aliyuncs.com/api-ws/v1/inference"
+
+	// paraformerWSReadLimit caps a single incoming text frame. The SDK
+	// (casibase/dashscope-go-sdk) hardcodes this at 1024 *and* silently
+	// drops errReadLimit instead of surfacing it, which made long-form
+	// streaming cut off the moment the cumulative transcript JSON
+	// exceeded ~1 KiB. 1 MiB is plenty for any realistic transcript.
+	paraformerWSReadLimit = 1 << 20
+
+	paraformerWSWriteWait  = 30 * time.Second
+	paraformerWSPongWait   = 30 * time.Second
+	paraformerWSPingPeriod = paraformerWSPongWait * 8 / 10
+)
+
+// finishTaskMsg is the JSON envelope sent to paraformer to signal that
+// the client is done streaming audio. Defined separately from
+// paraformer.PayloadIn so the marshaled body contains only the fields
+// the action expects (the upstream rejects unexpected payload fields
+// like model/task on finish-task).
+type finishTaskMsg struct {
+	Header  paraformer.ReqHeader     `json:"header"`
+	Payload finishTaskPayloadWrapper `json:"payload"`
+}
+
+type finishTaskPayloadWrapper struct {
+	Input map[string]interface{} `json:"input"`
+}
+
+// sendFinishTask tells paraformer the current task is over so it can
+// emit the final task-finished event and close the connection. Errors
+// here are best-effort — if the write fails, the conn is already broken
+// and the outer defer will clean up.
+func sendFinishTask(conn *websocket.Conn, taskID string) {
+	msg := finishTaskMsg{
+		Header: paraformer.ReqHeader{
+			Streaming: "duplex",
+			TaskID:    taskID,
+			Action:    "finish-task",
+		},
+		Payload: finishTaskPayloadWrapper{
+			Input: map[string]interface{}{},
+		},
+	}
+	buf, err := json.Marshal(msg)
+	if err != nil {
+		return
+	}
+	_ = conn.SetWriteDeadline(time.Now().Add(paraformerWSWriteWait))
+	_ = conn.WriteMessage(websocket.TextMessage, buf)
+}
+
+// runParaformerStreamingASR is a drop-in replacement for the SDK's
+// (q *TongyiClient).CreateSpeechToTextGeneration. It opens a websocket
+// directly to paraformer, sends the run-task request, forwards binary
+// PCM frames from `reader` upstream, and routes each upstream text
+// frame into request.StreamingFn. Returns when the pipe drains, the
+// reader sees a transport close, or the context is canceled.
+func runParaformerStreamingASR(ctx context.Context, request *paraformer.Request, token string, reader *bufio.Reader) error {
+	header := http.Header{}
+	header.Add("Authorization", token)
+
+	conn, resp, err := websocket.DefaultDialer.DialContext(ctx, paraformerStreamWSURL, header)
+	if err != nil {
+		return fmt.Errorf("paraformer ws dial: %w", err)
+	}
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
+	defer conn.Close()
+
+	conn.SetReadLimit(paraformerWSReadLimit)
+	if err := conn.SetReadDeadline(time.Now().Add(paraformerWSPongWait)); err != nil {
+		return err
+	}
+	conn.SetPongHandler(func(string) error {
+		return conn.SetReadDeadline(time.Now().Add(paraformerWSPongWait))
+	})
+
+	// The run-task message must precede any audio frames so upstream
+	// knows which task to associate them with. Done synchronously here
+	// before any writer goroutine starts, so there's no contention.
+	reqJSON, err := json.Marshal(request)
+	if err != nil {
+		return fmt.Errorf("paraformer marshal request: %w", err)
+	}
+	if err := conn.SetWriteDeadline(time.Now().Add(paraformerWSWriteWait)); err != nil {
+		return err
+	}
+	if err := conn.WriteMessage(websocket.TextMessage, reqJSON); err != nil {
+		return fmt.Errorf("paraformer send run-task: %w", err)
+	}
+
+	sessCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var (
+		firstErrMu sync.Mutex
+		firstErr   error
+	)
+	setErr := func(e error) {
+		if e == nil {
+			return
+		}
+		firstErrMu.Lock()
+		if firstErr == nil {
+			firstErr = e
+		}
+		firstErrMu.Unlock()
+		cancel()
+	}
+
+	// pcmCh decouples the blocking pipe read from the writer goroutine
+	// so the writer can multiplex audio frames with keepalive pings via
+	// a single select.
+	pcmCh := make(chan []byte, 16)
+
+	var wg sync.WaitGroup
+
+	// Upstream -> callback. gorilla/websocket allows only one concurrent
+	// reader, so this goroutine owns ReadMessage exclusively.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer cancel()
+		for {
+			msgType, data, rerr := conn.ReadMessage()
+			if rerr != nil {
+				if !errors.Is(rerr, context.Canceled) &&
+					!websocket.IsCloseError(rerr,
+						websocket.CloseNormalClosure,
+						websocket.CloseGoingAway) {
+					setErr(rerr)
+				}
+				return
+			}
+			// Any incoming frame means the session is healthy — extend
+			// the read deadline so long recognitions don't trip the
+			// idle timeout between pong cycles.
+			_ = conn.SetReadDeadline(time.Now().Add(paraformerWSPongWait))
+			if msgType != websocket.TextMessage {
+				continue
+			}
+			if request.StreamingFn != nil {
+				if cbErr := request.StreamingFn(sessCtx, data); cbErr != nil {
+					setErr(cbErr)
+					return
+				}
+			}
+		}
+	}()
+
+	// PCM pipe -> pcmCh. The pipe.Read here is the blocking call; pushing
+	// onto the buffered channel lets the writer goroutine continue to
+	// service its ping ticker without waiting on the pipe.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer close(pcmCh)
+		for {
+			buf := make([]byte, 1024)
+			n, rerr := reader.Read(buf)
+			if n > 0 {
+				select {
+				case pcmCh <- buf[:n]:
+				case <-sessCtx.Done():
+					return
+				}
+			}
+			if rerr != nil {
+				return
+			}
+		}
+	}()
+
+	// pcmCh + pingTicker -> upstream. Single writer to keep
+	// gorilla/websocket's write-once-at-a-time invariant.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer cancel()
+		pingTicker := time.NewTicker(paraformerWSPingPeriod)
+		defer pingTicker.Stop()
+		for {
+			select {
+			case <-sessCtx.Done():
+				return
+			case chunk, ok := <-pcmCh:
+				if !ok {
+					// Pipe drained (EOS from controller). Tell upstream
+					// we're done, then immediately initiate a close from
+					// our side so the reader doesn't sit blocked on
+					// ReadMessage waiting for an upstream-initiated close
+					// that may never come (which surfaces as an i/o
+					// timeout 30s later). The cost is potentially missing
+					// the task-finished event, but transcripts have
+					// already been streamed live to the frontend during
+					// recording, and ProcessAudio's main loop falls
+					// through to a 5s grace timeout that returns whatever
+					// partial transcript was accumulated.
+					sendFinishTask(conn, request.Header.TaskID)
+					_ = conn.SetWriteDeadline(time.Now().Add(paraformerWSWriteWait))
+					_ = conn.WriteMessage(websocket.CloseMessage,
+						websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+					return
+				}
+				if err := conn.SetWriteDeadline(time.Now().Add(paraformerWSWriteWait)); err != nil {
+					setErr(err)
+					return
+				}
+				if err := conn.WriteMessage(websocket.BinaryMessage, chunk); err != nil {
+					setErr(err)
+					return
+				}
+			case <-pingTicker.C:
+				if err := conn.SetWriteDeadline(time.Now().Add(paraformerWSWriteWait)); err != nil {
+					setErr(err)
+					return
+				}
+				if err := conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+					setErr(err)
+					return
+				}
+			}
+		}
+	}()
+
+	wg.Wait()
+
+	firstErrMu.Lock()
+	defer firstErrMu.Unlock()
+	return firstErr
+}

--- a/web/src/OpenAiCompatibleConfig.js
+++ b/web/src/OpenAiCompatibleConfig.js
@@ -1,0 +1,65 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from "react";
+import {Col, Input, Row, Space} from "antd";
+import i18next from "i18next";
+import * as Setting from "./Setting";
+import CopyButton from "./common/CopyButton";
+import {getOpenAiCompatibleBaseUrl, getOpenAiCompatibleChatCompletionsUrl} from "./OpenAiCompatibleSetting";
+
+function ReadOnlyCopyInput({value}) {
+  return (
+    <Input
+      readOnly
+      value={value}
+      addonAfter={<CopyButton value={value} />}
+    />
+  );
+}
+
+function OpenAiCompatibleConfig({apiKey, apiKeyLabel, apiKeyDisabled = false, onApiKeyChange, hint}) {
+  const baseUrl = getOpenAiCompatibleBaseUrl();
+  const chatCompletionsUrl = getOpenAiCompatibleChatCompletionsUrl();
+
+  return (
+    <div style={{marginTop: "20px", paddingTop: "16px", borderTop: "1px solid var(--ant-color-border-secondary)"}}>
+      <Space direction="vertical" size={4} style={{width: "100%"}}>
+        <div style={{fontWeight: 600}}>{i18next.t("general:OpenAI compatible API")}</div>
+        <div style={{color: "var(--ant-color-text-secondary)", fontSize: "13px"}}>{hint}</div>
+      </Space>
+      <Row gutter={16}>
+        <Col style={{marginTop: "12px"}} span={Setting.isMobile() ? 22 : 8}>
+          <div style={{marginBottom: "4px"}}>{apiKeyLabel || i18next.t("general:API key")}</div>
+          <Input.Password
+            value={apiKey}
+            disabled={apiKeyDisabled}
+            addonAfter={<CopyButton value={apiKey} disabled={apiKeyDisabled} />}
+            onChange={onApiKeyChange}
+          />
+        </Col>
+        <Col style={{marginTop: "12px"}} span={Setting.isMobile() ? 22 : 8}>
+          <div style={{marginBottom: "4px"}}>{i18next.t("general:Base URL")}</div>
+          <ReadOnlyCopyInput value={baseUrl} />
+        </Col>
+        <Col style={{marginTop: "12px"}} span={Setting.isMobile() ? 22 : 8}>
+          <div style={{marginBottom: "4px"}}>{i18next.t("general:Chat completions endpoint")}</div>
+          <ReadOnlyCopyInput value={chatCompletionsUrl} />
+        </Col>
+      </Row>
+    </div>
+  );
+}
+
+export default OpenAiCompatibleConfig;

--- a/web/src/OpenAiCompatibleSetting.js
+++ b/web/src/OpenAiCompatibleSetting.js
@@ -1,0 +1,21 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export function getOpenAiCompatibleBaseUrl() {
+  return `${window.location.origin}/api`;
+}
+
+export function getOpenAiCompatibleChatCompletionsUrl() {
+  return `${getOpenAiCompatibleBaseUrl()}/chat/completions`;
+}

--- a/web/src/ProviderEditPage.js
+++ b/web/src/ProviderEditPage.js
@@ -25,6 +25,7 @@ import ModelTestWidget from "./common/TestModelWidget";
 import TtsTestWidget from "./common/TestTtsWidget";
 import EmbedTestWidget from "./common/TestEmbedWidget";
 import TestMcpWidget from "./common/TestMcpWidget";
+import OpenAiCompatibleConfig from "./OpenAiCompatibleConfig";
 
 const {Option} = Select;
 const {TextArea} = Input;
@@ -1053,20 +1054,15 @@ class ProviderEditPage extends React.Component {
           </Row>
           {
             this.state.provider.category === "Model" ? (
-              <Row style={{marginTop: "20px"}} >
-                <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                  {this.getProviderKeyLabel(this.state.provider)}
-                </Col>
-                <Col span={22} >
-                  <Input.Password
-                    value={this.state.provider.providerKey}
-                    disabled={!Setting.isAdminUser(this.props.account)}
-                    onChange={e => {
-                      this.updateProviderField("providerKey", e.target.value);
-                    }}
-                  />
-                </Col>
-              </Row>
+              <OpenAiCompatibleConfig
+                apiKey={this.state.provider.providerKey}
+                apiKeyLabel={this.getProviderKeyLabel(this.state.provider)}
+                apiKeyDisabled={!Setting.isAdminUser(this.props.account)}
+                onApiKeyChange={e => {
+                  this.updateProviderField("providerKey", e.target.value);
+                }}
+                hint={i18next.t("general:Provider API integration hint")}
+              />
             ) : null
           }
         </Card>

--- a/web/src/StoreEditPage.js
+++ b/web/src/StoreEditPage.js
@@ -28,6 +28,7 @@ import i18next from "i18next";
 import FileTree from "./FileTree";
 import ExampleQuestionTable from "./table/ExampleQuestionTable";
 import StoreAvatarUploader from "./AvatarUpload";
+import OpenAiCompatibleConfig from "./OpenAiCompatibleConfig";
 
 const {Option} = Select;
 const {TextArea} = Input;
@@ -537,14 +538,15 @@ class StoreEditPage extends React.Component {
               }} />,
               24
             )}
-            {this.renderStoreField(
-              Setting.getLabel(i18next.t("general:API key"), i18next.t("general:API key - Tooltip")),
-              <Input.Password value={store.apiKey} onChange={e => {
-                this.updateStoreField("apiKey", e.target.value);
-              }} />,
-              24
-            )}
           </Row>
+          <OpenAiCompatibleConfig
+            apiKey={store.apiKey}
+            apiKeyLabel={Setting.getLabel(i18next.t("general:API key"), i18next.t("general:API key - Tooltip"))}
+            onApiKeyChange={e => {
+              this.updateStoreField("apiKey", e.target.value);
+            }}
+            hint={i18next.t("general:Store API integration hint")}
+          />
         </Card>
 
         <Card size="small" title={renderCardTitle(i18next.t("general:Providers"), i18next.t("general:Providers desc"))} style={sectionCardStyle} headStyle={cardHeadStyle}>

--- a/web/src/common/CopyButton.js
+++ b/web/src/common/CopyButton.js
@@ -1,0 +1,39 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from "react";
+import {Button, Tooltip} from "antd";
+import {CopyOutlined} from "@ant-design/icons";
+import copy from "copy-to-clipboard";
+import i18next from "i18next";
+import * as Setting from "../Setting";
+
+function CopyButton({value, disabled = false}) {
+  const isDisabled = disabled || !value || value === "***";
+
+  return (
+    <Tooltip title={i18next.t("general:Copy")}>
+      <Button
+        disabled={isDisabled}
+        icon={<CopyOutlined />}
+        onClick={() => {
+          copy(value);
+          Setting.showMessage("success", i18next.t("general:Successfully copied"));
+        }}
+      />
+    </Tooltip>
+  );
+}
+
+export default CopyButton;


### PR DESCRIPTION
## Summary

The `dashscope-go-sdk`'s `WsClient` hardcodes a 1024-byte `ReadLimit` on the websocket connection to paraformer **and** silently drops `errReadLimit` in its `readPump` (the error is not a `websocket.CloseError`, so it falls through the `IsUnexpectedCloseError` check and never reaches `errChan`). As soon as the cumulative transcript JSON exceeds ~1 KiB the upstream events stop being delivered, the SDK's reader goroutine exits without surfacing the error, and the recognition session appears to hang mid-transcript. In practice this caps a single continuous recording at roughly 10 seconds of Chinese speech or 20 characters of transcript.

Replaces the SDK's `CreateSpeechToTextGeneration` with a direct `gorilla/websocket` implementation (`stt/alibabacloud_ws.go`) that:
- sets the read limit to 1 MiB
- propagates transport errors instead of swallowing them
- sends a `finish-task` message when the audio pipe drains so upstream can finalize cleanly
- initiates the websocket close from our side after `finish-task` so the reader doesn't block waiting for an upstream-initiated close that may never come

The existing `streamCallbackFn`, segment accumulation, pricing, and control loop in `ProcessAudio` are unchanged — only the transport layer is swapped.

## Stacked on
- #2383 (fix: match paraformer's actual completion event names) — required for `finish-task` to actually terminate the session via the correct response event

## Test plan
- [ ] Record continuous Chinese speech for >30 seconds, verify transcript keeps growing past the 20-char mark
- [ ] Stop recording manually, confirm session ends within ~1s (no `i/o timeout` error in server log)
- [ ] Verify provider price calculation still reflects the actual audio duration

🤖 Generated with [Claude Code](https://claude.com/claude-code)