### PR TITLE
feat: add Github-like agent hub detail page

### DIFF
--- a/web/src/StoreHubAgentDetail.js
+++ b/web/src/StoreHubAgentDetail.js
@@ -1,0 +1,242 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from "react";
+import {Avatar, Button, Card, Col, Empty, Row, Space, Tabs, Tag, Typography} from "antd";
+import {BarChartOutlined, CommentOutlined, EyeOutlined, FolderOpenOutlined, ForkOutlined, SettingOutlined, StarOutlined} from "@ant-design/icons";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import i18next from "i18next";
+import FileTree from "./FileTree";
+import * as Setting from "./Setting";
+
+const {Text, Title} = Typography;
+
+function renderHeader(store, onStartChat, onPlaceholder) {
+  const initials = (store.displayName || store.name || "?")[0].toUpperCase();
+  const authorName = store.author || store.owner;
+
+  return (
+    <div style={{display: "flex", alignItems: "flex-start", gap: 20, marginBottom: 16, flexWrap: "wrap"}}>
+      {store.avatar ? (
+        <Avatar size={72} src={store.avatar} style={{flexShrink: 0}} />
+      ) : (
+        <Avatar size={72} style={{backgroundColor: Setting.getAvatarColor(store.name), flexShrink: 0, fontSize: 30}}>
+          {initials}
+        </Avatar>
+      )}
+      <div style={{flex: 1, minWidth: 0}}>
+        <div style={{display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 12, flexWrap: "wrap", marginBottom: 6}}>
+          <div style={{minWidth: 0}}>
+            <Title level={3} style={{margin: 0, wordBreak: "break-word"}}>
+              <Text type="secondary" style={{fontSize: 20, fontWeight: 400}}>{store.owner} / </Text>
+              {store.displayName || store.name}
+            </Title>
+            <Text type="secondary" style={{fontSize: 14}}>
+              {i18next.t("store:By")} <strong>{authorName}</strong>
+            </Text>
+          </div>
+          <Space wrap>
+            <Button icon={<StarOutlined />} onClick={() => onPlaceholder("star")}>
+              {i18next.t("store:Star")}
+            </Button>
+            <Button icon={<EyeOutlined />} onClick={() => onPlaceholder("watch")}>
+              {i18next.t("store:Watch")}
+            </Button>
+            <Button icon={<ForkOutlined />} onClick={() => onPlaceholder("fork")}>
+              {i18next.t("store:Fork")}
+            </Button>
+            <Button type="primary" icon={<CommentOutlined />} onClick={onStartChat}>
+              {i18next.t("store:Start Chat")}
+            </Button>
+          </Space>
+        </div>
+        {store.affiliation ? (
+          <div style={{fontSize: 13, color: "var(--ant-color-text-tertiary)", marginTop: 2}}>
+            {store.affiliation}
+          </div>
+        ) : null}
+        <div style={{marginTop: 8, display: "flex", flexWrap: "wrap", gap: 6}}>
+          {store.subject ? <Tag color="purple">{store.subject}</Tag> : null}
+          {store.grade ? <Tag color="cyan">{store.grade}</Tag> : null}
+          {store.topic ? <Tag color="geekblue">{store.topic}</Tag> : null}
+        </div>
+        {store.brief ? (
+          <div style={{marginTop: 8, fontSize: 14, color: "var(--ant-color-text-secondary)", maxWidth: 640}}>
+            {store.brief}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function renderAbout(store) {
+  const rows = [
+    [i18next.t("general:Owner"), store.owner],
+    [i18next.t("general:Author"), store.author],
+    [i18next.t("store:Affiliation"), store.affiliation],
+    [i18next.t("store:Tutor"), store.tutor],
+    [i18next.t("store:Subject"), store.subject],
+    [i18next.t("store:Grade"), store.grade],
+    [i18next.t("store:Topic"), store.topic],
+  ].filter(([, value]) => value);
+  const stats = [
+    [i18next.t("store:Chat count"), store.chatCount],
+    [i18next.t("general:Messages"), store.messageCount],
+    [i18next.t("store:Vector count"), store.vectorCount],
+  ].filter(([, value]) => value !== undefined && value !== null);
+
+  return (
+    <Card title={i18next.t("store:About")} size="small">
+      {store.brief ? (
+        <div style={{fontSize: 14, lineHeight: 1.6, marginBottom: 14}}>
+          {store.brief}
+        </div>
+      ) : null}
+      <div style={{display: "grid", gap: 8}}>
+        {rows.map(([label, value]) => (
+          <div key={label} style={{display: "flex", justifyContent: "space-between", gap: 12}}>
+            <Text type="secondary">{label}</Text>
+            <Text style={{textAlign: "right", wordBreak: "break-word"}}>{value}</Text>
+          </div>
+        ))}
+      </div>
+      {stats.length > 0 ? (
+        <div style={{display: "grid", gridTemplateColumns: "repeat(3, minmax(0, 1fr))", gap: 8, marginTop: 16}}>
+          {stats.map(([label, value]) => (
+            <div key={label} style={{border: "1px solid var(--ant-color-border-secondary)", borderRadius: 6, padding: "8px 6px", textAlign: "center"}}>
+              <div style={{fontWeight: 600}}>{value}</div>
+              <Text type="secondary" style={{fontSize: 12}}>{label}</Text>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </Card>
+  );
+}
+
+function renderReadme(store) {
+  const content = store.description || store.prompt || store.welcomeText || "";
+  if (!content) {return null;}
+
+  return (
+    <Card
+      title={
+        <div style={{display: "flex", alignItems: "center", gap: 8}}>
+          <FolderOpenOutlined />
+          <span>README</span>
+        </div>
+      }
+      styles={{body: {padding: "20px 24px"}}}
+    >
+      <div className="markdown-body" style={{fontSize: 14, lineHeight: "1.6"}}>
+        <ReactMarkdown remarkPlugins={[remarkGfm]}>
+          {content}
+        </ReactMarkdown>
+      </div>
+    </Card>
+  );
+}
+
+function renderFiles(account, store, onStoreUpdate, onRefresh) {
+  return (
+    <FileTree
+      account={account}
+      store={store}
+      onUpdateStore={onStoreUpdate}
+      onRefresh={onRefresh}
+    />
+  );
+}
+
+function renderOverview(account, store, onStoreUpdate, onRefresh) {
+  return (
+    <Row gutter={[16, 16]}>
+      <Col xs={24} lg={16}>
+        <div style={{display: "grid", gap: 16}}>
+          {renderFiles(account, store, onStoreUpdate, onRefresh)}
+          {renderReadme(store)}
+        </div>
+      </Col>
+      <Col xs={24} lg={8}>
+        {renderAbout(store)}
+      </Col>
+    </Row>
+  );
+}
+
+function renderIssues() {
+  return (
+    <Card>
+      <Empty description={i18next.t("store:Issues are coming soon")} />
+    </Card>
+  );
+}
+
+function renderInsights(store, onOpenAnalysis) {
+  return (
+    <Card>
+      <Empty
+        image={<BarChartOutlined style={{fontSize: 44, color: "var(--ant-color-primary)"}} />}
+        description={i18next.t("store:Open analysis to view agent insights")}
+      >
+        <Button icon={<BarChartOutlined />} onClick={onOpenAnalysis}>
+          {i18next.t("store:Analysis")}
+        </Button>
+      </Empty>
+    </Card>
+  );
+}
+
+function renderTabContent(account, store, activeTab, onStoreUpdate, onRefresh, onOpenAnalysis) {
+  if (activeTab === "files") {
+    return renderFiles(account, store, onStoreUpdate, onRefresh);
+  }
+  if (activeTab === "issues") {
+    return renderIssues();
+  }
+  if (activeTab === "insights") {
+    return renderInsights(store, onOpenAnalysis);
+  }
+  return renderOverview(account, store, onStoreUpdate, onRefresh);
+}
+
+function StoreHubAgentDetail({account, store, activeTab, canManage, onTabChange, onStartChat, onPlaceholder, onStoreUpdate, onRefresh, onOpenAnalysis}) {
+  const tabItems = [
+    {key: "overview", label: i18next.t("store:Overview")},
+    {key: "files", label: i18next.t("general:Files")},
+    {key: "issues", label: i18next.t("store:Issues")},
+    {key: "insights", label: i18next.t("store:Insights")},
+  ];
+
+  if (canManage) {
+    tabItems.push({key: "settings", label: <span><SettingOutlined /> {i18next.t("general:Settings")}</span>});
+  }
+
+  return (
+    <div style={{padding: "24px 32px", maxWidth: 1280, margin: "0 auto"}}>
+      {renderHeader(store, onStartChat, onPlaceholder)}
+      <Tabs
+        activeKey={activeTab}
+        items={tabItems}
+        onChange={onTabChange}
+        style={{marginBottom: 16}}
+      />
+      {renderTabContent(account, store, activeTab, onStoreUpdate, onRefresh, onOpenAnalysis)}
+    </div>
+  );
+}
+
+export default StoreHubAgentDetail;

--- a/web/src/StoreViewPage.js
+++ b/web/src/StoreViewPage.js
@@ -13,17 +13,12 @@
 // limitations under the License.
 
 import React from "react";
-import {Avatar, Button, Card, Divider, Spin, Tag, Typography} from "antd";
-import {CommentOutlined, FolderOpenOutlined} from "@ant-design/icons";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
+import {Spin} from "antd";
 import * as StoreBackend from "./backend/StoreBackend";
 import * as Setting from "./Setting";
 import i18next from "i18next";
-import FileTree from "./FileTree";
 import {getChatUrl} from "./StoreHubDrawer";
-
-const {Text, Title} = Typography;
+import StoreHubAgentDetail from "./StoreHubAgentDetail";
 
 class StoreViewPage extends React.Component {
   constructor(props) {
@@ -33,6 +28,7 @@ class StoreViewPage extends React.Component {
       storeName: props.match.params.storeName,
       store: null,
       loading: true,
+      activeTab: "overview",
     };
   }
 
@@ -66,81 +62,34 @@ class StoreViewPage extends React.Component {
     }
   }
 
-  renderHeader(store) {
-    const initials = (store.displayName || store.name || "?")[0].toUpperCase();
-    const authorName = store.author || store.owner;
-
-    return (
-      <div style={{display: "flex", alignItems: "flex-start", gap: 20, marginBottom: 20, flexWrap: "wrap"}}>
-        {store.avatar ? (
-          <Avatar size={80} src={store.avatar} style={{flexShrink: 0}} />
-        ) : (
-          <Avatar size={80} style={{backgroundColor: Setting.getAvatarColor(store.name), flexShrink: 0, fontSize: 32}}>
-            {initials}
-          </Avatar>
-        )}
-        <div style={{flex: 1, minWidth: 0}}>
-          <div style={{display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap", marginBottom: 6}}>
-            <Title level={3} style={{margin: 0}}>
-              {store.displayName || store.name}
-            </Title>
-            <Button
-              type="primary"
-              icon={<CommentOutlined />}
-              onClick={() => this.handleStartChat()}
-            >
-              {i18next.t("store:Start Chat")}
-            </Button>
-          </div>
-          <Text type="secondary" style={{fontSize: 14}}>
-            {i18next.t("store:By")} <strong>{authorName}</strong>
-          </Text>
-          {store.affiliation ? (
-            <div style={{fontSize: 13, color: "var(--ant-color-text-tertiary)", marginTop: 2}}>
-              {store.affiliation}
-            </div>
-          ) : null}
-          <div style={{marginTop: 8, display: "flex", flexWrap: "wrap", gap: 6}}>
-            {store.subject ? <Tag color="purple">{store.subject}</Tag> : null}
-            {store.grade ? <Tag color="cyan">{store.grade}</Tag> : null}
-            {store.topic ? <Tag color="geekblue">{store.topic}</Tag> : null}
-          </div>
-          {store.brief ? (
-            <div style={{marginTop: 8, fontSize: 14, color: "var(--ant-color-text-secondary)", maxWidth: 640}}>
-              {store.brief}
-            </div>
-          ) : null}
-        </div>
-      </div>
-    );
+  handlePlaceholder(action) {
+    const messages = {
+      star: i18next.t("store:Star is coming soon"),
+      watch: i18next.t("store:Watch is coming soon"),
+      fork: i18next.t("store:Fork requires storage copy support"),
+    };
+    Setting.showMessage("info", messages[action]);
   }
 
-  renderReadme(store) {
-    const content = store.description || store.prompt || store.welcomeText || "";
-    if (!content) {return null;}
+  canManageStore(store) {
+    const {account} = this.props;
+    if (!account || !store) {
+      return false;
+    }
+    return account.name === store.owner || Setting.isAdminUser(account);
+  }
 
-    return (
-      <Card
-        title={
-          <div style={{display: "flex", alignItems: "center", gap: 8}}>
-            <FolderOpenOutlined />
-            <span>{i18next.t("general:Description")}</span>
-          </div>
-        }
-        style={{marginTop: 16}}
-        styles={{body: {padding: "20px 24px"}}}
-      >
-        <div className="markdown-body" style={{fontSize: 14, lineHeight: "1.6"}}>
-          <ReactMarkdown remarkPlugins={[remarkGfm]}>
-            {content}
-          </ReactMarkdown>
-        </div>
-      </Card>
-    );
+  handleTabChange(key) {
+    if (key === "settings") {
+      const {store} = this.state;
+      this.props.history.push(`/stores/${store.owner}/${store.name}`);
+      return;
+    }
+    this.setState({activeTab: key});
   }
 
   render() {
-    const {store, loading} = this.state;
+    const {store, loading, activeTab} = this.state;
 
     if (loading) {
       return (
@@ -154,21 +103,23 @@ class StoreViewPage extends React.Component {
       return null;
     }
 
+    const canManage = this.canManageStore(store);
     return (
-      <div style={{padding: "24px 32px", maxWidth: 1200, margin: "0 auto"}}>
-        {this.renderHeader(store)}
-        <Divider style={{margin: "0 0 16px"}} />
-        <FileTree
-          account={this.props.account}
-          store={store}
-          onUpdateStore={(updatedStore) => {
-            this.setState({store: updatedStore});
-            Setting.submitStoreEdit(updatedStore);
-          }}
-          onRefresh={() => this.getStore()}
-        />
-        {this.renderReadme(store)}
-      </div>
+      <StoreHubAgentDetail
+        account={this.props.account}
+        store={store}
+        activeTab={activeTab}
+        canManage={canManage}
+        onTabChange={(key) => this.handleTabChange(key)}
+        onStartChat={() => this.handleStartChat()}
+        onPlaceholder={(action) => this.handlePlaceholder(action)}
+        onStoreUpdate={(updatedStore) => {
+          this.setState({store: updatedStore});
+          Setting.submitStoreEdit(updatedStore);
+        }}
+        onRefresh={() => this.getStore()}
+        onOpenAnalysis={() => this.props.history.push(`/analysis/${store.owner}/${store.name}`)}
+      />
     );
   }
 }


### PR DESCRIPTION
## Summary

- Refactor the Agent Hub detail UI into a dedicated `StoreHubAgentDetail` component
- Add GitHub-like detail page structure with header actions, tabs, About panel, Files, README, Issues placeholder, and Insights entry
- Keep Star, Watch, Fork, and Issues as UI placeholders only