### PR TITLE
feat: show user display name/avatar with a profile hover card

### DIFF
--- a/controllers/casdoor_user.go
+++ b/controllers/casdoor_user.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/the-open-agent/openagent/auth"
 	"github.com/the-open-agent/openagent/conf"
+	"github.com/the-open-agent/openagent/object"
 )
 
 func userMatchesCasdoorOrganization(configOrg string, u *auth.User) bool {
@@ -107,4 +108,53 @@ func (c *ApiController) GetOrganizationUsers() {
 	})
 
 	c.ResponseOk(out)
+}
+
+// GetUserInfo returns the display name and avatar for a single user by name.
+// It is used by the reusable frontend UserLabel component to resolve a bare
+// username into a real profile (Casdoor display name + avatar). Any signed-in
+// user may call it; only low-sensitivity display fields are returned.
+// @router /get-user-info [get]
+func (c *ApiController) GetUserInfo() {
+	if _, ok := c.RequireSignedIn(); !ok {
+		return
+	}
+
+	name := c.Input().Get("name")
+	if name == "" {
+		c.ResponseError(c.T("application:Missing required parameters"))
+		return
+	}
+
+	// Fallback so the frontend always has something to render.
+	info := organizationUser{Name: name}
+
+	sessionUser := c.GetSessionUser()
+	if sessionUser != nil && sessionUser.Owner == object.UserOwner {
+		// Basic (local) login mode — resolve against the local user table.
+		user, err := object.GetUserByRuntimeName(name)
+		if err != nil {
+			c.ResponseError(err.Error())
+			return
+		}
+		if user != nil {
+			info.DisplayName = user.DisplayName
+			info.Avatar = user.Avatar
+		}
+	} else if conf.IsCasdoorAvailable() {
+		user, err := auth.GetUser(name)
+		if err != nil {
+			c.ResponseError(err.Error())
+			return
+		}
+		if user != nil {
+			info.DisplayName = user.DisplayName
+			info.Avatar = user.Avatar
+			if info.Avatar == "" {
+				info.Avatar = user.PermanentAvatar
+			}
+		}
+	}
+
+	c.ResponseOk(info)
 }

--- a/routers/router.go
+++ b/routers/router.go
@@ -79,6 +79,7 @@ func initAPI() {
 	beego.Router("/api/get-store-cost-series", &controllers.ApiController{}, "GET:GetStoreCostSeries")
 	beego.Router("/api/get-store-names", &controllers.ApiController{}, "GET:GetStoreNames")
 	beego.Router("/api/get-organization-users", &controllers.ApiController{}, "GET:GetOrganizationUsers")
+	beego.Router("/api/get-user-info", &controllers.ApiController{}, "GET:GetUserInfo")
 	beego.Router("/api/add-shared-store", &controllers.ApiController{}, "POST:AddSharedStore")
 	beego.Router("/api/fork-store", &controllers.ApiController{}, "POST:ForkStore")
 	beego.Router("/api/claim-store", &controllers.ApiController{}, "POST:ClaimStore")

--- a/web/src/InsightsContributors.js
+++ b/web/src/InsightsContributors.js
@@ -13,12 +13,12 @@
 // limitations under the License.
 
 import React from "react";
-import {Alert, Avatar, Card, Col, Empty, Row, Spin, Statistic, Typography} from "antd";
+import {Alert, Card, Col, Empty, Row, Spin, Statistic, Typography} from "antd";
 import {TeamOutlined} from "@ant-design/icons";
 import ReactEcharts from "echarts-for-react";
 import i18next from "i18next";
 import * as AnalysisBackend from "./backend/AnalysisBackend";
-import * as Setting from "./Setting";
+import UserLabel from "./common/UserLabel";
 
 const LINE_COLOR = "#1677ff";
 
@@ -137,15 +137,7 @@ class InsightsContributors extends React.Component {
           <Col key={c.user} xs={24} sm={12} lg={8} xl={6}>
             <Card size="small" styles={{body: {padding: 14}}}>
               <div style={{display: "flex", alignItems: "center", gap: 10, marginBottom: 8, minWidth: 0}}>
-                <Avatar
-                  size="default"
-                  style={{backgroundColor: Setting.getAvatarColor(c.user), flexShrink: 0}}
-                >
-                  {c.user[0].toUpperCase()}
-                </Avatar>
-                <Typography.Text strong ellipsis={{tooltip: c.user}} style={{minWidth: 0, flex: 1}}>
-                  {c.user}
-                </Typography.Text>
+                <UserLabel user={c.user} account={this.props.account} size="default" strong nameStyle={{flex: 1}} />
               </div>
               <Row gutter={8}>
                 <Col span={12}>

--- a/web/src/InsightsPulse.js
+++ b/web/src/InsightsPulse.js
@@ -13,12 +13,12 @@
 // limitations under the License.
 
 import React from "react";
-import {Alert, Avatar, Card, Col, Empty, Progress, Row, Spin, Statistic, Typography} from "antd";
+import {Alert, Card, Col, Empty, Progress, Row, Spin, Statistic, Typography} from "antd";
 import {CommentOutlined, FileOutlined, MessageOutlined, TeamOutlined, ThunderboltOutlined} from "@ant-design/icons";
 import ReactEcharts from "echarts-for-react";
 import i18next from "i18next";
 import * as AnalysisBackend from "./backend/AnalysisBackend";
-import * as Setting from "./Setting";
+import UserLabel from "./common/UserLabel";
 
 const SPARK_COLOR = "#1677ff";
 
@@ -138,12 +138,7 @@ class InsightsPulse extends React.Component {
         <div style={{display: "grid", rowGap: 10}}>
           {topUsers.map((u) => (
             <div key={u.user} style={{display: "grid", gridTemplateColumns: "180px 1fr 80px", gap: 12, alignItems: "center"}}>
-              <div style={{display: "flex", alignItems: "center", gap: 8, minWidth: 0}}>
-                <Avatar size="small" style={{backgroundColor: Setting.getAvatarColor(u.user), flexShrink: 0}}>
-                  {u.user[0].toUpperCase()}
-                </Avatar>
-                <Typography.Text ellipsis={{tooltip: u.user}} style={{minWidth: 0}}>{u.user}</Typography.Text>
-              </div>
+              <UserLabel user={u.user} account={this.props.account} size="small" />
               <Progress
                 percent={Math.round((u.messageCount / max) * 100)}
                 showInfo={false}

--- a/web/src/StoreHubAgentDetail.js
+++ b/web/src/StoreHubAgentDetail.js
@@ -198,9 +198,10 @@ function renderIssues() {
   );
 }
 
-function renderInsights(store, activeSub, onSubTabChange) {
+function renderInsights(account, store, activeSub, onSubTabChange) {
   return (
     <StoreInsights
+      account={account}
       owner={store.owner}
       storeName={store.name}
       activeSub={activeSub}
@@ -217,7 +218,7 @@ function renderTabContent(account, store, activeTab, activeSub, onStoreUpdate, o
     return renderIssues();
   }
   if (activeTab === "insights") {
-    return renderInsights(store, activeSub, onSubTabChange);
+    return renderInsights(account, store, activeSub, onSubTabChange);
   }
   return renderOverview(account, store, onStoreUpdate, onRefresh);
 }

--- a/web/src/StoreInsights.js
+++ b/web/src/StoreInsights.js
@@ -84,9 +84,9 @@ class StoreInsights extends React.Component {
 
   renderSubTabContent() {
     const {period, refreshTick} = this.state;
-    const {owner, storeName} = this.props;
+    const {account, owner, storeName} = this.props;
     const activeSub = this.props.activeSub || "pulse";
-    const common = {owner, storeName, period, refreshTick, onLoaded: this.handleChildLoaded};
+    const common = {account, owner, storeName, period, refreshTick, onLoaded: this.handleChildLoaded};
 
     switch (activeSub) {
     case "pulse": return <InsightsPulse {...common} />;

--- a/web/src/TaskListPage.js
+++ b/web/src/TaskListPage.js
@@ -14,19 +14,18 @@
 
 import React from "react";
 import {Link} from "react-router-dom";
-import {Avatar, Button, Input, Popconfirm, Popover, Space, Table, Tag, Tooltip} from "antd";
-import {DeleteOutlined, EditOutlined, FilePdfOutlined, FileWordOutlined, UserOutlined} from "@ant-design/icons";
+import {Button, Input, Popconfirm, Popover, Table, Tag, Tooltip} from "antd";
+import {DeleteOutlined, EditOutlined, FilePdfOutlined, FileWordOutlined} from "@ant-design/icons";
 import moment from "moment";
 import BaseListPage from "./BaseListPage";
 import * as Setting from "./Setting";
 import * as TaskBackend from "./backend/TaskBackend";
 import * as ScaleBackend from "./backend/ScaleBackend";
 import * as ProviderBackend from "./backend/ProviderBackend";
-import * as OrganizationUserBackend from "./backend/OrganizationUserBackend";
 import i18next from "i18next";
 import * as ConfTask from "./ConfTask";
-import * as Conf from "./Conf";
 import TaskAnalysisReport from "./TaskAnalysisReport";
+import UserLabel from "./common/UserLabel";
 
 const {TextArea} = Input;
 
@@ -62,7 +61,6 @@ class TaskListPage extends BaseListPage {
       ...this.state,
       modelProviders: [],
       publicScales: [],
-      organizationUsers: [],
       pagination: {
         ...this.state.pagination,
         pageSize: 100,
@@ -77,11 +75,6 @@ class TaskListPage extends BaseListPage {
         this.setState({publicScales: res.data});
       }
     });
-    OrganizationUserBackend.getOrganizationUsers().then((res) => {
-      if (res.status === "ok" && Array.isArray(res.data)) {
-        this.setState({organizationUsers: res.data});
-      }
-    });
     if (Setting.isAdminUser(this.props.account)) {
       ProviderBackend.getProviders(this.props.account.name).then((res) => {
         if (res.status === "ok" && res.data) {
@@ -89,11 +82,6 @@ class TaskListPage extends BaseListPage {
         }
       });
     }
-  }
-
-  getUserAvatar(username) {
-    const user = this.state.organizationUsers.find((u) => u.name === username);
-    return user?.avatar || "";
   }
 
   getScalePreviewText(record) {
@@ -209,20 +197,8 @@ class TaskListPage extends BaseListPage {
         width: "90px",
         sorter: (a, b) => (a.owner || "").localeCompare(b.owner || ""),
         ...this.getColumnSearchProps("owner"),
-        render: (text, record, index) => {
-          const avatarUrl = this.getUserAvatar(text);
-          return (
-            <Space size={6}>
-              {avatarUrl ? (
-                <Avatar size={22} src={avatarUrl} />
-              ) : (
-                <Avatar size={22} icon={<UserOutlined />} />
-              )}
-              <a target="_blank" rel="noreferrer" href={Setting.getMyProfileUrl(this.props.account).replace("/account", `/users/${Conf.AuthConfig.organizationName}/${text}`)}>
-                {text}
-              </a>
-            </Space>
-          );
+        render: (text) => {
+          return <UserLabel user={text} account={this.props.account} size={22} />;
         },
       },
       {

--- a/web/src/backend/UserBackend.js
+++ b/web/src/backend/UserBackend.js
@@ -1,0 +1,51 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as Setting from "../Setting";
+
+// Module-level cache of resolved user info keyed by user name. The value is the
+// in-flight (or settled) Promise so that many UserLabel instances asking for the
+// same user share a single request. Resolved shape: {name, displayName, avatar}.
+const userInfoCache = new Map();
+
+function fetchUserInfo(name) {
+  return fetch(`${Setting.ServerUrl}/api/get-user-info?name=${encodeURIComponent(name)}`, {
+    method: "GET",
+    credentials: "include",
+    headers: {
+      "Accept-Language": Setting.getAcceptLanguage(),
+    },
+  })
+    .then(res => Setting.handleFetchResponse(res))
+    .then((res) => {
+      if (res.status === "ok" && res.data) {
+        return res.data;
+      }
+      return {name};
+    })
+    .catch(() => ({name}));
+}
+
+// getUserInfo returns a Promise that resolves to {name, displayName, avatar}.
+// Results are memoized for the lifetime of the page so repeated lookups of the
+// same user (e.g. across insights cards or comment threads) are free.
+export function getUserInfo(name) {
+  if (!name) {
+    return Promise.resolve({name: ""});
+  }
+  if (!userInfoCache.has(name)) {
+    userInfoCache.set(name, fetchUserInfo(name));
+  }
+  return userInfoCache.get(name);
+}

--- a/web/src/chat/MessageItem.js
+++ b/web/src/chat/MessageItem.js
@@ -31,6 +31,7 @@ import ToolCallSection from "./ToolCallSection";
 import ReasoningSection from "./ReasoningSection";
 import StatusStrip from "./StatusStrip";
 import GeneratedResourceList, {extractGeneratedResources} from "./GeneratedResourceList";
+import UserLabel from "../common/UserLabel";
 
 const MessageItem = ({
   message,
@@ -175,6 +176,27 @@ const MessageItem = ({
     setAvatarSrc(Setting.getAvatarFallback());
   };
 
+  // AI messages keep the plain avatar; human messages wrap the same avatar in a
+  // UserLabel so hovering shows the sender's profile card and clicking opens
+  // their Casdoor profile page. message.author is the sender's username here.
+  const renderAvatarNode = () => {
+    const avatarEl = <Avatar src={avatarSrc} onError={handleAvatarError} />;
+    if (message.author === "AI") {
+      return avatarEl;
+    }
+    const isSelf = account && message.author === account.name;
+    return (
+      <UserLabel
+        user={message.author}
+        account={account}
+        displayName={isSelf ? account.displayName : undefined}
+        avatar={isSelf ? account.avatar : undefined}
+      >
+        {avatarEl}
+      </UserLabel>
+    );
+  };
+
   const renderMessageContent = () => {
     if (message.errorText !== "") {
       const isNoModelProvider = message.errorText.includes("Please add a model provider first") || message.errorText.includes("请先添加模型提供商");
@@ -299,7 +321,7 @@ const MessageItem = ({
               step: 2,
               interval: 50,
             } : undefined}
-            avatar={<Avatar src={avatarSrc} onError={handleAvatarError} />}
+            avatar={renderAvatarNode()}
             styles={{
               content: {
                 borderRadius: "4px 18px 18px 18px",
@@ -423,7 +445,7 @@ const MessageItem = ({
             step: 2,
             interval: 50,
           } : undefined}
-          avatar={<Avatar src={avatarSrc} onError={handleAvatarError} />}
+          avatar={renderAvatarNode()}
           styles={{
             content: isUserMessage ? {
               borderRadius: "18px 18px 4px 18px",

--- a/web/src/comment/CommentArea.js
+++ b/web/src/comment/CommentArea.js
@@ -13,11 +13,12 @@
 // limitations under the License.
 
 import React, {useCallback, useEffect, useState} from "react";
-import {Avatar, Button, Card, Empty, Input, List, Modal, Pagination, Space, Typography} from "antd";
+import {Button, Card, Empty, Input, List, Modal, Pagination, Space, Typography} from "antd";
 import {CommentOutlined, DeleteOutlined} from "@ant-design/icons";
 import i18next from "i18next";
 import * as CommentBackend from "../backend/CommentBackend";
 import * as Setting from "../Setting";
+import UserLabel from "../common/UserLabel";
 
 const {Text, Paragraph} = Typography;
 const {TextArea} = Input;
@@ -125,12 +126,10 @@ function ReplyItem({account, reply, parentComment, targetOwner, replyTo, replyVa
   return (
     <div style={{padding: "10px 0", borderBottom: "1px solid var(--ant-color-border-secondary)"}}>
       <div style={{display: "flex", gap: 10, alignItems: "flex-start"}}>
-        <Avatar size={28} style={{backgroundColor: Setting.getAvatarColor(reply.owner), flexShrink: 0}}>
-          {(reply.owner || "?")[0].toUpperCase()}
-        </Avatar>
+        <UserLabel user={reply.owner} account={account} size={28} avatarOnly />
         <div style={{flex: 1, minWidth: 0}}>
           <Space size={8} wrap>
-            <Text strong>{reply.owner}</Text>
+            <UserLabel user={reply.owner} account={account} showAvatar={false} strong />
             <Text type="secondary" style={{fontSize: 12}}>{getCommentTime(reply.createdTime)}</Text>
           </Space>
           <ReplyQuote parentComment={parentComment} />
@@ -163,12 +162,10 @@ function RootCommentItem({account, comment, targetOwner, replyTo, replyValue, re
   return (
     <div style={{padding: "14px 0", borderBottom: "1px solid var(--ant-color-border-secondary)"}}>
       <div style={{display: "flex", gap: 12, alignItems: "flex-start"}}>
-        <Avatar size={32} style={{backgroundColor: Setting.getAvatarColor(comment.owner), flexShrink: 0}}>
-          {(comment.owner || "?")[0].toUpperCase()}
-        </Avatar>
+        <UserLabel user={comment.owner} account={account} size={32} avatarOnly />
         <div style={{flex: 1, minWidth: 0}}>
           <Space size={8} wrap>
-            <Text strong>{comment.owner}</Text>
+            <UserLabel user={comment.owner} account={account} showAvatar={false} strong />
             <Text type="secondary" style={{fontSize: 12}}>{getCommentTime(comment.createdTime)}</Text>
           </Space>
           <Paragraph style={{margin: "6px 0 8px", whiteSpace: "pre-wrap", wordBreak: "break-word"}}>

--- a/web/src/common/UserLabel.js
+++ b/web/src/common/UserLabel.js
@@ -1,0 +1,183 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from "react";
+import {Avatar, Button, Popover, Typography} from "antd";
+import {ExportOutlined} from "@ant-design/icons";
+import i18next from "i18next";
+import * as UserBackend from "../backend/UserBackend";
+import * as Setting from "../Setting";
+
+const {Text} = Typography;
+
+// UserLabel renders a user's real Casdoor display name + avatar with a GitHub-style
+// hover card. Hovering pops a small profile card; clicking the name/avatar (or the
+// "View profile" button in the card) opens that user's Casdoor profile page.
+//
+// It only needs a username; the display name + avatar are resolved lazily via a
+// shared, memoized backend lookup, so the same component drops into any page
+// (insights, comments, authors, ...) that has a bare username on hand.
+class UserLabel extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      displayName: props.displayName || "",
+      avatar: props.avatar || "",
+    };
+    this._isMounted = false;
+  }
+
+  componentDidMount() {
+    this._isMounted = true;
+    // Resolve only what the caller did not already supply.
+    if (this.props.user && (!this.props.displayName || this.props.avatar === undefined)) {
+      UserBackend.getUserInfo(this.props.user).then((info) => {
+        if (this._isMounted && info) {
+          this.setState((prev) => ({
+            displayName: prev.displayName || info.displayName || "",
+            avatar: prev.avatar || info.avatar || "",
+          }));
+        }
+      });
+    }
+  }
+
+  componentWillUnmount() {
+    this._isMounted = false;
+  }
+
+  getDisplayName() {
+    return this.state.displayName || Setting.getShortName(this.props.user || "");
+  }
+
+  getProfileUrl() {
+    const {user, account} = this.props;
+    if (!user || !account || Setting.isBasicLoginMode(account)) {
+      return null;
+    }
+    try {
+      const url = Setting.getUserProfileUrl(user, account);
+      return url && url !== "#" ? url : null;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  openProfile = (e) => {
+    if (e) {
+      e.stopPropagation();
+      e.preventDefault();
+    }
+    const url = this.getProfileUrl();
+    if (url) {
+      Setting.openLink(url);
+    }
+  };
+
+  renderAvatar(size) {
+    const {user} = this.props;
+    const {avatar} = this.state;
+    const name = this.getDisplayName();
+    const initial = (name || user || "?").charAt(0).toUpperCase();
+    if (avatar) {
+      return <Avatar size={size} src={avatar} style={{flexShrink: 0}}>{initial}</Avatar>;
+    }
+    return (
+      <Avatar size={size} style={{backgroundColor: Setting.getAvatarColor(user || name), flexShrink: 0}}>
+        {initial}
+      </Avatar>
+    );
+  }
+
+  renderCard() {
+    const {user} = this.props;
+    const name = this.getDisplayName();
+    const profileUrl = this.getProfileUrl();
+    return (
+      <div style={{width: 240}}>
+        <div style={{display: "flex", alignItems: "center", gap: 12, marginBottom: profileUrl ? 12 : 0}}>
+          {this.renderAvatar(48)}
+          <div style={{minWidth: 0, flex: 1}}>
+            <div style={{fontSize: 15, fontWeight: 600, lineHeight: 1.3, wordBreak: "break-word"}}>{name}</div>
+            <Text type="secondary" style={{fontSize: 13}} ellipsis={{tooltip: user}}>@{user}</Text>
+          </div>
+        </div>
+        {profileUrl && (
+          <Button block size="small" icon={<ExportOutlined />} onClick={this.openProfile}>
+            {i18next.t("general:View profile")}
+          </Button>
+        )}
+      </div>
+    );
+  }
+
+  render() {
+    const {user, size = "small", showAvatar = true, showName = true, avatarOnly = false, strong = false, nameStyle = {}, children} = this.props;
+    if (!user) {
+      return children || null;
+    }
+
+    const name = this.getDisplayName();
+    const profileUrl = this.getProfileUrl();
+    const clickable = !!profileUrl;
+    const withAvatar = avatarOnly || showAvatar;
+    const withName = !avatarOnly && showName;
+
+    // When children are provided (e.g. a pre-rendered chat avatar), use them as
+    // the trigger and only layer on the hover card + profile link, leaving the
+    // caller's own rendering untouched.
+    const trigger = (
+      <span
+        onClick={clickable ? this.openProfile : undefined}
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: !children && withAvatar && withName ? 8 : 0,
+          minWidth: 0,
+          maxWidth: "100%",
+          cursor: clickable ? "pointer" : "default",
+          verticalAlign: "middle",
+        }}
+      >
+        {children ? children : (
+          <>
+            {withAvatar && this.renderAvatar(size)}
+            {withName && (
+              <Text
+                strong={strong}
+                ellipsis={{tooltip: name}}
+                style={{minWidth: 0, ...nameStyle}}
+              >
+                {name}
+              </Text>
+            )}
+          </>
+        )}
+      </span>
+    );
+
+    return (
+      <Popover
+        content={this.renderCard()}
+        trigger="hover"
+        placement="topLeft"
+        mouseEnterDelay={0.3}
+      >
+        {trigger}
+      </Popover>
+    );
+  }
+}
+
+export default UserLabel;

--- a/web/src/locales/en/data.json
+++ b/web/src/locales/en/data.json
@@ -439,6 +439,7 @@
     "Vectors failed to generate": "Vectors failed to generate",
     "Vectors generated successfully": "Vectors generated successfully",
     "View": "View",
+    "View profile": "View profile",
     "Visible": "Visible",
     "Visitors": "Visitors",
     "Website": "Website",

--- a/web/src/locales/zh/data.json
+++ b/web/src/locales/zh/data.json
@@ -439,6 +439,7 @@
     "Vectors failed to generate": "向量生成失败",
     "Vectors generated successfully": "向量生成成功",
     "View": "查看",
+    "View profile": "查看主页",
     "Visible": "是否可见",
     "Visitors": "访客统计",
     "Website": "网站",


### PR DESCRIPTION
### Summary
Add a reusable UserLabel component that renders a user's real display name and avatar with a GitHub-style hover card, and links to their identity provider (Casdoor) profile page on click. Bare usernames are resolved via a new signed-in get-user-info endpoint (Casdoor users, and local users in basic login mode) with a memoized, request-deduped frontend cache.

Wire UserLabel into the places that previously rendered a raw username + initials avatar: Insights Pulse active users, Insights Contributors, store comments, the Tasks user column, and chat message avatars.