### PR TITLE
feat: add paraformer-v2 and fun-asr Alibaba Cloud STT model options

### DIFF
--- a/stt/alibabacloud.go
+++ b/stt/alibabacloud.go
@@ -74,15 +74,25 @@ func (p *AlibabacloudSpeechToTextProvider) GetPricing() string {
 https://help.aliyun.com/zh/model-studio/paraformer-speech-recognition/
 ASR models:
 
-|     Models      |    Price          |
-|-----------------|-------------------|
-|    Paraformer   |   0.288 yuan/hour |
+|           Models           |    Price          |
+|----------------------------|-------------------|
+|        Paraformer          |   0.288 yuan/hour |
+|       fun-asr-realtime     |   1.188 yuan/hour |
+| fun-asr-flash-8k-realtime  |   0.792 yuan/hour |
 `
 }
 
-// calculatePrice calculates the price based on audio duration
+// calculatePrice calculates the price based on audio duration. Rates are
+// keyed on the upstream model name (subType); paraformer is the default
+// fallback for models we haven't explicitly priced.
 func (p *AlibabacloudSpeechToTextProvider) calculatePrice(res *SpeechToTextResult) error {
 	pricePerHour := 0.288
+	switch p.subType {
+	case "fun-asr-realtime":
+		pricePerHour = 1.188
+	case "fun-asr-flash-8k-realtime":
+		pricePerHour = 0.792
+	}
 	res.Price = getPrice(res.AudioDurationSeconds, pricePerHour)
 	res.Currency = "CNY"
 	return nil

--- a/web/src/ProviderSetting.js
+++ b/web/src/ProviderSetting.js
@@ -1337,6 +1337,9 @@ export function getProviderSubTypeOptions(category, type) {
   } else if (category === "Speech-to-Text") {
     if (type === "Alibaba Cloud") {
       return [
+        {id: "fun-asr-realtime", name: "fun-asr-realtime"},
+        {id: "fun-asr-flash-8k-realtime", name: "fun-asr-flash-8k-realtime"},
+        {id: "paraformer-realtime-v2", name: "paraformer-realtime-v2"},
         {id: "paraformer-realtime-v1", name: "paraformer-realtime-v1"},
       ];
     } else {

--- a/web/src/SpeechProvider/StreamingSpeechToTextProvider.js
+++ b/web/src/SpeechProvider/StreamingSpeechToTextProvider.js
@@ -16,10 +16,14 @@ import * as Setting from "../Setting";
 import i18next from "i18next";
 
 // How long the websocket session may sit without a new transcript event
-// before we treat the user as "done speaking" and stop. Same idea as the
-// browser-builtin silence timer; needed here because the upstream SDK
-// does not send a finish-task to paraformer on its own, so without this
-// the session would only end on the server's 60s hard timeout.
+// before we treat the upstream as "done with this utterance" and stop.
+// This is the main exit mechanism for models with server-side VAD
+// (paraformer-realtime-v2, fun-asr-realtime, fun-asr-flash-8k-realtime):
+// once they finish a sentence they stop pushing transcript events even
+// though the websocket and microphone are still live. Without this timer
+// such sessions would idle until the 60s server-side hard timeout. v1
+// pushes interim transcripts continuously, so the timer never fires for
+// it and recording continues until the user clicks stop.
 const SILENCE_TIMEOUT_MS = 3000;
 
 // Bidirectional websocket STT: captures microphone via AudioWorklet,
@@ -48,7 +52,8 @@ class StreamingSpeechToTextProvider {
       this.silenceTimer = null;
       // Trigger the same path as a manual stop: send EOS upstream and
       // disconnect the mic. The websocket onclose handler then runs
-      // _teardown, which fires the onEndCallback so ChatBox auto-sends.
+      // _teardown, which fires the onEndCallback so the mic button
+      // resets and the user can click again to continue.
       this.stop();
     }, SILENCE_TIMEOUT_MS);
   }
@@ -132,8 +137,14 @@ class StreamingSpeechToTextProvider {
           return;
         }
         if (typeof msg.text === "string" && this.resultCallback) {
-          // Any transcript update means the user is still speaking, so
-          // push the silence deadline forward.
+          // Any transcript event resets the silence timer. For v1 this
+          // means the timer rarely fires (events keep flowing while audio
+          // arrives), so v1 sessions tend to end via explicit user stop
+          // or the 60s server hard timeout. For v2/fun-asr the upstream
+          // stops emitting after detecting end-of-utterance, so the timer
+          // fires naturally ~3s later. We don't try to distinguish "real"
+          // events from heartbeats here — it turned out we don't know v1
+          // well enough to filter correctly.
           this._resetSilenceTimer();
           // Match the synthetic event shape Browser/Remote providers use,
           // so ChatBox.processVoiceResult can stay unchanged.


### PR DESCRIPTION
## Summary

Exposes three additional model choices in the Alibaba Cloud speech-to-text provider dropdown:

- **paraformer-realtime-v2** — general successor to v1
- **fun-asr-realtime** — 1.188 yuan/hour
- **fun-asr-flash-8k-realtime** — 0.792 yuan/hour

All three share paraformer's `run-task` / `result-generated` websocket schema, so the only backend additions are pricing branches in `calculatePrice` and an updated `GetPricing` table.

Also updates the `StreamingSpeechToTextProvider.js` comments to document the model-specific silence-timer behavior observed during testing:
- `paraformer-realtime-v1` keeps pushing interim transcripts so the timer rarely fires — recording continues until the user stops manually
- The new v2 / fun-asr models stop emitting after server VAD detects end of utterance, so the timer naturally ends the session after ~3s

## Test plan

- [ ] Select `paraformer-realtime-v2` in the provider dropdown, record a sentence, verify transcription completes successfully.
- [ ] Same for `fun-asr-realtime` and `fun-a
- [ ] Verify the calculated price reflects the new per-model rates (`GetPricing` table shows correct entries, `calculatePrice` returns expected value).