### PR TITLE
Feat/preview docx and overview layout

### DIFF
--- a/web/craco.config.js
+++ b/web/craco.config.js
@@ -46,8 +46,9 @@ module.exports = {
       paths.appBuild = path.resolve(__dirname, "build-temp");
       webpackConfig.output.path = path.resolve(__dirname, "build-temp");
 
-      // dompurify (pulled in by mermaid) ships sourceMappingURL pointing at src/*.ts
-      // that are not published on npm; source-map-loader then floods the console.
+      // Some deps (dompurify via mermaid, docx-preview) ship sourceMappingURL
+      // pointing at src/*.ts that are not published on npm; source-map-loader
+      // then floods the console. These are harmless — silence them.
       const prev = webpackConfig.ignoreWarnings;
       webpackConfig.ignoreWarnings = [
         ...(Array.isArray(prev) ? prev : prev ? [prev] : []),
@@ -56,7 +57,7 @@ module.exports = {
           return (
             typeof msg === "string" &&
             msg.includes("Failed to parse source map") &&
-            msg.includes("dompurify")
+            (msg.includes("dompurify") || msg.includes("docx-preview"))
           );
         },
       ];

--- a/web/package.json
+++ b/web/package.json
@@ -37,6 +37,7 @@
     "d3-force": "^3.0.0",
     "dayjs": "^1.11.19",
     "docx": "^9.6.1",
+    "docx-preview": "^0.3.7",
     "dompurify": "^3.0.9",
     "echarts": "^5.4.2",
     "echarts-for-react": "^3.0.2",

--- a/web/src/FileTree.js
+++ b/web/src/FileTree.js
@@ -30,6 +30,7 @@ import * as PermissionUtil from "./PermissionUtil";
 import * as Conf from "./Conf";
 import FileTable from "./table/FileTable";
 import Editor from "./common/Editor";
+import DocxViewer from "./common/DocxViewer";
 
 const {Search} = Input;
 
@@ -409,6 +410,12 @@ class FileTree extends React.Component {
     return null;
   }
 
+  notifySelectedFile(file) {
+    if (this.props.onSelectFile) {
+      this.props.onSelectFile(file && file.isLeaf ? file : null);
+    }
+  }
+
   applyInitialSelection() {
     const {store, initialFileKey} = this.props;
 
@@ -432,6 +439,7 @@ class FileTree extends React.Component {
       selectedKeys: [file.key],
       selectedFile: file,
     });
+    this.notifySelectedFile(file);
 
     const ext = Setting.getExtFromPath(file.key);
     if (ext && file.url && !this.isExtForDocViewer(ext) && !this.isExtForFileViewer(ext)) {
@@ -497,6 +505,7 @@ class FileTree extends React.Component {
         selectedKeys: selectedKeys,
         selectedFile: info.node,
       });
+      this.notifySelectedFile(info.node);
     };
 
     const onCheck = (checkedKeys, info) => {
@@ -515,7 +524,7 @@ class FileTree extends React.Component {
 
     return (
       <Tree
-        height={"calc(100vh - 220px)"}
+        height={this.getTreeHeightCss()}
         virtual={true}
         className="draggable-tree"
         multiple={false}
@@ -797,12 +806,18 @@ class FileTree extends React.Component {
     const ext = Setting.getExtFromPath(path);
     const url = this.state.selectedFile.url;
 
+    if (ext === "docx") {
+      // Render .docx client-side (docx-preview) so it works for local/private
+      // files; the Office Online viewer would need a publicly reachable URL.
+      return <DocxViewer key={path} url={url} height={this.getEditorHeightCss()} />;
+    }
+
     if (this.isExtForDocViewer(ext)) {
       // https://github.com/Alcumus/react-doc-viewer
       return (
         <DocViewer
           key={path}
-          style={{height: this.getEditorHeightCss(), border: "1px solid rgb(242,242,242)", borderRadius: "6px"}}
+          style={{width: "100%", maxWidth: "100%", height: this.getEditorHeightCss(), border: "1px solid rgb(242,242,242)", borderRadius: "6px"}}
           pluginRenderers={DocViewerRenderers}
           documents={[{uri: url}]}
           theme={{
@@ -866,6 +881,8 @@ class FileTree extends React.Component {
             key={path}
             value={this.state.text}
             fillHeight
+            fillWidth
+            lineWrapping
           />
         </div>
       );
@@ -903,6 +920,9 @@ class FileTree extends React.Component {
   }
 
   renderProperties() {
+    if (this.props.showProperties === false) {
+      return null;
+    }
     if (this.state.selectedKeys.length === 0) {
       return null;
     }
@@ -946,6 +966,17 @@ class FileTree extends React.Component {
     return `calc(100vh - ${filePaneHeight + 136}px)`;
   }
 
+  // Height for the tree so it lines up (bottom-aligns) with the preview box:
+  // the preview height minus the search bar that sits above the tree.
+  getTreeHeightCss() {
+    let filePaneHeight = this.filePane.current?.offsetHeight;
+    if (!filePaneHeight) {
+      filePaneHeight = 0;
+    }
+
+    return `calc(100vh - ${filePaneHeight + 136 + 44}px)`;
+  }
+
   render() {
     if (this.props.store.fileTree === null) {
       if (this.props.store.error) {
@@ -969,7 +1000,7 @@ class FileTree extends React.Component {
     return (
       <div>
         <Row>
-          <Col span={8}>
+          <Col span={6} style={{minWidth: 0}}>
             <Card className="content-warp-card-filetreeleft" style={{marginRight: "10px"}}>
               <div style={{margin: "-25px"}}>
                 {
@@ -981,10 +1012,10 @@ class FileTree extends React.Component {
               </div>
             </Card>
           </Col>
-          <Col span={16}>
+          <Col span={18} style={{minWidth: 0}}>
             <Card className="content-warp-card-filetreeright">
               <div style={{margin: "-25px"}}>
-                <div style={{height: this.getEditorHeightCss(), border: "1px solid rgb(242,242,242)", borderRadius: "6px"}}>
+                <div style={{height: this.getEditorHeightCss(), border: "1px solid rgb(242,242,242)", borderRadius: "6px", overflow: "hidden"}}>
                   {
                     this.renderFileViewer(this.props.store)
                   }

--- a/web/src/StoreHubAgentDetail.js
+++ b/web/src/StoreHubAgentDetail.js
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 import React from "react";
-import {Avatar, Button, Card, Col, Row, Space, Tabs, Tag, Tooltip, Typography} from "antd";
+import {Avatar, Button, Card, Space, Tabs, Tag, Tooltip, Typography} from "antd";
 import StoreInsights from "./StoreInsights";
 import StoreIssues from "./StoreIssues";
 import StoreSecurity from "./StoreSecurity";
 import StoreEditPage from "./StoreEditPage";
 import ChatPage from "./ChatPage";
-import {AppstoreOutlined, BarChartOutlined, BugOutlined, CommentOutlined, EyeFilled, EyeOutlined, FolderOpenOutlined, ForkOutlined, SafetyCertificateOutlined, SettingOutlined, StarFilled, StarOutlined} from "@ant-design/icons";
+import {AppstoreOutlined, BarChartOutlined, BugOutlined, CommentOutlined, EyeFilled, EyeOutlined, FileTextOutlined, FolderOpenOutlined, ForkOutlined, SafetyCertificateOutlined, SettingOutlined, StarFilled, StarOutlined} from "@ant-design/icons";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import i18next from "i18next";
@@ -199,41 +199,92 @@ function renderReadme(store) {
   );
 }
 
-function renderFiles(account, store, onStoreUpdate, onRefresh) {
+function renderFiles(account, store, onStoreUpdate, onRefresh, onSelectFile) {
   return (
     <FileTree
       account={account}
       store={store}
       onUpdateStore={onStoreUpdate}
       onRefresh={onRefresh}
+      onSelectFile={onSelectFile}
+      showProperties={!onSelectFile}
     />
   );
 }
 
-function renderOverview(account, store, onStoreUpdate, onRefresh) {
+// Format an RFC3339 timestamp as Beijing time (UTC+8), e.g. "2026-07-05 22:31".
+function formatBeijingTime(date) {
+  if (!date) {
+    return "";
+  }
+  const d = new Date(date);
+  if (isNaN(d.getTime())) {
+    return date;
+  }
+  const parts = new Intl.DateTimeFormat("zh-CN", {
+    timeZone: "Asia/Shanghai",
+    year: "numeric", month: "2-digit", day: "2-digit",
+    hour: "2-digit", minute: "2-digit", hour12: false,
+  }).formatToParts(d).reduce((acc, p) => {
+    acc[p.type] = p.value;
+    return acc;
+  }, {});
+  return `${parts.year}-${parts.month}-${parts.day} ${parts.hour}:${parts.minute}`;
+}
+
+// File details shown under the About rail on the Overview tab (the file browser
+// reports the selected file via onSelectFile instead of rendering this inline).
+function renderFileProperties(file) {
+  if (!file) {
+    return null;
+  }
+  const rows = [
+    [i18next.t("store:File size"), Setting.getFriendlyFileSize(file.size)],
+    [i18next.t("general:Created time"), formatBeijingTime(file.createdTime)],
+  ];
+  return (
+    <Card title={i18next.t("store:File")} size="small">
+      <div style={{display: "flex", alignItems: "center", gap: 8, minWidth: 0, overflow: "hidden", marginBottom: 12, padding: "8px 10px", background: "var(--ant-color-fill-quaternary)", borderRadius: 6}}>
+        <FileTextOutlined style={{color: "var(--ant-color-primary)", flexShrink: 0}} />
+        <Text strong ellipsis={{tooltip: file.title}} style={{minWidth: 0}}>{file.title}</Text>
+      </div>
+      <div style={{display: "grid", gap: 8}}>
+        {rows.map(([label, value]) => (
+          <div key={label} style={{display: "flex", justifyContent: "space-between", gap: 12}}>
+            <Text type="secondary" style={{flexShrink: 0}}>{label}</Text>
+            <Text style={{textAlign: "right", wordBreak: "break-word", minWidth: 0}}>{value}</Text>
+          </div>
+        ))}
+      </div>
+    </Card>
+  );
+}
+
+function renderOverview(account, store, onStoreUpdate, onRefresh, selectedFile, onSelectFile) {
   const isExternalStore = Boolean(store.endpoint || store.hubDbName);
   const areCommentsUnavailable = isExternalStore || store.publishState !== "Published";
 
   return (
-    <Row gutter={[16, 16]}>
-      <Col xs={24} lg={18}>
-        <div style={{display: "grid", gap: 16}}>
-          {renderFiles(account, store, onStoreUpdate, onRefresh)}
-          {renderReadme(store)}
-          <CommentArea
-            account={account}
-            targetType="agenthub"
-            targetKey={`${store.owner}/${store.name}`}
-            targetOwner={store.owner}
-            disabled={areCommentsUnavailable}
-            unavailableText={isExternalStore ? i18next.t("store:Comments are unavailable for external agents") : i18next.t("store:Comments are unavailable")}
-          />
-        </div>
-      </Col>
-      <Col xs={24} lg={6}>
+    <div style={{display: "flex", gap: 16, alignItems: "flex-start", flexWrap: "wrap"}}>
+      {/* The file section is clipped (overflow: hidden) so a wide preview can
+          never spill over the About rail on the right. */}
+      <div style={{flex: "1 1 520px", minWidth: 0, overflow: "hidden", display: "grid", gridTemplateColumns: "minmax(0, 1fr)", gap: 16}}>
+        {renderFiles(account, store, onStoreUpdate, onRefresh, onSelectFile)}
+        {renderReadme(store)}
+        <CommentArea
+          account={account}
+          targetType="agenthub"
+          targetKey={`${store.owner}/${store.name}`}
+          targetOwner={store.owner}
+          disabled={areCommentsUnavailable}
+          unavailableText={isExternalStore ? i18next.t("store:Comments are unavailable for external agents") : i18next.t("store:Comments are unavailable")}
+        />
+      </div>
+      <div style={{flex: "0 0 280px", maxWidth: "100%", minWidth: 0, display: "grid", gridTemplateColumns: "minmax(0, 1fr)", gap: 16}}>
         {renderAbout(store, account)}
-      </Col>
-    </Row>
+        {renderFileProperties(selectedFile)}
+      </div>
+    </div>
   );
 }
 
@@ -296,7 +347,7 @@ function renderChat(account, store) {
   );
 }
 
-function renderTabContent(account, store, activeTab, activeSub, activeIssueName, onStoreUpdate, onRefresh, onSubTabChange, onIssueChange, history) {
+function renderTabContent(account, store, activeTab, activeSub, activeIssueName, onStoreUpdate, onRefresh, onSubTabChange, onIssueChange, history, selectedFile, onSelectFile) {
   if (activeTab === "files") {
     return renderFiles(account, store, onStoreUpdate, onRefresh);
   }
@@ -315,10 +366,11 @@ function renderTabContent(account, store, activeTab, activeSub, activeIssueName,
   if (activeTab === "chat") {
     return renderChat(account, store);
   }
-  return renderOverview(account, store, onStoreUpdate, onRefresh);
+  return renderOverview(account, store, onStoreUpdate, onRefresh, selectedFile, onSelectFile);
 }
 
 function StoreHubAgentDetail({account, store, activeTab, activeSub, activeIssueName, canManage, onTabChange, onSubTabChange, onIssueChange, onStartChat, onFork, forking, favoriteStatus, starLoading, watchLoading, onToggleFavorite, onStoreUpdate, onRefresh, history}) {
+  const [selectedFile, setSelectedFile] = React.useState(null);
   const tabItems = [
     {key: "overview", label: <span><AppstoreOutlined /> {i18next.t("store:Overview")}</span>},
     {key: "chat", label: <span><CommentOutlined /> {i18next.t("general:Chat")}</span>},
@@ -341,7 +393,7 @@ function StoreHubAgentDetail({account, store, activeTab, activeSub, activeIssueN
         onChange={onTabChange}
         style={{marginBottom: 16}}
       />
-      {renderTabContent(account, store, activeTab, activeSub, activeIssueName, onStoreUpdate, onRefresh, onSubTabChange, onIssueChange, history)}
+      {renderTabContent(account, store, activeTab, activeSub, activeIssueName, onStoreUpdate, onRefresh, onSubTabChange, onIssueChange, history, selectedFile, setSelectedFile)}
     </div>
   );
 }

--- a/web/src/common/DocxViewer.js
+++ b/web/src/common/DocxViewer.js
@@ -1,0 +1,128 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from "react";
+import {renderAsync} from "docx-preview";
+import {Spin} from "antd";
+import i18next from "i18next";
+
+// DocxViewer renders a .docx entirely in the browser (via docx-preview), so it
+// works for local/private files — unlike the Office Online viewer, which needs a
+// publicly reachable URL. The Word page is rendered at its natural width and
+// then scaled down proportionally (CSS zoom) to fit the preview box, so the
+// whole document is visible without changing its layout.
+class DocxViewer extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {loading: true, error: false};
+    this.scrollRef = React.createRef();
+    this.contentRef = React.createRef();
+    this.reqId = 0;
+    this.resizeObserver = null;
+    this.applyScale = this.applyScale.bind(this);
+  }
+
+  componentDidMount() {
+    this.load();
+    if (typeof ResizeObserver !== "undefined" && this.scrollRef.current) {
+      this.resizeObserver = new ResizeObserver(this.applyScale);
+      this.resizeObserver.observe(this.scrollRef.current);
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.url !== this.props.url) {
+      this.load();
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.resizeObserver) {
+      this.resizeObserver.disconnect();
+    }
+  }
+
+  load() {
+    const {url} = this.props;
+    const content = this.contentRef.current;
+    if (!url || !content) {
+      return;
+    }
+
+    const reqId = ++this.reqId;
+    this.setState({loading: true, error: false});
+    content.style.zoom = "1";
+    content.innerHTML = "";
+
+    fetch(url, {method: "GET", credentials: "include"})
+      .then((res) => {
+        if (!res.ok) {
+          throw new Error(`HTTP ${res.status}`);
+        }
+        return res.blob();
+      })
+      .then((blob) => renderAsync(blob, content, undefined, {inWrapper: true, breakPages: true}))
+      .then(() => {
+        if (reqId === this.reqId) {
+          this.setState({loading: false});
+          this.applyScale();
+        }
+      })
+      .catch(() => {
+        if (reqId === this.reqId) {
+          this.setState({loading: false, error: true});
+        }
+      });
+  }
+
+  // Scale the rendered Word page proportionally so the full page width fits the
+  // preview box, preserving the document's original layout.
+  applyScale() {
+    const scrollBox = this.scrollRef.current;
+    const content = this.contentRef.current;
+    if (!scrollBox || !content) {
+      return;
+    }
+    content.style.zoom = "1";
+    const page = content.querySelector("section.docx");
+    if (!page) {
+      return;
+    }
+    const pageWidth = page.offsetWidth;
+    const available = scrollBox.clientWidth - 24;
+    if (pageWidth > 0 && available > 0) {
+      content.style.zoom = String(Math.min(1, available / pageWidth));
+    }
+  }
+
+  render() {
+    return (
+      <div ref={this.scrollRef} style={{height: this.props.height, overflow: "auto", border: "1px solid rgb(242,242,242)", borderRadius: "6px", background: "rgb(250,250,250)", position: "relative"}}>
+        {this.state.loading ? (
+          <div style={{position: "absolute", inset: 0, display: "flex", justifyContent: "center", alignItems: "center"}}>
+            <Spin size="large" />
+          </div>
+        ) : null}
+        {this.state.error ? (
+          <div style={{padding: 24, textAlign: "center", color: "rgba(0,0,0,0.45)"}}>
+            {i18next.t("general:Failed to get")}
+          </div>
+        ) : null}
+        <div ref={this.contentRef} />
+      </div>
+    );
+  }
+}
+
+export default DocxViewer;

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -119,7 +119,10 @@ code {
 
 .markdownContainer {
   width: 100%;
-  overflow: hidden;
+  box-sizing: border-box;
+  overflow: auto;
+  overflow-wrap: anywhere;
+  word-break: break-word;
   background-color: rgb(251,240,217);
   padding: 10px;
 }
@@ -127,6 +130,49 @@ code {
 .markdownContainer img {
   max-width: 100%;
   height: auto;
+}
+
+.markdownContainer pre,
+.markdownContainer table {
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+/* react-doc-viewer: fit the pdf page / image to the preview box width so the
+   document is fully visible (not clipped) and never spills over the About rail.
+   The root is styled-components, so target the stable renderer ids + react-pdf
+   canvas directly. */
+#pdf-renderer,
+#image-renderer,
+#msdoc-renderer,
+#proxy-renderer {
+  width: 100% !important;
+  max-width: 100% !important;
+}
+
+#pdf-renderer .react-pdf__Document,
+#pdf-renderer .react-pdf__Page {
+  max-width: 100% !important;
+}
+
+#pdf-renderer canvas,
+#pdf-renderer .react-pdf__Page__svg {
+  height: auto !important;
+  max-width: 100% !important;
+  margin: 0 auto;
+}
+
+#image-renderer img,
+#proxy-renderer img {
+  max-width: 100% !important;
+  height: auto !important;
+}
+
+/* docx-preview: DocxViewer scales the wrapper (CSS zoom) to fit the box, so
+   drop the wrapper's default outer margin/background to avoid a large gap. */
+.docx-wrapper {
+  padding: 8px !important;
+  background: transparent !important;
 }
 
 /*.ant-modal-content {*/

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -6861,6 +6861,13 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+docx-preview@^0.3.7:
+  version "0.3.7"
+  resolved "https://registry.yarnpkg.com/docx-preview/-/docx-preview-0.3.7.tgz#15181817bca67c2137f4e4d46e01d9f570db340a"
+  integrity sha512-Lav69CTA/IYZPJTsKH7oYeoZjyg96N0wEJMNslGJnZJ+dMUZK85Lt5ASC79yUlD48ecWjuv+rkcmFt6EVPV0Xg==
+  dependencies:
+    jszip ">=3.0.0"
+
 docx@^9.6.1:
   version "9.6.1"
   resolved "https://registry.yarnpkg.com/docx/-/docx-9.6.1.tgz#c3f173b46be5de455bc5a8eb108923e2e46224e3"
@@ -9990,7 +9997,7 @@ jsonpointer@^5.0.0:
     object.assign "^4.1.4"
     object.values "^1.1.6"
 
-jszip@^3.10.1:
+jszip@>=3.0.0, jszip@^3.10.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.10.1.tgz#34aee70eb18ea1faec2f589208a157d1feb091c2"
   integrity sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==


### PR DESCRIPTION
## **Summary**
Description:
Stacked on #2439 (base branch: `fix/storage-cors-credentials`) — that PR's CORS fix is what lets the browser fetch a local/private store file cross-origin.

## What

Make local store files previewable and tidy up the store Overview.

**docx preview**
- Render `.docx` in the browser with `docx-preview` instead of react-doc-viewer's Office Online viewer, which needs a publicly reachable URL and shows "An error occurred" for local/private files.
- The Word page is rendered at its natural width and scaled down (CSS zoom) to fit the preview box, re-scaling on resize.

**Overview layout**
- Rework the Overview into a flex layout so a wide preview can never overlap the About panel: the file section is clipped (`overflow: hidden`) and About is a fixed-width right rail. (The old side-by-side grid let a wide PDF/doc spill over the About card.)
- Fit content to the box so nothing is cut off on the right: PDF/images scale to the box width, and text / markdown wrap.

**File details**
- Move the selected file's name / size / created time out from under the preview into a card below the About rail (the file browser reports the selection via a callback and hides its inline panel; the standalone Files tab keeps it inline).
- Show created time in Beijing time (UTC+8).
- Long file names truncate with a tooltip, and the rail stays a fixed 280px (fixes the rail collapsing when a name was very long).

**File tree**
- Align the file-tree height with the preview box so they bottom-align.