### PR TITLE
fix: deep-link agent tabs and Insights sub-tabs via URL

### DIFF
--- a/web/src/ManagementPage.js
+++ b/web/src/ManagementPage.js
@@ -586,6 +586,8 @@ function ManagementPage(props) {
         <Route exact path="/quick-setup" render={(props) => renderSigninIfNotSignedIn(<QuickSetupPage account={account} {...props} />)} />
         <Route exact path="/hub" render={(props) => renderSigninIfNotSignedIn(<StoreHubPage account={account} site={site} {...props} />)} />
         <Route exact path="/agents/:owner/:storeName" render={(props) => renderSigninIfNotSignedIn(<StoreViewPage account={account} {...props} />)} />
+        <Route exact path="/agents/:owner/:storeName/insights/:sub" render={(props) => renderSigninIfNotSignedIn(<StoreViewPage account={account} {...props} />)} />
+        <Route exact path="/agents/:owner/:storeName/:tab" render={(props) => renderSigninIfNotSignedIn(<StoreViewPage account={account} {...props} />)} />
         <Route exact path="/chat" render={(props) => renderSigninIfNotSignedIn(<ChatPage account={account} site={site} {...props} />)} />
         <Route exact path="/chat/:chatName" render={(props) => renderSigninIfNotSignedIn(<ChatPage account={account} site={site} {...props} />)} />
         <Route exact path="/stores/:owner/:storeName/chat" render={(props) => renderSigninIfNotSignedIn(<ChatPage account={account} site={site} {...props} />)} />

--- a/web/src/StoreHubAgentDetail.js
+++ b/web/src/StoreHubAgentDetail.js
@@ -198,11 +198,18 @@ function renderIssues() {
   );
 }
 
-function renderInsights(store) {
-  return <StoreInsights owner={store.owner} storeName={store.name} />;
+function renderInsights(store, activeSub, onSubTabChange) {
+  return (
+    <StoreInsights
+      owner={store.owner}
+      storeName={store.name}
+      activeSub={activeSub}
+      onSubTabChange={onSubTabChange}
+    />
+  );
 }
 
-function renderTabContent(account, store, activeTab, onStoreUpdate, onRefresh) {
+function renderTabContent(account, store, activeTab, activeSub, onStoreUpdate, onRefresh, onSubTabChange) {
   if (activeTab === "files") {
     return renderFiles(account, store, onStoreUpdate, onRefresh);
   }
@@ -210,12 +217,12 @@ function renderTabContent(account, store, activeTab, onStoreUpdate, onRefresh) {
     return renderIssues();
   }
   if (activeTab === "insights") {
-    return renderInsights(store);
+    return renderInsights(store, activeSub, onSubTabChange);
   }
   return renderOverview(account, store, onStoreUpdate, onRefresh);
 }
 
-function StoreHubAgentDetail({account, store, activeTab, canManage, onTabChange, onStartChat, onFork, forking, onPlaceholder, onStoreUpdate, onRefresh}) {
+function StoreHubAgentDetail({account, store, activeTab, activeSub, canManage, onTabChange, onSubTabChange, onStartChat, onFork, forking, onPlaceholder, onStoreUpdate, onRefresh}) {
   const tabItems = [
     {key: "overview", label: <span><AppstoreOutlined /> {i18next.t("store:Overview")}</span>},
     {key: "files", label: <span><FolderOpenOutlined /> {i18next.t("general:Files")}</span>},
@@ -236,7 +243,7 @@ function StoreHubAgentDetail({account, store, activeTab, canManage, onTabChange,
         onChange={onTabChange}
         style={{marginBottom: 16}}
       />
-      {renderTabContent(account, store, activeTab, onStoreUpdate, onRefresh)}
+      {renderTabContent(account, store, activeTab, activeSub, onStoreUpdate, onRefresh, onSubTabChange)}
     </div>
   );
 }

--- a/web/src/StoreInsights.js
+++ b/web/src/StoreInsights.js
@@ -49,15 +49,24 @@ class StoreInsights extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      activeSubTab: "pulse",
       period: "7d",
       refreshTick: 0,
       asOf: null,
     };
   }
 
+  componentDidUpdate(prevProps) {
+    // Sub-tab switched via URL — clear the previously displayed asOf so the
+    // shell shows "—" until the newly-mounted sub-tab reports its own fetch time.
+    if (prevProps.activeSub !== this.props.activeSub) {
+      this.setState({asOf: null});
+    }
+  }
+
   handleSubTabChange = (key) => {
-    this.setState({activeSubTab: key, asOf: null});
+    if (this.props.onSubTabChange) {
+      this.props.onSubTabChange(key);
+    }
   };
 
   handlePeriodChange = (period) => {
@@ -73,11 +82,11 @@ class StoreInsights extends React.Component {
   };
 
   renderSubTabContent() {
-    const {activeSubTab, period, refreshTick} = this.state;
-    const {owner, storeName} = this.props;
+    const {period, refreshTick} = this.state;
+    const {owner, storeName, activeSub} = this.props;
     const common = {owner, storeName, period, refreshTick, onLoaded: this.handleChildLoaded};
 
-    switch (activeSubTab) {
+    switch (activeSub) {
     case "pulse": return <InsightsPulse {...common} />;
     case "contributors": return <InsightsContributors {...common} />;
     case "traffic": return <InsightsTraffic {...common} />;
@@ -93,7 +102,8 @@ class StoreInsights extends React.Component {
   }
 
   render() {
-    const {activeSubTab, period, asOf} = this.state;
+    const {period, asOf} = this.state;
+    const activeSub = this.props.activeSub || "pulse";
 
     return (
       <Layout style={{background: "transparent"}}>
@@ -103,7 +113,7 @@ class StoreInsights extends React.Component {
         >
           <Menu
             mode="inline"
-            selectedKeys={[activeSubTab]}
+            selectedKeys={[activeSub]}
             onClick={({key}) => this.handleSubTabChange(key)}
             style={{background: "transparent", border: "none"}}
             items={SUB_TABS.map((t) => ({

--- a/web/src/StoreViewPage.js
+++ b/web/src/StoreViewPage.js
@@ -20,6 +20,33 @@ import i18next from "i18next";
 import {getChatUrl} from "./StoreHubDrawer";
 import StoreHubAgentDetail from "./StoreHubAgentDetail";
 
+const VALID_TABS = new Set(["overview", "files", "issues", "insights"]);
+const VALID_INSIGHTS_SUBS = new Set(["pulse", "contributors", "traffic", "wordcloud", "cost"]);
+
+function resolveActiveTab(match) {
+  const {tab, sub} = match.params;
+  // /agents/:owner/:storeName/insights/:sub → activeTab = "insights"
+  if (sub && VALID_INSIGHTS_SUBS.has(sub)) {return "insights";}
+  if (tab && VALID_TABS.has(tab)) {return tab;}
+  return "overview";
+}
+
+function resolveActiveSub(match) {
+  const {sub} = match.params;
+  if (sub && VALID_INSIGHTS_SUBS.has(sub)) {return sub;}
+  return "pulse";
+}
+
+function buildTabUrl(owner, storeName, tab, sub) {
+  if (tab === "insights") {
+    return `/agents/${owner}/${storeName}/insights/${sub || "pulse"}`;
+  }
+  if (!tab || tab === "overview") {
+    return `/agents/${owner}/${storeName}`;
+  }
+  return `/agents/${owner}/${storeName}/${tab}`;
+}
+
 class StoreViewPage extends React.Component {
   constructor(props) {
     super(props);
@@ -29,12 +56,23 @@ class StoreViewPage extends React.Component {
       store: null,
       loading: true,
       forking: false,
-      activeTab: "overview",
     };
   }
 
   componentDidMount() {
     this.getStore();
+  }
+
+  componentDidUpdate(prevProps) {
+    // Route changed to a different store — refetch. Sub-tab / tab changes
+    // reuse the already-loaded store, so we only refetch when the store
+    // coordinates in the URL actually change.
+    const {owner: prevOwner, storeName: prevName} = prevProps.match.params;
+    const {owner, storeName} = this.props.match.params;
+    if (owner !== prevOwner || storeName !== prevName) {
+      this.setState({owner, storeName, store: null, loading: true},
+        () => this.getStore(owner, storeName));
+    }
   }
 
   // Page-view logging runs entirely on the backend (see routers/TrackStoreVisit).
@@ -84,13 +122,8 @@ class StoreViewPage extends React.Component {
         if (res.status === "ok") {
           const forkedStore = res.data;
           Setting.showMessage("success", i18next.t("store:Forked successfully"));
+          // Route change picks up in componentDidUpdate → refetch happens there.
           this.props.history.push(`/agents/${forkedStore.owner}/${forkedStore.name}`);
-          this.setState({
-            owner: forkedStore.owner,
-            storeName: forkedStore.name,
-            store: null,
-            loading: true,
-          }, () => this.getStore(forkedStore.owner, forkedStore.name));
         } else {
           Setting.showMessage("error", `${i18next.t("store:Fork failed")}: ${res.msg}`);
         }
@@ -115,11 +148,19 @@ class StoreViewPage extends React.Component {
       this.props.history.push(`/stores/${store.owner}/${store.name}`);
       return;
     }
-    this.setState({activeTab: key});
+    const {store} = this.state;
+    if (!store) {return;}
+    this.props.history.push(buildTabUrl(store.owner, store.name, key));
+  }
+
+  handleSubTabChange(sub) {
+    const {store} = this.state;
+    if (!store) {return;}
+    this.props.history.push(buildTabUrl(store.owner, store.name, "insights", sub));
   }
 
   render() {
-    const {store, loading, forking, activeTab} = this.state;
+    const {store, loading, forking} = this.state;
 
     if (loading) {
       return (
@@ -134,13 +175,18 @@ class StoreViewPage extends React.Component {
     }
 
     const canManage = this.canManageStore(store);
+    const activeTab = resolveActiveTab(this.props.match);
+    const activeSub = resolveActiveSub(this.props.match);
+
     return (
       <StoreHubAgentDetail
         account={this.props.account}
         store={store}
         activeTab={activeTab}
+        activeSub={activeSub}
         canManage={canManage}
         onTabChange={(key) => this.handleTabChange(key)}
+        onSubTabChange={(sub) => this.handleSubTabChange(sub)}
         onStartChat={() => this.handleStartChat()}
         onFork={() => this.handleFork()}
         forking={forking}


### PR DESCRIPTION
## Summary

Makes the top-level agent tabs (Overview / Files / Issues / Insights) and the Insights sub-tabs (Pulse / Contributors / Traffic / Word Cloud / Cost) URL-driven, so F5 preserves the user's position and links to specific sub-tabs are shareable.

Bonus: bookmarks that outlive a rename or a removed sub-tab don't 404 — unknown values fall back to defaults (`overview` / `pulse`).

## URL structure

| Route | Lands on |
|---|---|
| `/agents/:owner/:name` | Overview (default) |
| `/agents/:owner/:name/files` | Files |
| `/agents/:owner/:name/issues` | Issues |
| `/agents/:owner/:name/insights/pulse` | Insights - Pulse |
| `/agents/:owner/:name/insights/contributors` | Insights - Contributors |
| `/agents/:owner/:name/insights/traffic` | Insights - Traffic |
| `/agents/:owner/:name/insights/wordcloud` | Insights - Word Cloud |
| `/agents/:owner/:name/insights/cost` | Insights - Cost |

## Changes

- Two new routes in `ManagementPage.js` — `/:tab` and `/insights/:sub`, both mount `StoreViewPage`.
- `StoreViewPage` derives `activeTab` / `activeSub` from `match.params` instead of holding them in state. Tab clicks now `history.push` a URL instead of calling `setState`. `componentDidUpdate` refetches only when the store's `(owner, storeName)` actually change, so switching sub-tabs reuses the already-loaded store.
- `StoreInsights` now takes `activeSub` as a prop from its parent; the Menu `onClick` calls a passed-in callback instead of self-mutating state. That way one source of truth (the URL) drives both the sidebar highlight and the content.
- `StoreHubAgentDetail` forwards `activeSub` / `onSubTabChange` through to `StoreInsights`, otherwise unchanged.
