### PR TITLE
feat: add Insights Contributors tab in store page

### DIFF
--- a/authz/authz.go
+++ b/authz/authz.go
@@ -103,6 +103,7 @@ p, anonymous, *, /api/is-session-duplicated
 p, anonymous, *, /api/add-node-tunnel
 p, anonymous, *, /api/chat-webhook/*
 p, anonymous, *, /api/get-store-insights-summary
+p, anonymous, *, /api/get-store-contributors
 
 g, admin, user
 g, user, anonymous

--- a/controllers/analysis.go
+++ b/controllers/analysis.go
@@ -15,6 +15,8 @@
 package controllers
 
 import (
+	"strconv"
+
 	"github.com/the-open-agent/openagent/object"
 )
 
@@ -77,4 +79,39 @@ func (c *ApiController) GetStoreInsightsSummary() {
 		return
 	}
 	c.ResponseOk(summary)
+}
+
+// GetStoreContributors
+// @Title GetStoreContributors
+// @Tag Analysis API
+// @Description Per-user rollup and time series for the Contributors sub-tab.
+// @Param   owner       query   string  true  "store owner"
+// @Param   storeName   query   string  true  "store name"
+// @Param   period      query   string  true  "time window: 24h | 7d | 30d"
+// @Param   topN        query   int     false "cap on returned contributors (default 20)"
+// @Success 200 {object} object.StoreContributorsData The Response object
+// @router /get-store-contributors [get]
+func (c *ApiController) GetStoreContributors() {
+	owner := c.Input().Get("owner")
+	storeName := c.Input().Get("storeName")
+	period := c.Input().Get("period")
+	if owner == "" || storeName == "" {
+		c.ResponseError("owner and storeName are required")
+		return
+	}
+	if period == "" {
+		period = "7d"
+	}
+	topN, _ := strconv.Atoi(c.Input().Get("topN"))
+
+	if _, ok := c.RequireSignedIn(); !ok {
+		return
+	}
+
+	data, err := object.GetStoreContributors(owner, storeName, period, topN)
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+	c.ResponseOk(data)
 }

--- a/object/store_insights.go
+++ b/object/store_insights.go
@@ -58,6 +58,29 @@ type InsightsUser struct {
 	ChatCount    int    `json:"chatCount"`
 }
 
+type StoreContributorsData struct {
+	Period    string `json:"period"`
+	StartTime string `json:"startTime"`
+	EndTime   string `json:"endTime"`
+	AsOf      string `json:"asOf"`
+
+	TotalActiveUsers int             `json:"totalActiveUsers"`
+	TotalSeries      []*ContribPoint `json:"totalSeries"`
+	Contributors     []*ContribUser  `json:"contributors"`
+}
+
+type ContribPoint struct {
+	Date         string `json:"date"`
+	MessageCount int    `json:"messageCount"`
+}
+
+type ContribUser struct {
+	User         string          `json:"user"`
+	MessageCount int             `json:"messageCount"`
+	ChatCount    int             `json:"chatCount"`
+	Series       []*ContribPoint `json:"series"`
+}
+
 type periodSpec struct {
 	duration   time.Duration
 	bucketUnit time.Duration
@@ -143,8 +166,11 @@ func GetStoreInsightsSummary(owner string, storeName string, period string) (*St
 	summary.ChatCount = len(chats)
 
 	// Messages — aggregated per bucket, plus per-user rollup for TopUsers.
+	// Only fetch the fields the aggregation actually reads so we don't drag the
+	// mediumtext columns (Text, ReasonText, ErrorText, Comment) into memory.
 	messages := []*Message{}
 	if err = adapter.engine.
+		Cols("user", "chat", "created_time", "author", "token_count", "price", "currency").
 		Where("store = ? and created_time >= ? and created_time < ?", storeName, startStr, endStr).
 		Find(&messages); err != nil {
 		return nil, err
@@ -161,16 +187,21 @@ func GetStoreInsightsSummary(owner string, storeName string, period string) (*St
 		if idx < 0 {
 			continue
 		}
-		buckets[idx].Messages++
+		// Token/price include AI replies because billing does; but the message-
+		// count / per-user metrics only count human-authored messages, matching
+		// the pattern in object/analysis.go's GetStoreWordCloud.
 		buckets[idx].TokenCount += m.TokenCount
 		buckets[idx].Price += m.Price
-
-		summary.MessageCount++
 		summary.TotalTokenCount += m.TokenCount
 		summary.TotalPrice += m.Price
 		if m.Currency != "" && summary.Currency == "" {
 			summary.Currency = m.Currency
 		}
+		if m.Author == "AI" {
+			continue
+		}
+		buckets[idx].Messages++
+		summary.MessageCount++
 		if m.User != "" {
 			userMsgCount[m.User]++
 			activeUserSet[m.User] = true
@@ -245,4 +276,118 @@ func GetStoreInsightsSummary(owner string, storeName string, period string) (*St
 	summary.TopUsers = top
 
 	return summary, nil
+}
+
+// GetStoreContributors returns per-user rollup and per-bucket series for the Contributors sub-tab.
+// topN caps the number of user cards returned (defaults to 20 if <= 0).
+func GetStoreContributors(owner string, storeName string, period string, topN int) (*StoreContributorsData, error) {
+	spec, err := resolvePeriod(period)
+	if err != nil {
+		return nil, err
+	}
+	if topN <= 0 {
+		topN = 20
+	}
+
+	now := time.Now()
+	end := now.Truncate(spec.bucketUnit).Add(spec.bucketUnit)
+	start := end.Add(-spec.duration)
+
+	startStr := util.FormatTimeForCompare(start)
+	endStr := util.FormatTimeForCompare(end)
+
+	dates := make([]string, spec.bucketN)
+	for i := 0; i < spec.bucketN; i++ {
+		dates[i] = start.Add(time.Duration(i) * spec.bucketUnit).Format(spec.bucketFmt)
+	}
+
+	// Filter by store only. Message.Owner is always "admin" (system-created), so
+	// filtering by the store's owner would never match — same reasoning as
+	// GetStoreInsightsSummary. Also restrict fetched columns so we don't drag
+	// the mediumtext body columns into memory (Text, ReasonText, ErrorText,
+	// Comment) since the aggregation only needs the four short fields below.
+	messages := []*Message{}
+	if err = adapter.engine.
+		Cols("user", "chat", "created_time", "author").
+		Where("store = ? and created_time >= ? and created_time < ?", storeName, startStr, endStr).
+		Find(&messages); err != nil {
+		return nil, err
+	}
+
+	totalSeries := make([]*ContribPoint, spec.bucketN)
+	for i := 0; i < spec.bucketN; i++ {
+		totalSeries[i] = &ContribPoint{Date: dates[i]}
+	}
+
+	// One accumulator per user; we only allocate series for users that actually have activity.
+	type userAgg struct {
+		messageCount int
+		chatSet      map[string]bool
+		series       []*ContribPoint
+	}
+	users := map[string]*userAgg{}
+
+	for _, m := range messages {
+		t, perr := time.Parse(time.RFC3339, m.CreatedTime)
+		if perr != nil {
+			continue
+		}
+		idx := bucketIndex(t, start, spec.bucketUnit, spec.bucketN)
+		if idx < 0 {
+			continue
+		}
+		// Exclude AI replies — Contributors ranks people by how much they typed,
+		// not by how much AI answered them (matches GetStoreWordCloud's filter).
+		if m.Author == "AI" {
+			continue
+		}
+		totalSeries[idx].MessageCount++
+		if m.User == "" {
+			continue
+		}
+		u, ok := users[m.User]
+		if !ok {
+			series := make([]*ContribPoint, spec.bucketN)
+			for i := 0; i < spec.bucketN; i++ {
+				series[i] = &ContribPoint{Date: dates[i]}
+			}
+			u = &userAgg{chatSet: map[string]bool{}, series: series}
+			users[m.User] = u
+		}
+		u.messageCount++
+		u.series[idx].MessageCount++
+		if m.Chat != "" {
+			u.chatSet[m.Chat] = true
+		}
+	}
+
+	contributors := make([]*ContribUser, 0, len(users))
+	for name, u := range users {
+		contributors = append(contributors, &ContribUser{
+			User:         name,
+			MessageCount: u.messageCount,
+			ChatCount:    len(u.chatSet),
+			Series:       u.series,
+		})
+	}
+	sort.Slice(contributors, func(i, j int) bool {
+		if contributors[i].MessageCount != contributors[j].MessageCount {
+			return contributors[i].MessageCount > contributors[j].MessageCount
+		}
+		return contributors[i].User < contributors[j].User
+	})
+	totalActive := len(contributors)
+	if len(contributors) > topN {
+		contributors = contributors[:topN]
+	}
+
+	return &StoreContributorsData{
+		Period:           period,
+		StartTime:        startStr,
+		EndTime:          endStr,
+		AsOf:             now.Format(time.RFC3339),
+		TotalActiveUsers: totalActive,
+		TotalSeries:      totalSeries,
+		Contributors:     contributors,
+	}, nil
 }

--- a/routers/router.go
+++ b/routers/router.go
@@ -74,6 +74,7 @@ func initAPI() {
 	beego.Router("/api/get-storage-providers", &controllers.ApiController{}, "GET:GetStorageProviders")
 	beego.Router("/api/get-store-word-cloud", &controllers.ApiController{}, "GET:GetStoreWordCloud")
 	beego.Router("/api/get-store-insights-summary", &controllers.ApiController{}, "GET:GetStoreInsightsSummary")
+	beego.Router("/api/get-store-contributors", &controllers.ApiController{}, "GET:GetStoreContributors")
 	beego.Router("/api/get-store-names", &controllers.ApiController{}, "GET:GetStoreNames")
 	beego.Router("/api/get-organization-users", &controllers.ApiController{}, "GET:GetOrganizationUsers")
 	beego.Router("/api/add-shared-store", &controllers.ApiController{}, "POST:AddSharedStore")

--- a/web/src/InsightsContributors.js
+++ b/web/src/InsightsContributors.js
@@ -1,0 +1,200 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from "react";
+import {Alert, Avatar, Card, Col, Empty, Row, Spin, Statistic, Typography} from "antd";
+import {TeamOutlined} from "@ant-design/icons";
+import ReactEcharts from "echarts-for-react";
+import i18next from "i18next";
+import * as AnalysisBackend from "./backend/AnalysisBackend";
+import * as Setting from "./Setting";
+
+const LINE_COLOR = "#1677ff";
+
+function totalSeriesOption(series) {
+  return {
+    grid: {top: 24, right: 16, bottom: 32, left: 40},
+    tooltip: {trigger: "axis"},
+    xAxis: {
+      type: "category",
+      data: series.map(p => p.date),
+      axisLabel: {fontSize: 11},
+      boundaryGap: false,
+    },
+    yAxis: {type: "value", minInterval: 1},
+    series: [{
+      name: i18next.t("general:Messages"),
+      type: "line",
+      data: series.map(p => p.messageCount),
+      smooth: true,
+      showSymbol: false,
+      lineStyle: {width: 2, color: LINE_COLOR},
+      areaStyle: {opacity: 0.15, color: LINE_COLOR},
+    }],
+  };
+}
+
+function miniSparkOption(series) {
+  return {
+    grid: {top: 4, right: 4, bottom: 4, left: 4},
+    xAxis: {type: "category", show: false, data: series.map((_, i) => i)},
+    yAxis: {type: "value", show: false},
+    tooltip: {trigger: "axis", formatter: (params) => `${params[0].value}`},
+    series: [{
+      type: "line",
+      data: series.map(p => p.messageCount),
+      smooth: true,
+      showSymbol: false,
+      lineStyle: {width: 2, color: LINE_COLOR},
+      areaStyle: {opacity: 0.15, color: LINE_COLOR},
+    }],
+  };
+}
+
+class InsightsContributors extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      loading: true,
+      error: null,
+      data: null,
+    };
+  }
+
+  componentDidMount() {
+    this.fetch();
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.period !== this.props.period || prevProps.refreshTick !== this.props.refreshTick) {
+      this.fetch();
+    }
+  }
+
+  fetch() {
+    const {owner, storeName, period, onLoaded} = this.props;
+    this.setState({loading: true, error: null});
+    AnalysisBackend.getStoreContributors(owner, storeName, period, 20)
+      .then((res) => {
+        if (res.status === "ok") {
+          this.setState({loading: false, data: res.data});
+          if (onLoaded) {onLoaded(res.data.asOf);}
+        } else {
+          this.setState({loading: false, error: res.msg});
+        }
+      })
+      .catch((err) => this.setState({loading: false, error: err.message || String(err)}));
+  }
+
+  renderTotalChart(data) {
+    return (
+      <Card
+        title={
+          <span>
+            <TeamOutlined /> {i18next.t("store:Activity over time")}
+            <Typography.Text type="secondary" style={{fontSize: 13, marginLeft: 12}}>
+              {i18next.t("store:{n} active users").replace("{n}", data.totalActiveUsers)}
+            </Typography.Text>
+          </span>
+        }
+        size="small"
+      >
+        <div style={{height: 220}}>
+          <ReactEcharts
+            option={totalSeriesOption(data.totalSeries)}
+            style={{height: "100%", width: "100%"}}
+            notMerge={true}
+            lazyUpdate={true}
+          />
+        </div>
+      </Card>
+    );
+  }
+
+  renderContributorCards(data) {
+    const {contributors} = data;
+    if (!contributors || contributors.length === 0) {
+      return (
+        <Card style={{marginTop: 16}} size="small">
+          <Empty description={i18next.t("store:No activity in this window")} />
+        </Card>
+      );
+    }
+    return (
+      <Row gutter={[16, 16]} style={{marginTop: 16}}>
+        {contributors.map((c) => (
+          <Col key={c.user} xs={24} sm={12} lg={8} xl={6}>
+            <Card size="small" styles={{body: {padding: 14}}}>
+              <div style={{display: "flex", alignItems: "center", gap: 10, marginBottom: 8, minWidth: 0}}>
+                <Avatar
+                  size="default"
+                  style={{backgroundColor: Setting.getAvatarColor(c.user), flexShrink: 0}}
+                >
+                  {c.user[0].toUpperCase()}
+                </Avatar>
+                <Typography.Text strong ellipsis={{tooltip: c.user}} style={{minWidth: 0, flex: 1}}>
+                  {c.user}
+                </Typography.Text>
+              </div>
+              <Row gutter={8}>
+                <Col span={12}>
+                  <Statistic
+                    title={i18next.t("general:Messages")}
+                    value={c.messageCount}
+                    valueStyle={{fontSize: 18}}
+                  />
+                </Col>
+                <Col span={12}>
+                  <Statistic
+                    title={i18next.t("general:Chats")}
+                    value={c.chatCount}
+                    valueStyle={{fontSize: 18}}
+                  />
+                </Col>
+              </Row>
+              <div style={{height: 44, marginTop: 8}}>
+                <ReactEcharts
+                  option={miniSparkOption(c.series)}
+                  style={{height: "100%", width: "100%"}}
+                  notMerge={true}
+                  lazyUpdate={true}
+                />
+              </div>
+            </Card>
+          </Col>
+        ))}
+      </Row>
+    );
+  }
+
+  render() {
+    const {loading, error, data} = this.state;
+    if (loading && !data) {
+      return <div style={{padding: 40, textAlign: "center"}}><Spin /></div>;
+    }
+    if (error) {
+      return <Alert type="error" message={error} />;
+    }
+    if (!data) {return null;}
+
+    return (
+      <div>
+        {this.renderTotalChart(data)}
+        {this.renderContributorCards(data)}
+      </div>
+    );
+  }
+}
+
+export default InsightsContributors;

--- a/web/src/StoreInsights.js
+++ b/web/src/StoreInsights.js
@@ -17,6 +17,7 @@ import {Button, Card, Empty, Layout, Menu, Segmented, Space, Tooltip, Typography
 import {CloudOutlined, DollarOutlined, EnvironmentOutlined, ReloadOutlined, TeamOutlined, ThunderboltOutlined} from "@ant-design/icons";
 import i18next from "i18next";
 import InsightsPulse from "./InsightsPulse";
+import InsightsContributors from "./InsightsContributors";
 
 const {Sider, Content} = Layout;
 const {Text} = Typography;
@@ -76,7 +77,7 @@ class StoreInsights extends React.Component {
 
     switch (activeSubTab) {
     case "pulse": return <InsightsPulse {...common} />;
-    case "contributors":
+    case "contributors": return <InsightsContributors {...common} />;
     case "traffic":
     case "wordcloud":
     case "cost":

--- a/web/src/backend/AnalysisBackend.js
+++ b/web/src/backend/AnalysisBackend.js
@@ -34,3 +34,15 @@ export function getStoreInsightsSummary(owner, storeName, period) {
     },
   }).then(res => Setting.handleFetchResponse(res));
 }
+
+export function getStoreContributors(owner, storeName, period, topN) {
+  const extra = topN ? `&topN=${topN}` : "";
+  const url = `${Setting.ServerUrl}/api/get-store-contributors?owner=${encodeURIComponent(owner)}&storeName=${encodeURIComponent(storeName)}&period=${encodeURIComponent(period)}${extra}`;
+  return fetch(url, {
+    method: "GET",
+    credentials: "include",
+    headers: {
+      "Accept-Language": Setting.getAcceptLanguage(),
+    },
+  }).then(res => Setting.handleFetchResponse(res));
+}

--- a/web/src/locales/en/data.json
+++ b/web/src/locales/en/data.json
@@ -730,6 +730,7 @@
   "store": {
     "About": "About",
     "Active users": "Active users",
+    "Activity over time": "Activity over time",
     "Add Permission": "Add Permission",
     "Add comment": "Add comment",
     "Affiliation": "Affiliation",

--- a/web/src/locales/zh/data.json
+++ b/web/src/locales/zh/data.json
@@ -730,6 +730,7 @@
   "store": {
     "About": "关于",
     "Active users": "活跃用户",
+    "Activity over time": "活动趋势",
     "Add Permission": "添加权限",
     "Add comment": "发表评论",
     "Affiliation": "单位",


### PR DESCRIPTION
## Summary

Adds the **Contributors** sub-tab (Part 2 of 5 for #2412), building on the Insights shell landed in #2415.

- Top: aggregate messages-over-time line across all users, with the total active-user count
- Below: grid of contributor cards (top 20 by message count), each with mini sparkline + Messages/Chats counts
- Backend endpoint aggregates from the `message` table only — no new tables

## What's in this PR

- `GET /api/get-store-contributors?owner=&storeName=&period=&topN=` — per-user rollup + per-bucket time series
- `object/store_insights.go` — `StoreContributorsData` / `ContribPoint` / `ContribUser` types + `GetStoreContributors` function
- `web/src/InsightsContributors.js` — the tab content component
- Rewires the `"contributors"` case in `StoreInsights.js` (previously the placeholder

## Fixes applied per @hsluoyz review

- **Time-window bounds** — use `util.FormatTimeForCompare` + `time.Now()` (matches the fix on `GetStoreInsightsSummary`) so string comparison against `created_time` doesn't break under non-UTC server timezones.
- **AI-message double-count** — exclude `Message.Author == "AI"` when tallying `messageCount` / per-user rollup, matching the pattern in `object/analysis.go`'s `GetStoreWordCloud`. Same filter also applied to `GetStoreInsightsSummary` in this PR, since the bug lives there too and affects the same "who contributed how much" reading.
- **Column-narrowed query** — added `.Cols("user", "chat", "created_time", "author")` on the messages query so the mediumtext body columns (`Text`, `ReasonText`, `ErrorText`, `Comment`) aren't pulled into memory for the aggregation. Same optimization applied to Pulse's query.