### PR TITLE
fix: Fix comment loading error after forking an Agent Hub agent

### DIFF
--- a/web/src/StoreHubAgentDetail.js
+++ b/web/src/StoreHubAgentDetail.js
@@ -166,6 +166,7 @@ function renderFiles(account, store, onStoreUpdate, onRefresh) {
 
 function renderOverview(account, store, onStoreUpdate, onRefresh) {
   const isExternalStore = Boolean(store.endpoint || store.hubDbName);
+  const areCommentsUnavailable = isExternalStore || store.publishState !== "Published";
 
   return (
     <Row gutter={[16, 16]}>
@@ -178,8 +179,8 @@ function renderOverview(account, store, onStoreUpdate, onRefresh) {
             targetType="agenthub"
             targetKey={`${store.owner}/${store.name}`}
             targetOwner={store.owner}
-            disabled={isExternalStore}
-            unavailableText={i18next.t("store:Comments are unavailable for external agents")}
+            disabled={areCommentsUnavailable}
+            unavailableText={isExternalStore ? i18next.t("store:Comments are unavailable for external agents") : i18next.t("store:Comments are unavailable")}
           />
         </div>
       </Col>


### PR DESCRIPTION
## Summary

- Disable the Agent Hub comment area when the current store is not published
- Keep existing behavior for external agents, where comments are also unavailable
- Prevent forked agents from immediately loading comments before they are published

## Reason

Forked stores are created with an empty `publishState`. The comment API only treats published Agent Hub stores as valid comment targets, so the fork success redirect could trigger:

`Failed to get: Comment target does not exist`