### PR TITLE
fix: fix i18n insights breadcrumb sub-tabs and period range labels

### DIFF
--- a/web/src/StoreInsights.js
+++ b/web/src/StoreInsights.js
@@ -26,9 +26,9 @@ const {Sider, Content} = Layout;
 const {Text} = Typography;
 
 const PERIOD_OPTIONS = [
-  {value: "24h", label: "24h"},
-  {value: "7d", label: "7d"},
-  {value: "30d", label: "30d"},
+  {value: "24h", i18nKey: "store:24h"},
+  {value: "7d", i18nKey: "store:7d"},
+  {value: "30d", i18nKey: "store:30d"},
 ];
 
 const SUB_TABS = [
@@ -133,7 +133,7 @@ class StoreInsights extends React.Component {
           >
             <Space size="middle">
               <Segmented
-                options={PERIOD_OPTIONS}
+                options={PERIOD_OPTIONS.map((o) => ({value: o.value, label: i18next.t(o.i18nKey)}))}
                 value={period}
                 onChange={this.handlePeriodChange}
               />

--- a/web/src/common/BreadcrumbBar.js
+++ b/web/src/common/BreadcrumbBar.js
@@ -46,6 +46,17 @@ const RESOURCE_LABELS = {
   "scales": "general:Scales",
   "forms": "general:Forms",
   "sysinfo": "general:System Info",
+  // Store detail tabs
+  "overview": "store:Overview",
+  "issues": "store:Issues",
+  "insights": "store:Insights",
+  "settings": "general:Settings",
+  // Insights sub-tabs (deep-linked as the last path segment)
+  "pulse": "store:Pulse",
+  "contributors": "store:Contributors",
+  "traffic": "store:Traffic",
+  "wordcloud": "store:Word Cloud",
+  "cost": "store:Cost",
 };
 
 function buildBreadcrumbItems(uri) {

--- a/web/src/locales/en/data.json
+++ b/web/src/locales/en/data.json
@@ -728,6 +728,9 @@
     "Skill folder path placeholder": "e.g. /Users/alice/skills/my-skill  or  D:\\skills\\my-skill"
   },
   "store": {
+    "24h": "24h",
+    "30d": "30d",
+    "7d": "7d",
     "About": "About",
     "Active users": "Active users",
     "Activity over time": "Activity over time",

--- a/web/src/locales/zh/data.json
+++ b/web/src/locales/zh/data.json
@@ -728,6 +728,9 @@
     "Skill folder path placeholder": "例如：/Users/alice/skills/my-skill或D:\\skills\\my-skill"
   },
   "store": {
+    "24h": "24小时",
+    "30d": "30天",
+    "7d": "7天",
     "About": "关于",
     "Active users": "活跃用户",
     "Activity over time": "活动趋势",


### PR DESCRIPTION
### **Summary**
- Translate the store detail tab and Insights sub-tab segments in the breadcrumb (overview/issues/insights/settings, pulse/contributors/ traffic/wordcloud/cost) instead of rendering the raw URL slug (e.g. "pulse").
- Make the 24h / 7d / 30d period toggle translatable via store:24h/7d/30d (zh: 24小时/7天/30天) instead of hardcoded labels.