### PR TITLE
feat: make API chat logs read-only

### DIFF
--- a/controllers/chat.go
+++ b/controllers/chat.go
@@ -244,29 +244,34 @@ func (c *ApiController) GetChat() {
 func (c *ApiController) UpdateChat() {
 	id := c.Input().Get("id")
 
+	originalChat, err := object.GetChat(id)
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+	if originalChat == nil {
+		c.ResponseError(fmt.Sprintf("The chat: %s is not found", id))
+		return
+	}
+	if originalChat.IsApiLog() {
+		c.ResponseError(c.T("controllers:API chat logs are read-only"))
+		return
+	}
+
 	var chat object.Chat
-	err := json.Unmarshal(c.Ctx.Input.RequestBody, &chat)
+	err = json.Unmarshal(c.Ctx.Input.RequestBody, &chat)
 	if err != nil {
 		c.ResponseError(err.Error())
 		return
 	}
 
-	ok := c.IsCurrentUser(chat.User)
+	ok := c.IsCurrentUser(originalChat.User)
 	if !ok {
 		return
 	}
+	chat.Source = originalChat.Source
 
 	if conf.IsDemoMode() {
-		originalChat, err := object.GetChat(id)
-		if err != nil {
-			c.ResponseError(err.Error())
-			return
-		}
-		if originalChat == nil {
-			c.ResponseError(fmt.Sprintf("The chat: %s is not found", id))
-			return
-		}
-
 		originalChat.ModelProvider = chat.ModelProvider
 		chat = *originalChat
 	}
@@ -307,6 +312,7 @@ func (c *ApiController) AddChat() {
 	chat.UserAgent = c.getUserAgent()
 	chat.ClientIpDesc = util.GetDescFromIP(chat.ClientIp)
 	chat.UserAgentDesc = util.GetDescFromUserAgent(chat.UserAgent)
+	chat.Source = ""
 
 	if chat.Store == "" {
 		var store *object.Store
@@ -347,20 +353,35 @@ func (c *ApiController) DeleteChat() {
 		return
 	}
 
-	ok := c.IsCurrentUser(chat.User)
-	if !ok {
+	persistedChat, err := object.GetChat(chat.GetId())
+	if err != nil {
+		c.ResponseError(err.Error())
 		return
 	}
+	if persistedChat == nil {
+		c.ResponseError(fmt.Sprintf("The chat: %s is not found", chat.GetId()))
+		return
+	}
+	if persistedChat.IsApiLog() {
+		if !c.RequireAdmin() {
+			return
+		}
+	} else {
+		ok := c.IsCurrentUser(persistedChat.User)
+		if !ok {
+			return
+		}
+	}
 
-	success, err := object.DeleteChat(&chat)
+	success, err := object.DeleteChat(persistedChat)
 	if err != nil {
 		c.ResponseError(err.Error())
 		return
 	}
 
 	message := object.Message{
-		Owner: chat.Owner,
-		Chat:  chat.Name,
+		Owner: persistedChat.Owner,
+		Chat:  persistedChat.Name,
 	}
 	success, err = object.DeleteMessagesByChat(&message)
 	if err != nil {

--- a/controllers/message.go
+++ b/controllers/message.go
@@ -24,6 +24,36 @@ import (
 	"github.com/the-open-agent/openagent/util"
 )
 
+func (c *ApiController) ensureMessageMutable(message *object.Message) (*object.Chat, bool) {
+	if message == nil || message.Chat == "" {
+		return nil, true
+	}
+	chat, err := object.GetChat(util.GetId(message.Owner, message.Chat))
+	if err != nil {
+		c.ResponseError(err.Error())
+		return nil, false
+	}
+	if chat == nil {
+		c.ResponseError(fmt.Sprintf("The chat: %s/%s is not found", message.Owner, message.Chat))
+		return nil, false
+	}
+	if chat.IsApiLog() {
+		c.ResponseError(c.T("controllers:API chat logs are read-only"))
+		return nil, false
+	}
+	return chat, true
+}
+
+func preserveMessageOwnership(message, persistedMessage *object.Message) {
+	message.Owner = persistedMessage.Owner
+	message.Name = persistedMessage.Name
+	message.CreatedTime = persistedMessage.CreatedTime
+	message.Organization = persistedMessage.Organization
+	message.Store = persistedMessage.Store
+	message.User = persistedMessage.User
+	message.Chat = persistedMessage.Chat
+}
+
 // GetGlobalMessages
 // @Title GetGlobalMessages
 // @Tag Message API
@@ -42,6 +72,10 @@ func (c *ApiController) GetGlobalMessages() {
 	if limit == "" || page == "" {
 		messages, err := object.GetGlobalMessages()
 		if err != nil {
+			c.ResponseError(err.Error())
+			return
+		}
+		if err = object.PopulateMessagesReadOnly(messages); err != nil {
 			c.ResponseError(err.Error())
 			return
 		}
@@ -100,6 +134,10 @@ func (c *ApiController) GetGlobalMessages() {
 			c.ResponseError(err.Error())
 			return
 		}
+		if err = object.PopulateMessagesReadOnly(messages); err != nil {
+			c.ResponseError(err.Error())
+			return
+		}
 
 		c.ResponseOk(messages, count)
 	}
@@ -137,12 +175,20 @@ func (c *ApiController) GetMessages() {
 			c.ResponseError(err.Error())
 			return
 		}
+		if err = object.PopulateMessagesReadOnly(messages); err != nil {
+			c.ResponseError(err.Error())
+			return
+		}
 		c.ResponseOk(messages)
 		return
 	}
 
 	messages, err := object.GetChatMessages(chat)
 	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+	if err = object.PopulateMessagesReadOnly(messages); err != nil {
 		c.ResponseError(err.Error())
 		return
 	}
@@ -170,6 +216,10 @@ func (c *ApiController) GetMessage() {
 		c.ResponseError("Message not found")
 		return
 	}
+	if err = object.PopulateMessagesReadOnly([]*object.Message{message}); err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
 
 	// Check if user has permission to view this message
 	if !c.IsAdmin() {
@@ -195,17 +245,31 @@ func (c *ApiController) UpdateMessage() {
 	id := c.Input().Get("id")
 	isHitOnly := c.Input().Get("isHitOnly")
 
+	persistedMessage, err := object.GetMessage(id)
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+	if persistedMessage == nil {
+		c.ResponseError("Message not found")
+		return
+	}
+	if _, ok := c.ensureMessageMutable(persistedMessage); !ok {
+		return
+	}
+
 	var message object.Message
-	err := json.Unmarshal(c.Ctx.Input.RequestBody, &message)
+	err = json.Unmarshal(c.Ctx.Input.RequestBody, &message)
 	if err != nil {
 		c.ResponseError(err.Error())
 		return
 	}
 
-	ok := c.IsCurrentUser(message.User)
+	ok := c.IsCurrentUser(persistedMessage.User)
 	if !ok {
 		return
 	}
+	preserveMessageOwnership(&message, persistedMessage)
 
 	if message.NeedNotify {
 		if conf.IsCasdoorAvailable() {
@@ -243,17 +307,37 @@ func (c *ApiController) AddMessage() {
 		return
 	}
 
-	ok := c.IsCurrentUser(message.User)
-	if !ok {
-		return
-	}
-
 	id := util.GetIdFromOwnerAndName(message.Owner, message.Name)
 	originMessage, err := object.GetMessage(id)
 	if err != nil {
 		c.ResponseError(err.Error())
 		return
 	}
+
+	var chat *object.Chat
+	if originMessage != nil {
+		if !c.IsCurrentUser(originMessage.User) {
+			return
+		}
+		var mutable bool
+		chat, mutable = c.ensureMessageMutable(originMessage)
+		if !mutable {
+			return
+		}
+		preserveMessageOwnership(&message, originMessage)
+	} else {
+		if !c.IsCurrentUser(message.User) {
+			return
+		}
+		if message.Chat != "" {
+			var mutable bool
+			chat, mutable = c.ensureMessageMutable(&message)
+			if !mutable {
+				return
+			}
+		}
+	}
+
 	// if originMessage not nil, means edit message, delete all later messages
 	if originMessage != nil {
 		err = object.DeleteAllLaterMessages(id)
@@ -312,7 +396,6 @@ func (c *ApiController) AddMessage() {
 			}
 		}
 	}
-	var chat *object.Chat
 	if message.Chat == "" {
 		chat, err = c.addInitialChat(message.Organization, message.User, message.Store)
 		if err != nil {
@@ -322,18 +405,6 @@ func (c *ApiController) AddMessage() {
 
 		message.Organization = chat.Organization
 		message.Chat = chat.Name
-	} else {
-		chatId := util.GetId(message.Owner, message.Chat)
-		chat, err = object.GetChat(chatId)
-		if err != nil {
-			c.ResponseError(err.Error())
-			return
-		}
-
-		if chat == nil {
-			c.ResponseError(fmt.Sprintf("chat:The chat: %s is not found", chatId))
-			return
-		}
 	}
 
 	host := c.Ctx.Request.Host
@@ -438,7 +509,17 @@ func (c *ApiController) DeleteMessage() {
 		return
 	}
 
-	success, err := object.DeleteMessage(&message)
+	persistedMessage, err := object.GetMessage(message.GetId())
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+	if persistedMessage == nil {
+		c.ResponseError("Message not found")
+		return
+	}
+
+	success, err := object.DeleteMessage(persistedMessage)
 	if err != nil {
 		c.ResponseError(err.Error())
 		return

--- a/controllers/openai_api_util.go
+++ b/controllers/openai_api_util.go
@@ -77,6 +77,7 @@ func createApiChatSession(store *object.Store, modelProviderName, question, requ
 		UpdatedTime:   now,
 		Store:         store.Name,
 		ModelProvider: modelProviderName,
+		Source:        object.ChatSourceOpenAICompatibleAPI,
 		User:          "api",
 	}
 	if _, err := object.AddChat(chat); err != nil {

--- a/object/chat.go
+++ b/object/chat.go
@@ -21,6 +21,8 @@ import (
 	"xorm.io/core"
 )
 
+const ChatSourceOpenAICompatibleAPI = "OpenAICompatibleAPI"
+
 type Chat struct {
 	Owner       string `xorm:"varchar(100) notnull pk" json:"owner"`
 	Name        string `xorm:"varchar(100) notnull pk" json:"name"`
@@ -33,6 +35,7 @@ type Chat struct {
 	ModelProvider string  `xorm:"varchar(100)" json:"modelProvider"`
 	Tool          string  `xorm:"varchar(100)" json:"tool"`
 	Category      string  `xorm:"varchar(100)" json:"category"`
+	Source        string  `xorm:"varchar(100)" json:"source"`
 	User          string  `xorm:"varchar(100) index" json:"user"`
 	ClientIp      string  `xorm:"varchar(100)" json:"clientIp"`
 	UserAgent     string  `xorm:"varchar(200)" json:"userAgent"`
@@ -138,6 +141,10 @@ func DeleteChat(chat *Chat) (bool, error) {
 
 func (chat *Chat) GetId() string {
 	return fmt.Sprintf("%s/%s", chat.Owner, chat.Name)
+}
+
+func (chat *Chat) IsApiLog() bool {
+	return chat != nil && chat.Source == ChatSourceOpenAICompatibleAPI
 }
 
 func getChatCountByMessages(owner string, value string, store string) (int64, error) {

--- a/object/message.go
+++ b/object/message.go
@@ -74,6 +74,49 @@ type Message struct {
 	SearchResults     []model.SearchResult `xorm:"mediumtext" json:"searchResults"`
 
 	TransactionId string `xorm:"varchar(100)" json:"transactionId"`
+	IsReadOnly    bool   `xorm:"-" json:"isReadOnly"`
+}
+
+const messageReadOnlyChatBatchSize = 500
+
+func PopulateMessagesReadOnly(messages []*Message) error {
+	chatNamesByOwner := map[string]map[string]struct{}{}
+	for _, message := range messages {
+		if message == nil || message.Chat == "" {
+			continue
+		}
+		if chatNamesByOwner[message.Owner] == nil {
+			chatNamesByOwner[message.Owner] = map[string]struct{}{}
+		}
+		chatNamesByOwner[message.Owner][message.Chat] = struct{}{}
+	}
+
+	readOnlyChats := map[string]bool{}
+	for owner, nameSet := range chatNamesByOwner {
+		names := make([]string, 0, len(nameSet))
+		for name := range nameSet {
+			names = append(names, name)
+		}
+
+		for start := 0; start < len(names); start += messageReadOnlyChatBatchSize {
+			end := min(start+messageReadOnlyChatBatchSize, len(names))
+			chats := []*Chat{}
+			err := adapter.engine.In("name", names[start:end]).Find(&chats, &Chat{Owner: owner})
+			if err != nil {
+				return err
+			}
+			for _, chat := range chats {
+				readOnlyChats[chat.GetId()] = chat.IsApiLog()
+			}
+		}
+	}
+
+	for _, message := range messages {
+		if message != nil {
+			message.IsReadOnly = readOnlyChats[util.GetId(message.Owner, message.Chat)]
+		}
+	}
+	return nil
 }
 
 func GetGlobalMessages() ([]*Message, error) {

--- a/web/src/ChatEditPage.js
+++ b/web/src/ChatEditPage.js
@@ -14,7 +14,7 @@
 
 import React from "react";
 import Loading from "./common/Loading";
-import {Button, Card, Col, Input, Row, Select, Space, Switch} from "antd";
+import {Button, Card, Col, Input, Row, Select, Space, Switch, Tag} from "antd";
 import * as ChatBackend from "./backend/ChatBackend";
 import * as ProviderBackend from "./backend/ProviderBackend";
 import * as Setting from "./Setting";
@@ -22,6 +22,7 @@ import i18next from "i18next";
 import ChatBox from "./ChatBox";
 import {renderText} from "./ChatMessageRender";
 import * as MessageBackend from "./backend/MessageBackend";
+import {isApiChat} from "./ChatUtil";
 
 const {Option} = Select;
 
@@ -113,8 +114,14 @@ class ChatEditPage extends React.Component {
     });
   }
 
-  renderChatActions() {
+  isReadOnly() {
+    return isApiChat(this.state.chat);
+  }
 
+  renderChatActions() {
+    if (this.isReadOnly()) {
+      return null;
+    }
     return (
       <Space wrap>
         <Button onClick={() => this.submitChatEdit(false)}>{i18next.t("general:Save")}</Button>
@@ -134,11 +141,12 @@ class ChatEditPage extends React.Component {
   }
 
   renderChatSwitch(label, checked, onChange, span = 6) {
-    return this.renderChatField(label, <Switch checked={checked} onChange={onChange} />, span);
+    return this.renderChatField(label, <Switch checked={checked} disabled={this.isReadOnly()} onChange={onChange} />, span);
   }
 
   renderChat() {
     const chat = this.state.chat;
+    const isReadOnly = this.isReadOnly();
     const rowGutter = [16, 8];
     const cardHeadStyle = {background: "transparent", borderBottom: "none", fontWeight: 600, fontSize: "15px", fontFamily: "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"};
     const sectionCardStyle = {
@@ -158,7 +166,11 @@ class ChatEditPage extends React.Component {
     return (
       <div>
         <div style={{marginBottom: "16px", display: "flex", justifyContent: "space-between", alignItems: "center"}}>
-          <span style={{fontSize: "22px", fontWeight: 600}}>{i18next.t("chat:Edit Chat")}</span>
+          <Space wrap>
+            <span style={{fontSize: "22px", fontWeight: 600}}>{i18next.t(isReadOnly ? "chat:Chat Log" : "chat:Edit Chat")}</span>
+            {isReadOnly && <Tag color="blue">{i18next.t("general:API")}</Tag>}
+            {isReadOnly && <Tag>{i18next.t("general:Read-only")}</Tag>}
+          </Space>
           <div style={{display: "flex", gap: "8px", marginRight: "4px"}}>
             {this.renderChatActions()}
           </div>
@@ -168,21 +180,21 @@ class ChatEditPage extends React.Component {
           <Row gutter={rowGutter}>
             {this.renderChatField(
               Setting.getLabel(i18next.t("general:Name"), i18next.t("general:Name - Tooltip")),
-              <Input value={chat.name} onChange={e => {
+              <Input value={chat.name} disabled={isReadOnly} onChange={e => {
                 this.updateChatField("name", e.target.value);
               }} />,
               8
             )}
             {this.renderChatField(
               Setting.getLabel(i18next.t("general:Display name"), i18next.t("general:Display name - Tooltip")),
-              <Input value={chat.displayName} onChange={e => {
+              <Input value={chat.displayName} disabled={isReadOnly} onChange={e => {
                 this.updateChatField("displayName", e.target.value);
               }} />,
               8
             )}
             {this.renderChatField(
               Setting.getLabel(i18next.t("general:Store"), i18next.t("general:Store - Tooltip")),
-              <Input value={chat.store} onChange={e => {
+              <Input value={chat.store} disabled={isReadOnly} onChange={e => {
                 this.updateChatField("store", e.target.value);
               }} />,
               8
@@ -191,6 +203,7 @@ class ChatEditPage extends React.Component {
               Setting.getLabel(i18next.t("provider:Model provider"), i18next.t("provider:Model provider - Tooltip")),
               <Select
                 virtual={false}
+                disabled={isReadOnly}
                 style={{width: "100%"}}
                 value={chat.modelProvider}
                 onChange={(value) => {
@@ -215,7 +228,7 @@ class ChatEditPage extends React.Component {
             )}
             {this.renderChatField(
               Setting.getLabel(i18next.t("general:Category"), i18next.t("provider:Category - Tooltip")),
-              <Input value={chat.category} onChange={e => {
+              <Input value={chat.category} disabled={isReadOnly} onChange={e => {
                 this.updateChatField("category", e.target.value);
               }} />,
               8
@@ -227,7 +240,7 @@ class ChatEditPage extends React.Component {
           <Row gutter={rowGutter}>
             {this.renderChatField(
               Setting.getLabel(i18next.t("general:User"), i18next.t("general:User - Tooltip")),
-              <Input value={chat.user} onChange={e => {
+              <Input value={chat.user} disabled={isReadOnly} onChange={e => {
                 this.updateChatField("user", e.target.value);
               }} />,
               8

--- a/web/src/ChatListPage.js
+++ b/web/src/ChatListPage.js
@@ -14,7 +14,7 @@
 
 import React from "react";
 import {Link} from "react-router-dom";
-import {Button, Popconfirm, Switch, Table, Tooltip} from "antd";
+import {Button, Popconfirm, Space, Switch, Table, Tag, Tooltip} from "antd";
 import moment from "moment";
 import BaseListPage from "./BaseListPage";
 import * as Setting from "./Setting";
@@ -25,7 +25,8 @@ import * as Conf from "./Conf";
 import * as MessageBackend from "./backend/MessageBackend";
 import ChatBox from "./ChatBox";
 import {renderText} from "./ChatMessageRender";
-import {DeleteOutlined, EditOutlined} from "@ant-design/icons";
+import {DeleteOutlined, EditOutlined, EyeOutlined} from "@ant-design/icons";
+import {isApiChat} from "./ChatUtil";
 
 class ChatListPage extends BaseListPage {
   constructor(props) {
@@ -318,14 +319,18 @@ class ChatListPage extends BaseListPage {
         title: i18next.t("general:Name"),
         dataIndex: "name",
         key: "name",
-        width: "100px",
+        width: "180px",
         sorter: (a, b) => a.name.localeCompare(b.name),
         ...this.getColumnSearchProps("name"),
         render: (text, record, index) => {
           return (
-            <Link to={`chats/${text}`}>
-              {text}
-            </Link>
+            <Space size={4} wrap>
+              <Link to={`chats/${text}`}>
+                {text}
+              </Link>
+              {isApiChat(record) && <Tag color="blue">{i18next.t("general:API")}</Tag>}
+              {isApiChat(record) && <Tag>{i18next.t("general:Read-only")}</Tag>}
+            </Space>
           );
         },
       },
@@ -526,10 +531,11 @@ class ChatListPage extends BaseListPage {
         width: "130px",
         fixed: "right",
         render: (text, record, index) => {
+          const isReadOnly = isApiChat(record);
           return (
             <div style={{display: "flex", alignItems: "center", gap: "2px", flexWrap: "nowrap"}}>
-              <Tooltip title={i18next.t("general:Edit")}>
-                <Button type="text" size="small" icon={<EditOutlined />} style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}} onClick={() => this.props.history.push(`/chats/${record.name}`)} />
+              <Tooltip title={i18next.t(isReadOnly ? "general:View" : "general:Edit")}>
+                <Button type="text" size="small" icon={isReadOnly ? <EyeOutlined /> : <EditOutlined />} style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}} onClick={() => this.props.history.push(`/chats/${record.name}`)} />
               </Tooltip>
               <Popconfirm
                 title={`${i18next.t("general:Sure to delete")}: ${record.name} ?`}
@@ -577,7 +583,7 @@ class ChatListPage extends BaseListPage {
 
     return (
       <div>
-        <Table scroll={{x: "max-content"}} columns={columns} dataSource={chats} rowKey="name" rowSelection={this.getRowSelection()} size="middle" bordered pagination={paginationProps}
+        <Table scroll={{x: "max-content"}} columns={columns} dataSource={chats} rowKey="name" rowSelection={{...this.getRowSelection(), getCheckboxProps: record => ({disabled: isApiChat(record) && !Setting.isLocalAdminUser(this.props.account)})}} size="middle" bordered pagination={paginationProps}
           title={() => (
             <div>
               {i18next.t("general:Chats")}&nbsp;&nbsp;&nbsp;&nbsp;

--- a/web/src/ChatUtil.js
+++ b/web/src/ChatUtil.js
@@ -1,0 +1,19 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export const ApiChatSource = "OpenAICompatibleAPI";
+
+export function isApiChat(chat) {
+  return chat?.source === ApiChatSource;
+}

--- a/web/src/MessageEditPage.js
+++ b/web/src/MessageEditPage.js
@@ -14,12 +14,13 @@
 
 import React from "react";
 import Loading from "./common/Loading";
-import {Button, Card, Col, Input, Row, Select, Space, Switch} from "antd";
+import {Button, Card, Col, Input, Row, Select, Space, Switch, Tag} from "antd";
 import i18next from "i18next";
 import * as Setting from "./Setting";
 import * as MessageBackend from "./backend/MessageBackend";
 import * as ChatBackend from "./backend/ChatBackend";
 import * as ProviderBackend from "./backend/ProviderBackend";
+import {isApiChat} from "./ChatUtil";
 
 const {TextArea} = Input;
 const {Option} = Select;
@@ -85,8 +86,8 @@ class MessageEditPage extends React.Component {
       });
   }
 
-  getChat(chatName) {
-    ChatBackend.getChat("admin", chatName)
+  getChat(owner, chatName) {
+    ChatBackend.getChat(owner, chatName)
       .then((res) => {
         if (res.status === "ok") {
           this.setState({
@@ -105,6 +106,7 @@ class MessageEditPage extends React.Component {
           this.setState({
             message: res.data,
           });
+          this.getChat(res.data.owner, res.data.chat);
           this.getProvider(res.data.modelProvider);
         } else {
           Setting.showMessage("error", `${i18next.t("general:Failed to get")}: ${res.msg}`);
@@ -142,6 +144,10 @@ class MessageEditPage extends React.Component {
     });
   }
 
+  isReadOnly() {
+    return this.state.message?.isReadOnly === true || isApiChat(this.state.chat);
+  }
+
   renderMessageField(label, control, span = 8) {
     return (
       <Col style={{marginTop: "12px"}} span={Setting.isMobile() ? 22 : span}>
@@ -152,10 +158,13 @@ class MessageEditPage extends React.Component {
   }
 
   renderMessageSwitch(label, checked, onChange, span = 6) {
-    return this.renderMessageField(label, <Switch checked={checked} onChange={onChange} />, span);
+    return this.renderMessageField(label, <Switch checked={checked} disabled={this.isReadOnly()} onChange={onChange} />, span);
   }
 
   renderMessageActions() {
+    if (this.isReadOnly()) {
+      return null;
+    }
     return (
       <Space wrap>
         <Button onClick={() => this.submitMessageEdit(false)}>{i18next.t("general:Save")}</Button>
@@ -167,6 +176,7 @@ class MessageEditPage extends React.Component {
 
   renderMessage() {
     const message = this.state.message;
+    const isReadOnly = this.isReadOnly();
     const rowGutter = [16, 8];
     const cardHeadStyle = {background: "transparent", borderBottom: "none", fontWeight: 600, fontSize: "15px", fontFamily: "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"};
     const sectionCardStyle = {
@@ -185,7 +195,11 @@ class MessageEditPage extends React.Component {
     return (
       <div>
         <div style={{marginBottom: "16px", display: "flex", justifyContent: "space-between", alignItems: "center"}}>
-          <span style={{fontSize: "22px", fontWeight: 600}}>{i18next.t("message:Edit Message")}</span>
+          <Space wrap>
+            <span style={{fontSize: "22px", fontWeight: 600}}>{i18next.t(isReadOnly ? "message:Message Log" : "message:Edit Message")}</span>
+            {isReadOnly && <Tag color="blue">{i18next.t("general:API")}</Tag>}
+            {isReadOnly && <Tag>{i18next.t("general:Read-only")}</Tag>}
+          </Space>
           <div style={{display: "flex", gap: "8px", marginRight: "4px"}}>
             {this.renderMessageActions()}
           </div>
@@ -195,12 +209,12 @@ class MessageEditPage extends React.Component {
           <Row gutter={rowGutter}>
             {this.renderMessageField(
               Setting.getLabel(i18next.t("general:Name"), i18next.t("general:Name - Tooltip")),
-              <Input value={message.name} onChange={(e) => this.updateMessageField("name", e.target.value)} />,
+              <Input value={message.name} disabled={isReadOnly} onChange={(e) => this.updateMessageField("name", e.target.value)} />,
               8
             )}
             {this.renderMessageField(
               Setting.getLabel(i18next.t("general:User"), i18next.t("general:User - Tooltip")),
-              <Input value={message.user} onChange={(e) => this.updateMessageField("user", e.target.value)} />,
+              <Input value={message.user} disabled={isReadOnly} onChange={(e) => this.updateMessageField("user", e.target.value)} />,
               8
             )}
             {this.renderMessageField(
@@ -212,12 +226,13 @@ class MessageEditPage extends React.Component {
               Setting.getLabel(i18next.t("message:Author"), i18next.t("message:Author - Tooltip")),
               <Select
                 virtual={false}
+                disabled={isReadOnly}
                 style={{width: "100%"}}
                 value={message.author}
                 onChange={(value) => this.updateMessageField("author", value)}
                 options={
                   this.state.chat !== null
-                    ? this.state.chat.users.map((user) => Setting.getOption(`${user}`, `${user}`))
+                    ? (this.state.chat.users || []).map((user) => Setting.getOption(`${user}`, `${user}`))
                     : []
                 }
               />,
@@ -227,6 +242,7 @@ class MessageEditPage extends React.Component {
               Setting.getLabel(i18next.t("provider:Model provider"), i18next.t("provider:Model provider - Tooltip")),
               <Select
                 virtual={false}
+                disabled={isReadOnly}
                 style={{width: "100%"}}
                 value={message.modelProvider}
                 onChange={(value) => {
@@ -251,6 +267,7 @@ class MessageEditPage extends React.Component {
               Setting.getLabel(i18next.t("message:Reply to"), i18next.t("message:Reply to - Tooltip")),
               <Select
                 virtual={false}
+                disabled={isReadOnly}
                 style={{width: "100%"}}
                 value={message.replyTo}
                 onChange={(value) => this.updateMessageField("replyTo", value)}
@@ -269,22 +286,22 @@ class MessageEditPage extends React.Component {
           <Row gutter={rowGutter}>
             {this.renderMessageField(
               Setting.getLabel(i18next.t("general:Reasoning text"), i18next.t("general:Reasoning text - Tooltip")),
-              <TextArea autoSize={{minRows: 1, maxRows: 15}} value={message.reasonText} onChange={(e) => this.updateMessageField("reasonText", e.target.value)} />,
+              <TextArea autoSize={{minRows: 1, maxRows: 15}} value={message.reasonText} disabled={isReadOnly} onChange={(e) => this.updateMessageField("reasonText", e.target.value)} />,
               24
             )}
             {this.renderMessageField(
               Setting.getLabel(i18next.t("general:Text"), i18next.t("general:Text - Tooltip")),
-              <TextArea autoSize={{minRows: 1, maxRows: 15}} value={message.text} onChange={(e) => this.updateMessageField("text", e.target.value)} />,
+              <TextArea autoSize={{minRows: 1, maxRows: 15}} value={message.text} disabled={isReadOnly} onChange={(e) => this.updateMessageField("text", e.target.value)} />,
               24
             )}
             {this.renderMessageField(
               Setting.getLabel(i18next.t("message:Error text"), i18next.t("message:Error text - Tooltip")),
-              <TextArea autoSize={{minRows: 1, maxRows: 15}} value={message.errorText} onChange={(e) => this.updateMessageField("errorText", e.target.value)} />,
+              <TextArea autoSize={{minRows: 1, maxRows: 15}} value={message.errorText} disabled={isReadOnly} onChange={(e) => this.updateMessageField("errorText", e.target.value)} />,
               24
             )}
             {this.renderMessageField(
               Setting.getLabel(i18next.t("message:Comment"), i18next.t("message:Comment - Tooltip")),
-              <TextArea autoSize={{minRows: 1, maxRows: 15}} value={message.comment} onChange={(e) => {
+              <TextArea autoSize={{minRows: 1, maxRows: 15}} value={message.comment} disabled={isReadOnly} onChange={(e) => {
                 if (e.target.value !== "") {
                   this.updateMessageField("needNotify", true);
                 } else {

--- a/web/src/MessageListPage.js
+++ b/web/src/MessageListPage.js
@@ -23,7 +23,7 @@ import * as ProviderBackend from "./backend/ProviderBackend";
 import moment from "moment";
 import i18next from "i18next";
 import * as Conf from "./Conf";
-import {DeleteOutlined, EditOutlined} from "@ant-design/icons";
+import {DeleteOutlined, EditOutlined, EyeOutlined} from "@ant-design/icons";
 import VectorTooltip from "./VectorTooltip";
 
 class MessageListPage extends BaseListPage {
@@ -330,9 +330,13 @@ class MessageListPage extends BaseListPage {
         ...this.getColumnSearchProps("chat"),
         render: (text, record, index) => {
           return (
-            <Link to={`/chats/${text}`}>
-              {text}
-            </Link>
+            <div>
+              <Link to={`/chats/${text}`}>
+                {text}
+              </Link>
+              {record.isReadOnly && <Tag color="blue" style={{marginLeft: 4}}>{i18next.t("general:API")}</Tag>}
+              {record.isReadOnly && <Tag>{i18next.t("general:Read-only")}</Tag>}
+            </div>
           );
         },
       },
@@ -575,8 +579,8 @@ class MessageListPage extends BaseListPage {
         render: (text, record, index) => {
           return (
             <div style={{display: "flex", alignItems: "center", gap: "2px", flexWrap: "nowrap"}}>
-              <Tooltip title={i18next.t("general:Edit")}>
-                <Button type="text" size="small" icon={<EditOutlined />} style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}} onClick={() => this.props.history.push(`/messages/${record.name}`)} />
+              <Tooltip title={i18next.t(record.isReadOnly ? "general:View" : "general:Edit")}>
+                <Button type="text" size="small" icon={record.isReadOnly ? <EyeOutlined /> : <EditOutlined />} style={{minWidth: "28px", width: "28px", height: "28px", padding: 0, borderRadius: "6px"}} onClick={() => this.props.history.push(`/messages/${record.name}`)} />
               </Tooltip>
               <Popconfirm
                 title={`${i18next.t("general:Sure to delete")}: ${record.name} ?`}


### PR DESCRIPTION
## Summary

Make chats created through the OpenAI-compatible API identifiable and read-only in OpenAgent.

## Changes

- Add a source marker to newly created API chats.
- Prevent API chats from being edited.
- Prevent messages in API chats from being added, edited and regenerated.
- Allow administrators to delete an API chat and its messages.
- Preserve persisted message ownership fields during updates to prevent moving messages between chats.
- Display API and read-only markers on chat and message pages.
- Replace edit actions with view actions for API logs.
- Compute message read-only state from parent chats in batches of 500 to avoid database parameter limits.
- Share the frontend API chat detection logic through `ChatUtil.js`.