### PR TITLE
feat: resume speech-to-text by appending instead of overwriting existing text

### DIFF
--- a/controllers/openai_api.go
+++ b/controllers/openai_api.go
@@ -98,7 +98,29 @@ func (c *ApiController) chatCompletionsViaStore(store *object.Store, request ope
 	}
 
 	writer := newOpenAIWriter(c.Ctx.ResponseWriter, request, requestId)
-	modelResult, err := modelProviderObj.QueryText(question, writer, history, prompt, []*model.RawMessage{}, nil, lang)
+
+	mcpToolSet, err := object.GetServerMcpToolSet(store.Owner, store.McpServer, lang)
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+	origin := getOriginFromHost(c.Ctx.Request.Host)
+	mcpToolSet = object.MergeMcpTools(mcpToolSet, store, false, "api", origin, lang)
+
+	var modelResult *model.ModelResult
+	if mcpToolSet != nil && (len(mcpToolSet.Tools) > 0 || mcpToolSet.WebSearchEnabled) {
+		toolSession := &model.ToolSession{
+			McpToolSet: mcpToolSet,
+			ToolMessages: &model.ToolMessages{
+				Messages:  []*model.RawMessage{},
+				ToolCalls: nil,
+			},
+			IsVision: model.IsVisionModel(modelProviderRecord.SubType),
+		}
+		modelResult, err = model.QueryTextWithTools(modelProviderObj, question, writer, history, prompt, []*model.RawMessage{}, toolSession, lang)
+	} else {
+		modelResult, err = modelProviderObj.QueryText(question, writer, history, prompt, []*model.RawMessage{}, nil, lang)
+	}
 	if err != nil {
 		c.ResponseError(err.Error())
 		return

--- a/controllers/openai_api_util.go
+++ b/controllers/openai_api_util.go
@@ -118,6 +118,7 @@ func createApiChatSession(store *object.Store, modelProviderName, question, requ
 // applyResultToApiSession writes the AI answer and token counts back to the DB.
 func applyResultToApiSession(aiMsg *object.Message, chat *object.Chat, writer *OpenAIWriter, modelResult *model.ModelResult) error {
 	aiMsg.Text = writer.MessageString()
+	aiMsg.ToolCalls = model.GetToolCallsFromWriter(writer.ToolString())
 	aiMsg.TokenCount = modelResult.TotalTokenCount
 	aiMsg.Price = modelResult.TotalPrice
 	aiMsg.Currency = modelResult.Currency

--- a/controllers/openai_writer.go
+++ b/controllers/openai_writer.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net/http"
 
 	"github.com/beego/beego/context"
 	"github.com/sashabaranov/go-openai"
@@ -30,29 +31,55 @@ type OpenAIWriter struct {
 	Cleaner    Cleaner
 	Buffer     []byte
 	MessageBuf []byte
+	ToolBuf    []byte
 	RequestID  string
 	Stream     bool
 	StreamSent bool
 	Model      string
 }
 
+func getOpenAIEventData(p []byte, eventType string) string {
+	prefix := []byte(fmt.Sprintf("event: %s\ndata: ", eventType))
+	suffix := []byte("\n\n")
+	return string(bytes.TrimSuffix(bytes.TrimPrefix(p, prefix), suffix))
+}
+
 // Write processes incoming data chunks and formats them for OpenAI compatibility
 func (w *OpenAIWriter) Write(p []byte) (n int, err error) {
+	if len(p) > 0 && p[0] == ':' {
+		if !w.Stream {
+			return len(p), nil
+		}
+		n, err = w.ResponseWriter.Write(p)
+		if flusher, ok := w.ResponseWriter.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		return n, err
+	}
+
+	// Always store the original bytes.
+	w.Buffer = append(w.Buffer, p...)
+
 	// Parse the incoming SSE message format
 	var content string
 
 	if bytes.HasPrefix(p, []byte("event: message\ndata: ")) {
-		prefix := []byte("event: message\ndata: ")
-		suffix := []byte("\n\n")
-		content = string(bytes.TrimSuffix(bytes.TrimPrefix(p, prefix), suffix))
+		content = getOpenAIEventData(p, "message")
 
 		// Add content to message buffer
 		w.MessageBuf = append(w.MessageBuf, []byte(content)...)
 	} else if bytes.HasPrefix(p, []byte("event: reason\ndata: ")) {
-		// We don't expose reason data in OpenAI format, but we'll store it
-		prefix := []byte("event: reason\ndata: ")
-		suffix := []byte("\n\n")
-		content = string(bytes.TrimSuffix(bytes.TrimPrefix(p, prefix), suffix))
+		return len(p), nil
+	} else if bytes.HasPrefix(p, []byte("event: tool-delta\ndata: ")) || bytes.HasPrefix(p, []byte("event: tool-start\ndata: ")) {
+		return len(p), nil
+	} else if bytes.HasPrefix(p, []byte("event: tool\ndata: ")) {
+		if len(w.ToolBuf) > 0 {
+			w.ToolBuf = append(w.ToolBuf, '\n')
+		}
+		w.ToolBuf = append(w.ToolBuf, []byte(getOpenAIEventData(p, "tool"))...)
+		return len(p), nil
+	} else if bytes.HasPrefix(p, []byte("event: search\ndata: ")) {
+		return len(p), nil
 	} else {
 		// If we can't parse, just store the raw bytes and attempt to clean
 		content = w.Cleaner.CleanString(string(p))
@@ -60,9 +87,6 @@ func (w *OpenAIWriter) Write(p []byte) (n int, err error) {
 			w.MessageBuf = append(w.MessageBuf, []byte(content)...)
 		}
 	}
-
-	// Always store the original bytes
-	w.Buffer = append(w.Buffer, p...)
 
 	// For non-streaming, just collect the data
 	if !w.Stream {
@@ -113,6 +137,10 @@ func (w *OpenAIWriter) MessageString() string {
 	return string(w.MessageBuf)
 }
 
+func (w *OpenAIWriter) ToolString() string {
+	return string(w.ToolBuf)
+}
+
 // Close finalizes the stream by sending completion message and DONE marker
 func (w *OpenAIWriter) Close(promptTokens, completionTokens, totalTokens int) error {
 	if !w.Stream {
@@ -145,16 +173,21 @@ func (w *OpenAIWriter) Close(promptTokens, completionTokens, totalTokens int) er
 			return err
 		}
 
-		// Send usage information as a custom message
-		usage := map[string]interface{}{
-			"usage": openai.Usage{
+		// Send usage information as an OpenAI-compatible stream chunk.
+		usageChunk := openai.ChatCompletionStreamResponse{
+			ID:      "chatcmpl-" + w.RequestID,
+			Object:  "chat.completion.chunk",
+			Created: util.GetCurrentUnixTime(),
+			Model:   w.Model,
+			Choices: []openai.ChatCompletionStreamChoice{},
+			Usage: &openai.Usage{
 				PromptTokens:     promptTokens,
 				CompletionTokens: completionTokens,
 				TotalTokens:      totalTokens,
 			},
 		}
 
-		usageData, err := json.Marshal(usage)
+		usageData, err := json.Marshal(usageChunk)
 		if err != nil {
 			return err
 		}

--- a/controllers/store.go
+++ b/controllers/store.go
@@ -37,7 +37,7 @@ func (c *ApiController) GetHubStores() {
 		c.ResponseError(err.Error())
 		return
 	}
-	c.ResponseOk(stores)
+	c.ResponseOk(object.GetMaskedStores(stores, c.GetSessionUser()))
 }
 
 // GetGlobalStores
@@ -62,7 +62,7 @@ func (c *ApiController) GetGlobalStores() {
 			return
 		}
 
-		c.ResponseOk(stores)
+		c.ResponseOk(object.GetMaskedStores(stores, c.GetSessionUser()))
 	} else {
 		if !c.RequireAdmin() {
 			return
@@ -112,7 +112,7 @@ func (c *ApiController) GetGlobalStores() {
 			object.SortStoresInMemory(stores, sortField, sortOrder)
 		}
 
-		c.ResponseOk(stores, count)
+		c.ResponseOk(object.GetMaskedStores(stores, c.GetSessionUser()), count)
 	}
 }
 
@@ -138,7 +138,7 @@ func (c *ApiController) GetStores() {
 		return
 	}
 
-	c.ResponseOk(object.GetMaskedStores(stores))
+	c.ResponseOk(object.GetMaskedStores(stores, c.GetSessionUser()))
 }
 
 // GetStore
@@ -168,12 +168,12 @@ func (c *ApiController) GetStore() {
 		origin := getOriginFromHost(host)
 		err = store.Populate(origin, c.GetAcceptLanguage())
 		if err != nil {
-			c.ResponseOk(object.GetMaskedStore(store), err.Error())
+			c.ResponseOk(object.GetMaskedStore(store, c.GetSessionUser()), err.Error())
 			return
 		}
 	}
 
-	c.ResponseOk(object.GetMaskedStore(store))
+	c.ResponseOk(object.GetMaskedStore(store, c.GetSessionUser()))
 }
 
 // UpdateStore
@@ -386,7 +386,7 @@ func (c *ApiController) ClaimStore() {
 		return
 	}
 
-	c.ResponseOk(store)
+	c.ResponseOk(object.GetMaskedStore(store, c.GetSessionUser()))
 }
 
 // RefreshStoreVectors
@@ -497,5 +497,5 @@ func (c *ApiController) AddSharedStore() {
 		return
 	}
 
-	c.ResponseOk(newStore)
+	c.ResponseOk(object.GetMaskedStore(newStore, c.GetSessionUser()))
 }

--- a/object/store.go
+++ b/object/store.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/the-open-agent/openagent/auth"
 	"github.com/the-open-agent/openagent/conf"
 	"github.com/the-open-agent/openagent/i18n"
 	"github.com/the-open-agent/openagent/storage"
@@ -159,21 +160,21 @@ func generateStoreApiKey() string {
 	return fmt.Sprintf("sk-%s", util.GetRandomString(24))
 }
 
-func GetMaskedStore(store *Store) *Store {
+func GetMaskedStore(store *Store, user *auth.User) *Store {
 	if store == nil {
 		return nil
 	}
 
-	if store.ApiKey != "" {
+	if store.ApiKey != "" && !util.IsGlobalAdmin(user) && (user == nil || user.Name != store.Owner) {
 		store.ApiKey = "***"
 	}
 
 	return store
 }
 
-func GetMaskedStores(stores []*Store) []*Store {
+func GetMaskedStores(stores []*Store, user *auth.User) []*Store {
 	for _, store := range stores {
-		store = GetMaskedStore(store)
+		GetMaskedStore(store, user)
 	}
 	return stores
 }

--- a/web/src/ChatBox.js
+++ b/web/src/ChatBox.js
@@ -276,17 +276,14 @@ class ChatBox extends React.Component {
       // End-to-end streaming via websocket. processVoiceResult handles
       // each transcript event the same way the browser-builtin path does;
       // the onEnd callback resets the mic button when the server-side
-      // session ends (final result, paraformer completed, or error) and
-      // auto-sends the accumulated text, matching the old batch behavior.
+      // session ends (final result, paraformer completed, or error). The
+      // transcript stays in the input box so the user can review/edit
+      // it before deciding to send.
       this.sttHelper.startStreaming(
         this.props.store,
         this.processVoiceResult(),
         () => {
-          this.setState({isVoiceInput: false}, () => {
-            if (this.state.value && this.state.value.trim() !== "") {
-              this.handleSend();
-            }
-          });
+          this.setState({isVoiceInput: false});
         }
       ).catch(error => {
         Setting.showMessage("error", `${i18next.t("general:Failed to start recording")}: ${error.message}`);
@@ -320,13 +317,6 @@ class ChatBox extends React.Component {
       this.sttHelper.stopStreaming();
     } else {
       this.sttHelper.stopRecognition();
-
-      setTimeout(() => {
-        // Send the message after speech recognition is complete
-        if (this.state.value && this.state.value.trim() !== "") {
-          this.handleSend();
-        }
-      }, 300);
     }
 
     this.setState({isVoiceInput: false});

--- a/web/src/ChatBox.js
+++ b/web/src/ChatBox.js
@@ -118,6 +118,28 @@ class ChatBox extends React.Component {
     this.cursorPosition = undefined;
   }
 
+  focusInputAtEnd = () => {
+    const value = this.state.value || "";
+    this.cursorPosition = value.length;
+    setTimeout(() => {
+      const el = document.querySelector(".cs-message-input__content-editor");
+      if (!el) {
+        return;
+      }
+      el.focus();
+      try {
+        const range = document.createRange();
+        range.selectNodeContents(el);
+        range.collapse(false);
+        const sel = window.getSelection();
+        sel.removeAllRanges();
+        sel.addRange(range);
+      } catch (_e) {
+        // ignore — focus alone is still useful
+      }
+    }, 0);
+  };
+
   addCursorPositionListener() {
     const inputElement = document.querySelector(".cs-message-input__content-editor");
     const updateCursorPosition = () => {
@@ -283,7 +305,9 @@ class ChatBox extends React.Component {
         this.props.store,
         this.processVoiceResult(),
         () => {
-          this.setState({isVoiceInput: false});
+          this.setState({isVoiceInput: false}, () => {
+            this.focusInputAtEnd();
+          });
         }
       ).catch(error => {
         Setting.showMessage("error", `${i18next.t("general:Failed to start recording")}: ${error.message}`);
@@ -295,7 +319,11 @@ class ChatBox extends React.Component {
       // tab switch, mobile Safari time cap) so the mic button can reset.
       const recognition = this.sttHelper.initBrowserRecognition(
         this.processVoiceResult(),
-        () => this.setState({isVoiceInput: false})
+        () => {
+          this.setState({isVoiceInput: false}, () => {
+            this.focusInputAtEnd();
+          });
+        }
       );
 
       if (!recognition) {
@@ -313,10 +341,14 @@ class ChatBox extends React.Component {
     if (useCloudProvider) {
       // Send the end-of-stream marker; the streaming provider's onEnd
       // callback (registered in startVoiceInput) will flip isVoiceInput
-      // off once the server has finalized the transcript.
+      // off and focus the input once the server has finalized the transcript.
       this.sttHelper.stopStreaming();
     } else {
       this.sttHelper.stopRecognition();
+      this.setState({isVoiceInput: false}, () => {
+        this.focusInputAtEnd();
+      });
+      return;
     }
 
     this.setState({isVoiceInput: false});

--- a/web/src/ChatBox.js
+++ b/web/src/ChatBox.js
@@ -45,6 +45,8 @@ class ChatBox extends React.Component {
     };
     this.synth = window.speechSynthesis;
     this.cursorPosition = undefined;
+    this.voiceInputBaseValue = "";
+    this.voiceInputBasePos = 0;
     this.copyFileName = null;
     this.messageListRef = React.createRef();
     this.inputRef = React.createRef();
@@ -116,6 +118,8 @@ class ChatBox extends React.Component {
       isVoiceInput: false,
     });
     this.cursorPosition = undefined;
+    this.voiceInputBaseValue = "";
+    this.voiceInputBasePos = 0;
   }
 
   focusInputAtEnd = () => {
@@ -288,6 +292,14 @@ class ChatBox extends React.Component {
 
   // Updated startVoiceInput method for ChatBox component
   startVoiceInput = () => {
+    // Snapshot the current input value and insert position so cumulative
+    // transcript events during this session insert at a stable spot. On a
+    // second mic click after a previous session, this makes new transcripts
+    // append after the existing text instead of overwriting it.
+    const base = this.state.value || "";
+    this.voiceInputBaseValue = base;
+    this.voiceInputBasePos = this.cursorPosition !== undefined ? this.cursorPosition : base.length;
+
     this.setState({isVoiceInput: true});
 
     // Check if using browser builtin or cloud provider
@@ -363,22 +375,20 @@ class ChatBox extends React.Component {
         return; // Skip empty transcripts
       }
 
-      // Update the input field with the transcript
-      if (this.cursorPosition === undefined) {
-        this.setState({value: transcript}, () => {
-          if (shouldSendAfterProcessing && this.state.value && this.state.value.trim() !== "") {
-            this.handleSend();
-          }
-        });
-      } else {
-        const oldValue = this.state.value || "";
-        const newValue = oldValue.slice(0, this.cursorPosition) + transcript + oldValue.slice(this.cursorPosition);
-        this.setState({value: newValue}, () => {
-          if (shouldSendAfterProcessing && this.state.value && this.state.value.trim() !== "") {
-            this.handleSend();
-          }
-        });
-      }
+      // Cumulative transcripts arrive during a single session, so always
+      // rebuild from the per-session baseline captured in startVoiceInput.
+      // This keeps any text the user had typed (or any transcript from a
+      // previous session) untouched while replacing only the portion this
+      // session is producing.
+      const base = this.voiceInputBaseValue ?? "";
+      const pos = this.voiceInputBasePos ?? base.length;
+      const newValue = base.slice(0, pos) + transcript + base.slice(pos);
+
+      this.setState({value: newValue}, () => {
+        if (shouldSendAfterProcessing && this.state.value && this.state.value.trim() !== "") {
+          this.handleSend();
+        }
+      });
     };
   };
 

--- a/web/src/OpenAiCompatibleConfig.js
+++ b/web/src/OpenAiCompatibleConfig.js
@@ -1,0 +1,65 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from "react";
+import {Col, Input, Row, Space} from "antd";
+import i18next from "i18next";
+import * as Setting from "./Setting";
+import CopyButton from "./common/CopyButton";
+import {getOpenAiCompatibleBaseUrl, getOpenAiCompatibleChatCompletionsUrl} from "./OpenAiCompatibleSetting";
+
+function ReadOnlyCopyInput({value}) {
+  return (
+    <Input
+      readOnly
+      value={value}
+      addonAfter={<CopyButton value={value} />}
+    />
+  );
+}
+
+function OpenAiCompatibleConfig({apiKey, apiKeyLabel, apiKeyDisabled = false, onApiKeyChange, hint}) {
+  const baseUrl = getOpenAiCompatibleBaseUrl();
+  const chatCompletionsUrl = getOpenAiCompatibleChatCompletionsUrl();
+
+  return (
+    <div style={{marginTop: "20px", paddingTop: "16px", borderTop: "1px solid var(--ant-color-border-secondary)"}}>
+      <Space direction="vertical" size={4} style={{width: "100%"}}>
+        <div style={{fontWeight: 600}}>{i18next.t("general:OpenAI compatible API")}</div>
+        <div style={{color: "var(--ant-color-text-secondary)", fontSize: "13px"}}>{hint}</div>
+      </Space>
+      <Row gutter={16}>
+        <Col style={{marginTop: "12px"}} span={Setting.isMobile() ? 22 : 8}>
+          <div style={{marginBottom: "4px"}}>{apiKeyLabel || i18next.t("general:API key")}</div>
+          <Input.Password
+            value={apiKey}
+            disabled={apiKeyDisabled}
+            addonAfter={<CopyButton value={apiKey} disabled={apiKeyDisabled} />}
+            onChange={onApiKeyChange}
+          />
+        </Col>
+        <Col style={{marginTop: "12px"}} span={Setting.isMobile() ? 22 : 8}>
+          <div style={{marginBottom: "4px"}}>{i18next.t("general:Base URL")}</div>
+          <ReadOnlyCopyInput value={baseUrl} />
+        </Col>
+        <Col style={{marginTop: "12px"}} span={Setting.isMobile() ? 22 : 8}>
+          <div style={{marginBottom: "4px"}}>{i18next.t("general:Chat completions endpoint")}</div>
+          <ReadOnlyCopyInput value={chatCompletionsUrl} />
+        </Col>
+      </Row>
+    </div>
+  );
+}
+
+export default OpenAiCompatibleConfig;

--- a/web/src/OpenAiCompatibleSetting.js
+++ b/web/src/OpenAiCompatibleSetting.js
@@ -1,0 +1,21 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export function getOpenAiCompatibleBaseUrl() {
+  return `${window.location.origin}/api`;
+}
+
+export function getOpenAiCompatibleChatCompletionsUrl() {
+  return `${getOpenAiCompatibleBaseUrl()}/chat/completions`;
+}

--- a/web/src/ProviderEditPage.js
+++ b/web/src/ProviderEditPage.js
@@ -25,6 +25,7 @@ import ModelTestWidget from "./common/TestModelWidget";
 import TtsTestWidget from "./common/TestTtsWidget";
 import EmbedTestWidget from "./common/TestEmbedWidget";
 import TestMcpWidget from "./common/TestMcpWidget";
+import OpenAiCompatibleConfig from "./OpenAiCompatibleConfig";
 
 const {Option} = Select;
 const {TextArea} = Input;
@@ -1053,20 +1054,15 @@ class ProviderEditPage extends React.Component {
           </Row>
           {
             this.state.provider.category === "Model" ? (
-              <Row style={{marginTop: "20px"}} >
-                <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>
-                  {this.getProviderKeyLabel(this.state.provider)}
-                </Col>
-                <Col span={22} >
-                  <Input.Password
-                    value={this.state.provider.providerKey}
-                    disabled={!Setting.isAdminUser(this.props.account)}
-                    onChange={e => {
-                      this.updateProviderField("providerKey", e.target.value);
-                    }}
-                  />
-                </Col>
-              </Row>
+              <OpenAiCompatibleConfig
+                apiKey={this.state.provider.providerKey}
+                apiKeyLabel={this.getProviderKeyLabel(this.state.provider)}
+                apiKeyDisabled={!Setting.isAdminUser(this.props.account)}
+                onApiKeyChange={e => {
+                  this.updateProviderField("providerKey", e.target.value);
+                }}
+                hint={i18next.t("general:Provider API integration hint")}
+              />
             ) : null
           }
         </Card>

--- a/web/src/StoreEditPage.js
+++ b/web/src/StoreEditPage.js
@@ -28,6 +28,7 @@ import i18next from "i18next";
 import FileTree from "./FileTree";
 import ExampleQuestionTable from "./table/ExampleQuestionTable";
 import StoreAvatarUploader from "./AvatarUpload";
+import OpenAiCompatibleConfig from "./OpenAiCompatibleConfig";
 
 const {Option} = Select;
 const {TextArea} = Input;
@@ -537,14 +538,15 @@ class StoreEditPage extends React.Component {
               }} />,
               24
             )}
-            {this.renderStoreField(
-              Setting.getLabel(i18next.t("general:API key"), i18next.t("general:API key - Tooltip")),
-              <Input.Password value={store.apiKey} onChange={e => {
-                this.updateStoreField("apiKey", e.target.value);
-              }} />,
-              24
-            )}
           </Row>
+          <OpenAiCompatibleConfig
+            apiKey={store.apiKey}
+            apiKeyLabel={Setting.getLabel(i18next.t("general:API key"), i18next.t("general:API key - Tooltip"))}
+            onApiKeyChange={e => {
+              this.updateStoreField("apiKey", e.target.value);
+            }}
+            hint={i18next.t("general:Store API integration hint")}
+          />
         </Card>
 
         <Card size="small" title={renderCardTitle(i18next.t("general:Providers"), i18next.t("general:Providers desc"))} style={sectionCardStyle} headStyle={cardHeadStyle}>

--- a/web/src/common/CopyButton.js
+++ b/web/src/common/CopyButton.js
@@ -1,0 +1,39 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from "react";
+import {Button, Tooltip} from "antd";
+import {CopyOutlined} from "@ant-design/icons";
+import copy from "copy-to-clipboard";
+import i18next from "i18next";
+import * as Setting from "../Setting";
+
+function CopyButton({value, disabled = false}) {
+  const isDisabled = disabled || !value || value === "***";
+
+  return (
+    <Tooltip title={i18next.t("general:Copy")}>
+      <Button
+        disabled={isDisabled}
+        icon={<CopyOutlined />}
+        onClick={() => {
+          copy(value);
+          Setting.showMessage("success", i18next.t("general:Successfully copied"));
+        }}
+      />
+    </Tooltip>
+  );
+}
+
+export default CopyButton;


### PR DESCRIPTION
## Summary

After a recording session ends, the transcript stays in the input box. Previously, clicking the mic a second time would **overwrite** that text with whatever the new session transcribed, because `processVoiceResult` either replaced the entire value (when `cursorPosition` was undefined) or inserted at a stale cursor position. Users that wanted to dictate in pieces had no easy way to continue from where they left off.

Snapshots the current input value and an insert position at `startVoiceInput`, then has `processVoiceResult` rebuild the field from that baseline on every cumulative transcript event. A second click on the mic now appends new transcripts after the existing text (or inserts at the user's cursor if they had clicked into the middle of the value), letting users build up a long message in multiple recordings.

## Stacked on
- #2387 (feat: focus chat input and move caret to end after STT ends)

## Test plan
- [ ] Record a STT utterance, stop, click mic again, speak more — verify new transcript appends after first one
- [ ] Click into the middle of an existing message, click mic, speak — verify new transcript inserts at clicked position (not at end)
- [ ] Empty input + first mic click: verify normal single-utterance behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)