### PR TITLE
fix: echo request Origin for /storage so credentialed cross-origin fetches work

### DIFF
--- a/routers/static_filter.go
+++ b/routers/static_filter.go
@@ -78,7 +78,15 @@ func StaticFilter(ctx *context.Context) {
 	}
 
 	if strings.HasPrefix(urlPath, "/storage") {
-		ctx.Output.Header(headerAllowOrigin, "*")
+		// Echo the request Origin instead of "*": browsers reject a wildcard
+		// Allow-Origin when the request carries credentials, which the file
+		// preview fetch does (credentials: "include"). Same-origin / non-CORS
+		// requests have no Origin header and fall back to "*".
+		if origin := ctx.Input.Header(headerOrigin); origin != "" && origin != "null" {
+			ctx.Output.Header(headerAllowOrigin, origin)
+		} else {
+			ctx.Output.Header(headerAllowOrigin, "*")
+		}
 		ctx.Output.Header(headerAllowMethods, "POST, GET, OPTIONS, DELETE")
 		ctx.Output.Header(headerAllowHeaders, "Content-Type, Authorization")
 		ctx.Output.Header(headerAllowCredentials, "true")


### PR DESCRIPTION
### Summary
The static file route replied with Access-Control-Allow-Origin: * while also sending Access-Control-Allow-Credentials: true. Browsers reject a wildcard Allow-Origin on a credentialed request, so the file-preview fetch (which uses credentials: "include") failed with "Failed to fetch" whenever the frontend and backend are served from different origins — e.g. the dev server on :13001 hitting the backend on :14000. Echo the request Origin instead (matching what CorsFilter already does for /api), falling back to "*" for same-origin / non-CORS requests.