### PR TITLE
fix: align API chat session IDs with existing conventions

### DIFF
--- a/controllers/openai_api.go
+++ b/controllers/openai_api.go
@@ -92,7 +92,7 @@ func (c *ApiController) chatCompletionsViaStore(store *object.Store, request ope
 		prompt = systemPrompt
 	}
 
-	chat, _, aiMsg, err := createApiChatSession(store, modelProviderRecord.Name, question, requestId)
+	chat, _, aiMsg, err := createApiChatSession(store, modelProviderRecord.Name, question)
 	if err != nil {
 		c.ResponseError(err.Error())
 		return

--- a/controllers/openai_api_util.go
+++ b/controllers/openai_api_util.go
@@ -66,13 +66,13 @@ func newOpenAIWriter(rw *context.Response, request openai.ChatCompletionRequest,
 }
 
 // createApiChatSession inserts a Chat, a user Message, and a placeholder AI Message into the DB.
-func createApiChatSession(store *object.Store, modelProviderName, question, requestId string) (*object.Chat, *object.Message, *object.Message, error) {
+func createApiChatSession(store *object.Store, modelProviderName, question string) (*object.Chat, *object.Message, *object.Message, error) {
 	now := util.GetCurrentTime()
 	userMessageTime := util.GetCurrentTimeWithMilli()
 
 	chat := &object.Chat{
 		Owner:         store.Owner,
-		Name:          "chat_api_" + requestId,
+		Name:          fmt.Sprintf("chat_%s", util.GetRandomName()),
 		CreatedTime:   now,
 		UpdatedTime:   now,
 		Store:         store.Name,
@@ -85,7 +85,7 @@ func createApiChatSession(store *object.Store, modelProviderName, question, requ
 
 	userMsg := &object.Message{
 		Owner:         store.Owner,
-		Name:          "msg_user_" + requestId,
+		Name:          fmt.Sprintf("message_%s", util.GetRandomName()),
 		CreatedTime:   userMessageTime,
 		Store:         store.Name,
 		Chat:          chat.Name,
@@ -100,7 +100,7 @@ func createApiChatSession(store *object.Store, modelProviderName, question, requ
 
 	aiMsg := &object.Message{
 		Owner:         store.Owner,
-		Name:          "msg_ai_" + requestId,
+		Name:          fmt.Sprintf("message_%s", util.GetRandomName()),
 		CreatedTime:   util.GetCurrentTimeBasedOnLastMilli(userMessageTime),
 		Store:         store.Name,
 		Chat:          chat.Name,


### PR DESCRIPTION
## Summary

- Use `util.GetRandomName()` when creating API chats and messages.
- Generate independent `chat_xxxxxx` and `message_xxxxxx` database IDs.
- Remove the API request ID from `createApiChatSession()`.

## Details

API chat records previously reused the OpenAI request UUID:

- `chat_api_<UUID>`
- `msg_user_<UUID>`
- `msg_ai_<UUID>`

The new implementation follows the existing project convention:

- `chat_xxxxxx`
- `message_xxxxxx`
- `message_xxxxxx`

Messages remain associated through `Message.Chat` and `Message.ReplyTo`. The UUID request ID is still used for OpenAI-compatible response tracking.