### PR TITLE
fix: preserve message count for API chat sessions

### DIFF
--- a/controllers/openai_api_util.go
+++ b/controllers/openai_api_util.go
@@ -127,11 +127,19 @@ func applyResultToApiSession(aiMsg *object.Message, chat *object.Chat, writer *O
 		return err
 	}
 
-	chat.TokenCount += modelResult.TotalTokenCount
-	chat.Price += modelResult.TotalPrice
-	if chat.Currency == "" {
-		chat.Currency = modelResult.Currency
+	latestChat, err := object.GetChat(chat.GetId())
+	if err != nil {
+		return err
 	}
-	_, err := object.UpdateChat(chat.GetId(), chat)
+	if latestChat == nil {
+		return fmt.Errorf("chat not found: %s", chat.GetId())
+	}
+
+	latestChat.TokenCount += modelResult.TotalTokenCount
+	latestChat.Price += modelResult.TotalPrice
+	if latestChat.Currency == "" {
+		latestChat.Currency = modelResult.Currency
+	}
+	_, err = object.UpdateChat(latestChat.GetId(), latestChat)
 	return err
 }


### PR DESCRIPTION
## Summary

- Reload the latest Chat before updating API usage data.
- Prevent API chat sessions from being incorrectly removed by the cleanup task.

## Root Cause

`AddMessage()` correctly increments `Chat.MessageCount` when creating the user and AI messages.

However, `applyResultToApiSession()` later updated the Chat using the stale object created before those messages were inserted. This overwrote the database message count back to `0`.

The cleanup task treats chats with `MessageCount == 0` as empty and deletes them.

## Fix

Reload the Chat from the database before updating token count, price, and currency. This preserves the latest message count and other fields updated during message creation.