### PR TITLE
fix: resolve out-of-order messages caused by identical timestamps

### DIFF
--- a/controllers/openai_api_util.go
+++ b/controllers/openai_api_util.go
@@ -68,6 +68,7 @@ func newOpenAIWriter(rw *context.Response, request openai.ChatCompletionRequest,
 // createApiChatSession inserts a Chat, a user Message, and a placeholder AI Message into the DB.
 func createApiChatSession(store *object.Store, modelProviderName, question, requestId string) (*object.Chat, *object.Message, *object.Message, error) {
 	now := util.GetCurrentTime()
+	userMessageTime := util.GetCurrentTimeWithMilli()
 
 	chat := &object.Chat{
 		Owner:         store.Owner,
@@ -85,7 +86,7 @@ func createApiChatSession(store *object.Store, modelProviderName, question, requ
 	userMsg := &object.Message{
 		Owner:         store.Owner,
 		Name:          "msg_user_" + requestId,
-		CreatedTime:   now,
+		CreatedTime:   userMessageTime,
 		Store:         store.Name,
 		Chat:          chat.Name,
 		Author:        "Human",
@@ -100,7 +101,7 @@ func createApiChatSession(store *object.Store, modelProviderName, question, requ
 	aiMsg := &object.Message{
 		Owner:         store.Owner,
 		Name:          "msg_ai_" + requestId,
-		CreatedTime:   util.GetCurrentTime(),
+		CreatedTime:   util.GetCurrentTimeEx(userMessageTime),
 		Store:         store.Name,
 		Chat:          chat.Name,
 		Author:        "AI",


### PR DESCRIPTION
### Summary
This PR fixes a frontend rendering issue where AI responses could occasionally appear *before* the user's prompt. 

### Root Cause
When a message pair is created:
1. The **Human** message uses a high-precision `now` timestamp.
2. The **AI** message follows immediately, calling `GetCurrentTime()`, which only provides **second-level precision**.
3. Due to this precision truncation, both messages can end up with the exact same `created_time` in the database.
4. The backend queries messages sorted strictly by `created_time ASC`. When timestamps are identical, MySQL does not guarantee a deterministic row order, causing the AI message to sometimes be returned first.