### PR TITLE
fix: do not auto-send speech-to-text transcript on recording end

### DIFF
--- a/web/src/ChatBox.js
+++ b/web/src/ChatBox.js
@@ -276,17 +276,14 @@ class ChatBox extends React.Component {
       // End-to-end streaming via websocket. processVoiceResult handles
       // each transcript event the same way the browser-builtin path does;
       // the onEnd callback resets the mic button when the server-side
-      // session ends (final result, paraformer completed, or error) and
-      // auto-sends the accumulated text, matching the old batch behavior.
+      // session ends (final result, paraformer completed, or error). The
+      // transcript stays in the input box so the user can review/edit
+      // it before deciding to send.
       this.sttHelper.startStreaming(
         this.props.store,
         this.processVoiceResult(),
         () => {
-          this.setState({isVoiceInput: false}, () => {
-            if (this.state.value && this.state.value.trim() !== "") {
-              this.handleSend();
-            }
-          });
+          this.setState({isVoiceInput: false});
         }
       ).catch(error => {
         Setting.showMessage("error", `${i18next.t("general:Failed to start recording")}: ${error.message}`);
@@ -320,13 +317,6 @@ class ChatBox extends React.Component {
       this.sttHelper.stopStreaming();
     } else {
       this.sttHelper.stopRecognition();
-
-      setTimeout(() => {
-        // Send the message after speech recognition is complete
-        if (this.state.value && this.state.value.trim() !== "") {
-          this.handleSend();
-        }
-      }, 300);
     }
 
     this.setState({isVoiceInput: false});


### PR DESCRIPTION
## Summary

Both the cloud-streaming `onEnd` callback and the browser-builtin `stopVoiceInput` `setTimeout` were calling `handleSend()` as soon as the recording session ended, dispatching the transcript immediately without giving the user a chance to review or edit it. Users frequently want to correct recognition errors (or add more context) before the message goes out, so this auto-send is the wrong default.

This PR drops both auto-send call sites in `ChatBox.js`. The transcript still ends up in the input box via `processVoiceResult`; the user now presses Enter (or clicks Send) when they're ready.

## Test plan

- [ ] Record a STT utterance via the cloud streaming provider, verify the message does NOT auto-send after silence or manual stop.
- [ ] Same for the browser-builtin Web Speech path.
- [ ] Verify the transcript text remains in the input box and can be edited or sent manually.