### PR TITLE
feat: support pasting files into chat input

### DIFF
--- a/web/src/chat/ChatInput.js
+++ b/web/src/chat/ChatInput.js
@@ -19,7 +19,7 @@ import {CloseOutlined, GlobalOutlined} from "@ant-design/icons";
 import ChatFileInput from "./ChatFileInput";
 import UploadFileArea from "./UploadFileArea";
 import ChatInputMenu from "./ChatInputMenu";
-import {getClipboardFiles, isClipboardImageFile} from "./clipboardFiles";
+import {ChatInputAcceptedFileTypes, getClipboardFiles, isSupportedClipboardFile} from "./clipboardFiles";
 import * as Setting from "../Setting";
 import i18next from "i18next";
 
@@ -104,7 +104,7 @@ const ChatInput = React.forwardRef(({
   function handleFileUploadClick() {
     const input = document.createElement("input");
     input.type = "file";
-    input.accept = "image/*, .txt, .md, .yaml, .csv, .docx, .pdf, .xlsx, .pptx";
+    input.accept = ChatInputAcceptedFileTypes;
     input.multiple = false;
     input.style.display = "none";
 
@@ -130,8 +130,8 @@ const ChatInput = React.forwardRef(({
   }
 
   async function handlePaste(event) {
-    const imageFiles = getClipboardFiles(event, isClipboardImageFile);
-    if (imageFiles.length === 0) {
+    const pastedFiles = getClipboardFiles(event, isSupportedClipboardFile);
+    if (pastedFiles.length === 0) {
       return;
     }
 
@@ -141,7 +141,7 @@ const ChatInput = React.forwardRef(({
       return;
     }
 
-    for (const file of imageFiles) {
+    for (const file of pastedFiles) {
       await handleInputChange(file);
     }
   }

--- a/web/src/chat/clipboardFiles.js
+++ b/web/src/chat/clipboardFiles.js
@@ -12,14 +12,56 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+export const ChatInputAcceptedFileTypes = "image/*, .txt, .md, .yaml, .csv, .docx, .pdf, .xlsx, .pptx";
+
+const supportedFileExtensions = new Set([
+  "txt",
+  "md",
+  "yaml",
+  "csv",
+  "docx",
+  "pdf",
+  "xlsx",
+  "pptx",
+]);
+
+const supportedFileTypes = new Set([
+  "text/plain",
+  "text/markdown",
+  "text/yaml",
+  "text/csv",
+  "application/pdf",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+]);
+
 export function getClipboardFiles(event, acceptFile) {
-  const items = Array.from(event.clipboardData?.items || []);
-  return items
+  const clipboardData = event.clipboardData;
+  const itemFiles = Array.from(clipboardData?.items || [])
     .filter(item => item.kind === "file")
-    .map(item => item.getAsFile())
-    .filter(file => file && acceptFile(file));
+    .map(item => item.getAsFile());
+  const dataTransferFiles = Array.from(clipboardData?.files || []);
+  const fileMap = new Map();
+
+  [...itemFiles, ...dataTransferFiles]
+    .filter(file => file && acceptFile(file))
+    .forEach(file => {
+      fileMap.set(`${file.name}:${file.type}:${file.size}:${file.lastModified}`, file);
+    });
+
+  return Array.from(fileMap.values());
 }
 
-export function isClipboardImageFile(file) {
-  return (file.type || "").startsWith("image/");
+export function isSupportedClipboardFile(file) {
+  const fileType = (file.type || "").toLowerCase();
+  if (fileType.startsWith("image/")) {
+    return true;
+  }
+  if (supportedFileTypes.has(fileType)) {
+    return true;
+  }
+
+  const extension = file.name?.split(".").pop()?.toLowerCase();
+  return supportedFileExtensions.has(extension);
 }


### PR DESCRIPTION
## Summary

- Extend chat Ctrl+V paste support from images to supported file attachments
- Reuse the existing chat file flow for preview, removal, send, and backend handling
- Share the accepted file type list between the file picker and clipboard paste path