### PR TITLE
feat: support the v1 OpenAI-compatible chat completions endpoint

### DIFF
--- a/controllers/openai_api.go
+++ b/controllers/openai_api.go
@@ -32,6 +32,7 @@ import (
 // @Param   body    body    openai.ChatCompletionRequest  true    "The OpenAI chat request"
 // @Success 200 {object} openai.ChatCompletionResponse
 // @router /api/chat/completions [post]
+// @router /api/v1/chat/completions [post]
 func (c *ApiController) ChatCompletions() {
 	auth := c.Ctx.Request.Header.Get("Authorization")
 	if !strings.HasPrefix(auth, "Bearer ") {

--- a/routers/authz_filter.go
+++ b/routers/authz_filter.go
@@ -59,7 +59,7 @@ func permissionFilter(ctx *context.Context) {
 	controllerName := strings.TrimPrefix(urlPath, "/api/")
 
 	// OpenAI-compatible endpoint uses Bearer token auth
-	if controllerName == "chat/completions" {
+	if controllerName == "chat/completions" || controllerName == "v1/chat/completions" {
 		return
 	}
 

--- a/routers/cors_filter.go
+++ b/routers/cors_filter.go
@@ -38,7 +38,7 @@ const (
 func setCorsHeaders(ctx *context.Context, origin string) {
 	ctx.Output.Header(headerAllowOrigin, origin)
 	ctx.Output.Header(headerAllowMethods, "GET, POST, DELETE, PUT, PATCH, OPTIONS")
-	ctx.Output.Header(headerAllowHeaders, "Origin, X-Requested-With, Content-Type, Accept")
+	ctx.Output.Header(headerAllowHeaders, "Origin, X-Requested-With, Content-Type, Accept, Authorization")
 	ctx.Output.Header(headerExposeHeaders, "Content-Length")
 	ctx.Output.Header(headerAllowCredentials, "true")
 

--- a/routers/router.go
+++ b/routers/router.go
@@ -240,4 +240,5 @@ func initAPI() {
 	beego.Router("/api/metrics", &controllers.ApiController{}, "GET:GetMetrics")
 
 	beego.Router("/api/chat/completions", &controllers.ApiController{}, "POST:ChatCompletions")
+	beego.Router("/api/v1/chat/completions", &controllers.ApiController{}, "POST:ChatCompletions")
 }

--- a/web/src/OpenAiCompatibleConfig.js
+++ b/web/src/OpenAiCompatibleConfig.js
@@ -40,7 +40,7 @@ function OpenAiCompatibleConfig({apiKey, apiKeyDisabled = false, onApiKeyChange}
         <div style={{color: "var(--ant-color-text-secondary)", fontSize: "13px"}}>{i18next.t("general:API integration hint")}</div>
       </Space>
       <Row gutter={48}>
-        <Col style={{marginTop: "12px"}} span={Setting.isMobile() ? 22 : 7}>
+        <Col style={{marginTop: "12px"}} span={Setting.isMobile() ? 22 : 6}>
           <div style={{marginBottom: "4px"}}>{i18next.t("general:External API key")}</div>
           <Space.Compact style={{width: "100%"}}>
             <Input.Password
@@ -51,11 +51,11 @@ function OpenAiCompatibleConfig({apiKey, apiKeyDisabled = false, onApiKeyChange}
             <CopyButton value={apiKey} disabled={apiKeyDisabled} />
           </Space.Compact>
         </Col>
-        <Col style={{marginTop: "12px"}} span={Setting.isMobile() ? 22 : 7}>
+        <Col style={{marginTop: "12px"}} span={Setting.isMobile() ? 22 : 6}>
           <div style={{marginBottom: "4px"}}>{i18next.t("general:Base URL")}</div>
           <ReadOnlyCopyInput value={baseUrl} />
         </Col>
-        <Col style={{marginTop: "12px"}} span={Setting.isMobile() ? 22 : 7}>
+        <Col style={{marginTop: "12px"}} span={Setting.isMobile() ? 22 : 12}>
           <div style={{marginBottom: "4px"}}>{i18next.t("general:Chat completions endpoint")}</div>
           <ReadOnlyCopyInput value={chatCompletionsUrl} />
         </Col>

--- a/web/src/OpenAiCompatibleSetting.js
+++ b/web/src/OpenAiCompatibleSetting.js
@@ -20,5 +20,5 @@ export function getOpenAiCompatibleBaseUrl() {
 }
 
 export function getOpenAiCompatibleChatCompletionsUrl() {
-  return `${getOpenAiCompatibleBaseUrl()}/chat/completions`;
+  return `${getOpenAiCompatibleBaseUrl()}/v1/chat/completions`;
 }


### PR DESCRIPTION
## Summary

- Add `/api/v1/chat/completions` as an alias for the existing OpenAI-compatible endpoint.
- Allow the `Authorization` header in CORS preflight requests.
- Exclude the new endpoint from session-based authorization checks.
- Display the v1 endpoint in Store and Provider configuration pages.
- Increase the endpoint field width so the complete URL remains visible.

## Compatibility

Both endpoint formats remain supported:

- `/api/chat/completions`
- `/api/v1/chat/completions`

They use the same handler and request/response protocol.