### PR TITLE
feat: add LiteLLM provider

### DIFF
--- a/model/litellm.go
+++ b/model/litellm.go
@@ -1,0 +1,92 @@
+// Copyright 2025 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"io"
+)
+
+type LiteLLMModelProvider struct {
+	subType                      string
+	secretKey                    string
+	temperature                  float32
+	topP                         float32
+	frequencyPenalty             float32
+	presencePenalty              float32
+	providerUrl                  string
+	inputPricePerThousandTokens  float64
+	outputPricePerThousandTokens float64
+	currency                     string
+}
+
+func NewLiteLLMModelProvider(subType string, secretKey string, temperature float32, topP float32, frequencyPenalty float32, presencePenalty float32, providerUrl string, inputPricePerThousandTokens float64, outputPricePerThousandTokens float64, currency string) (*LiteLLMModelProvider, error) {
+	return &LiteLLMModelProvider{
+		subType:                      subType,
+		secretKey:                    secretKey,
+		temperature:                  temperature,
+		topP:                         topP,
+		frequencyPenalty:             frequencyPenalty,
+		presencePenalty:              presencePenalty,
+		providerUrl:                  providerUrl,
+		inputPricePerThousandTokens:  inputPricePerThousandTokens,
+		outputPricePerThousandTokens: outputPricePerThousandTokens,
+		currency:                     currency,
+	}, nil
+}
+
+func (p *LiteLLMModelProvider) GetPricing() string {
+	return `URL:
+https://docs.litellm.ai/docs/
+
+LiteLLM is an AI gateway that provides a unified OpenAI-compatible
+interface to 100+ LLM providers (OpenAI, Anthropic, Gemini, Bedrock,
+Vertex AI, Groq, Ollama, Mistral, Cohere, and more).
+
+Pricing depends on the upstream model routed through the LiteLLM proxy.
+Configure per-model pricing in your LiteLLM proxy config or set custom
+input/output prices in the provider settings.
+`
+}
+
+func (p *LiteLLMModelProvider) calculatePrice(modelResult *ModelResult) {
+	if p.inputPricePerThousandTokens > 0 || p.outputPricePerThousandTokens > 0 {
+		inputPrice := getPrice(modelResult.PromptTokenCount, p.inputPricePerThousandTokens)
+		outputPrice := getPrice(modelResult.ResponseTokenCount, p.outputPricePerThousandTokens)
+		modelResult.TotalPrice = AddPrices(inputPrice, outputPrice)
+		modelResult.Currency = p.currency
+	} else {
+		modelResult.TotalPrice = 0
+		modelResult.Currency = "USD"
+	}
+}
+
+func (p *LiteLLMModelProvider) QueryText(question string, writer io.Writer, history []*RawMessage, prompt string, knowledgeMessages []*RawMessage, toolSession *ToolSession, lang string) (*ModelResult, error) {
+	localProvider, err := NewLocalModelProvider("Custom-think", "custom-model", p.secretKey, p.temperature, p.topP, p.frequencyPenalty, p.presencePenalty, p.providerUrl, p.subType, p.inputPricePerThousandTokens, p.outputPricePerThousandTokens, p.currency)
+	if err != nil {
+		return nil, err
+	}
+
+	modelResult, err := localProvider.QueryText(question, writer, history, prompt, knowledgeMessages, toolSession, lang)
+	if err != nil {
+		return nil, err
+	}
+
+	p.calculatePrice(modelResult)
+	return modelResult, nil
+}
+
+func (p *LiteLLMModelProvider) ListModels() ([]string, error) {
+	return openaiCompatibleListModels("litellm", p.secretKey, p.providerUrl)
+}

--- a/model/provider.go
+++ b/model/provider.go
@@ -175,6 +175,8 @@ func GetModelProvider(typ string, subType string, clientId string, clientSecret 
 		p, err = NewWriterModelProvider(subType, clientSecret, temperature, topP)
 	} else if typ == "OpenCode" {
 		p, err = NewOpenCodeProvider(providerUrl, clientSecret)
+	} else if typ == "LiteLLM" {
+		p, err = NewLiteLLMModelProvider(subType, clientSecret, temperature, topP, frequencyPenalty, presencePenalty, providerUrl, inputPricePerThousandTokens, outputPricePerThousandTokens, Currency)
 	} else {
 		return nil, nil
 	}

--- a/web/src/ProviderEditPage.js
+++ b/web/src/ProviderEditPage.js
@@ -128,7 +128,7 @@ class ProviderEditPage extends React.Component {
   }
 
   modelCategoryShowsProviderUrlInput(type) {
-    return ["Local", "Ollama", "Azure", "Volcano Engine", "Tencent Cloud", "OpenCode"].includes(type);
+    return ["Local", "Ollama", "Azure", "Volcano Engine", "Tencent Cloud", "OpenCode", "LiteLLM"].includes(type);
   }
 
   getRegionLabel(provider) {
@@ -213,7 +213,7 @@ class ProviderEditPage extends React.Component {
 
   isTemperatureEnabled(provider) {
     if (provider.category === "Model") {
-      if (["OpenRouter", "iFlytek", "Hugging Face", "Baidu Cloud", "MiniMax", "Gemini", "Alibaba Cloud", "Baichuan", "Volcano Engine", "DeepSeek", "StepFun", "Tencent Cloud", "Mistral", "Yi", "Silicon Flow", "Ollama", "Writer"].includes(provider.type)) {
+      if (["OpenRouter", "iFlytek", "Hugging Face", "Baidu Cloud", "MiniMax", "Gemini", "Alibaba Cloud", "Baichuan", "Volcano Engine", "DeepSeek", "StepFun", "Tencent Cloud", "Mistral", "Yi", "Silicon Flow", "Ollama", "Writer", "LiteLLM"].includes(provider.type)) {
         return true;
       } else if (provider.type === "OpenAI") {
         if (provider.subType.includes("o1") || provider.subType.includes("o3") || provider.subType.includes("o4")) {
@@ -228,7 +228,7 @@ class ProviderEditPage extends React.Component {
 
   isTopPEnabled(provider) {
     if (provider.category === "Model") {
-      if (["OpenRouter", "Baidu Cloud", "Gemini", "Alibaba Cloud", "Baichuan", "Volcano Engine", "DeepSeek", "StepFun", "Tencent Cloud", "Mistral", "Yi", "Silicon Flow", "Ollama", "Writer"].includes(provider.type)) {
+      if (["OpenRouter", "Baidu Cloud", "Gemini", "Alibaba Cloud", "Baichuan", "Volcano Engine", "DeepSeek", "StepFun", "Tencent Cloud", "Mistral", "Yi", "Silicon Flow", "Ollama", "Writer", "LiteLLM"].includes(provider.type)) {
         return true;
       } else if (provider.type === "OpenAI") {
         if (provider.subType.includes("o1") || provider.subType.includes("o3") || provider.subType.includes("o4")) {
@@ -436,6 +436,8 @@ class ProviderEditPage extends React.Component {
                     this.updateProviderField("subType", "palmyra-x5");
                   } else if (value === "OpenCode") {
                     this.updateProviderField("subType", "");
+                  } else if (value === "LiteLLM") {
+                    this.updateProviderField("subType", "");
                   }
                 } else if (provider.category === "Embedding") {
                   if (value === "OpenAI") {
@@ -514,7 +516,7 @@ class ProviderEditPage extends React.Component {
                         }
                       </Select>
                     )}
-                    {["OpenAI", "OpenRouter", "Local", "OpenAI Compatible", "Ollama", "DeepSeek", "Moonshot", "Grok", "Silicon Flow", "Mistral", "StepFun"].includes(provider.type) && (
+                    {["OpenAI", "OpenRouter", "Local", "OpenAI Compatible", "Ollama", "DeepSeek", "Moonshot", "Grok", "Silicon Flow", "Mistral", "StepFun", "LiteLLM"].includes(provider.type) && (
                       <Button
                         type="primary"
                         icon={<SyncOutlined spin={this.state.isFetchingModels} />}
@@ -1072,7 +1074,7 @@ class ProviderEditPage extends React.Component {
                   <div style={{marginBottom: "4px"}}>{Setting.getLabel(i18next.t("provider:Temperature"), i18next.t("provider:Temperature - Tooltip"))}</div>
                   <Slider
                     min={0}
-                    max={["Alibaba Cloud", "Gemini", "OpenAI", "OpenRouter", "Baichuan", "DeepSeek", "StepFun", "Tencent Cloud", "Mistral", "Yi", "Ollama", "Writer"].includes(provider.type) ? 2 : 1}
+                    max={["Alibaba Cloud", "Gemini", "OpenAI", "OpenRouter", "Baichuan", "DeepSeek", "StepFun", "Tencent Cloud", "Mistral", "Yi", "Ollama", "Writer", "LiteLLM"].includes(provider.type) ? 2 : 1}
                     step={0.01}
                     value={provider.temperature}
                     disabled={isRemote}
@@ -1085,7 +1087,7 @@ class ProviderEditPage extends React.Component {
                   <div style={{marginBottom: "4px"}}>&nbsp;</div>
                   <InputNumber
                     min={0}
-                    max={["Alibaba Cloud", "Gemini", "OpenAI", "OpenRouter", "Baichuan", "DeepSeek", "StepFun", "Tencent Cloud", "Mistral", "Yi", "Ollama", "Writer"].includes(provider.type) ? 2 : 1}
+                    max={["Alibaba Cloud", "Gemini", "OpenAI", "OpenRouter", "Baichuan", "DeepSeek", "StepFun", "Tencent Cloud", "Mistral", "Yi", "Ollama", "Writer", "LiteLLM"].includes(provider.type) ? 2 : 1}
                     step={0.01}
                     style={{width: "100%"}}
                     value={provider.temperature}

--- a/web/src/ProviderSetting.js
+++ b/web/src/ProviderSetting.js
@@ -605,6 +605,7 @@ export function getProviderTypeOptions(category) {
         {id: "GitHub", name: "GitHub"},
         {id: "Writer", name: "Writer"},
         {id: "OpenCode", name: "OpenCode"},
+        {id: "LiteLLM", name: "LiteLLM"},
       ]
     );
   } else if (category === "Embedding") {
@@ -1194,6 +1195,8 @@ export function getModelSubTypeOptions(type) {
       {id: "palmyra-fin", name: "Palmyra Fin"},
       {id: "palmyra-creative", name: "Palmyra Creative"},
     ];
+  } else if (type === "LiteLLM") {
+    return [];
   } else {
     return [];
   }


### PR DESCRIPTION
## Summary

Adds [LiteLLM](https://github.com/BerriAI/litellm) as a first-class model provider, giving OpenAgent users access to 100+ LLM providers (OpenAI, Anthropic, Gemini, Bedrock, Vertex AI, Groq, Ollama, Mistral, Cohere, and more) through a single unified gateway.

LiteLLM exposes an OpenAI-compatible API, so this integration reuses the existing `LocalModelProvider` ("Custom-think") delegation pattern for chat completions and the `openaiCompatibleListModels` helper for dynamic model discovery via `/v1/models`.

## Changes

### Backend (Go)

**`model/litellm.go`** - New `LiteLLMModelProvider` struct implementing the `ModelProvider` interface:
- `QueryText()` delegates to `LocalModelProvider("Custom-think")` which uses the `go-openai` client to send OpenAI-compatible requests to the LiteLLM proxy. This reuses all existing streaming, message formatting, and error handling logic without duplication.
- `ListModels()` calls `openaiCompatibleListModels("litellm", ...)` to auto-discover available models from the proxy's `GET /v1/models` endpoint. No hardcoded model list needed since available models depend on the user's proxy configuration.
- `calculatePrice()` supports custom per-token pricing configured in the provider settings, falling back to $0/USD when no custom prices are set (actual costs depend on the upstream model routed through the proxy).
- `GetPricing()` returns documentation text explaining that pricing depends on the upstream model.

**`model/provider.go`** - Added `"LiteLLM"` case to `GetModelProvider()` dispatch, passing through all relevant parameters: `subType`, `clientSecret` (API key), `temperature`, `topP`, `frequencyPenalty`, `presencePenalty`, `providerUrl` (proxy base URL), and pricing/currency fields.

### Frontend (React)

**`web/src/ProviderEditPage.js`**:
- Added `"LiteLLM"` to the provider URL input list (`modelCategoryShowsProviderUrlInput`) so users can configure their proxy base URL
- Added to the "Fetch Models" button list so users can dynamically discover available models from their proxy
- Added to `isTemperatureEnabled` and `isTopPEnabled` lists with max temperature = 2.0 (matching OpenAI/OpenRouter range since LiteLLM proxies can route to any provider)
- Added default subType reset (`""`) when switching to LiteLLM provider type

**`web/src/ProviderSetting.js`**:
- Added `{id: "LiteLLM", name: "LiteLLM"}` to the Model category provider type dropdown
- Returns empty subType options for LiteLLM (models are fetched dynamically from the proxy, not hardcoded)

## How it works

1. User deploys a [LiteLLM proxy](https://docs.litellm.ai/docs/simple_proxy) with their desired model configurations
2. In OpenAgent, user creates a new provider with type "LiteLLM"
3. User enters their proxy URL (e.g., `http://localhost:4000/v1`) and API key (master key or virtual key)
4. User clicks "Fetch Models" to auto-discover available models from the proxy
5. All chat completions route through the proxy, which handles provider-specific translation (parameter mapping, auth, retries)


## Testing

- [x] `go build ./...` compiles clean (no new warnings)
- [x] Verified `QueryText` path: LiteLLM proxy receives OpenAI-compatible requests, returns correct completions with usage tokens
- [x] Verified `ListModels` path: `GET /v1/models` returns configured models from proxy
- [x] Verified streaming: SSE chunks received correctly through proxy
- [x] Verified error handling: invalid model returns 400, auth errors surface correctly
- [ ] Existing model package has no test infrastructure (`[no test files]` for all providers except `gemini_test.go` which is build-tagged `!skipCi`)
