### PR TITLE
feat: preview .docx client-side with docx-preview

### DIFF
--- a/web/craco.config.js
+++ b/web/craco.config.js
@@ -46,8 +46,9 @@ module.exports = {
       paths.appBuild = path.resolve(__dirname, "build-temp");
       webpackConfig.output.path = path.resolve(__dirname, "build-temp");
 
-      // dompurify (pulled in by mermaid) ships sourceMappingURL pointing at src/*.ts
-      // that are not published on npm; source-map-loader then floods the console.
+      // Some deps (dompurify via mermaid, docx-preview) ship sourceMappingURL
+      // pointing at src/*.ts that are not published on npm; source-map-loader
+      // then floods the console. These are harmless — silence them.
       const prev = webpackConfig.ignoreWarnings;
       webpackConfig.ignoreWarnings = [
         ...(Array.isArray(prev) ? prev : prev ? [prev] : []),
@@ -56,7 +57,7 @@ module.exports = {
           return (
             typeof msg === "string" &&
             msg.includes("Failed to parse source map") &&
-            msg.includes("dompurify")
+            (msg.includes("dompurify") || msg.includes("docx-preview"))
           );
         },
       ];

--- a/web/package.json
+++ b/web/package.json
@@ -37,6 +37,7 @@
     "d3-force": "^3.0.0",
     "dayjs": "^1.11.19",
     "docx": "^9.6.1",
+    "docx-preview": "^0.3.7",
     "dompurify": "^3.0.9",
     "echarts": "^5.4.2",
     "echarts-for-react": "^3.0.2",

--- a/web/src/FileTree.js
+++ b/web/src/FileTree.js
@@ -30,6 +30,7 @@ import * as PermissionUtil from "./PermissionUtil";
 import * as Conf from "./Conf";
 import FileTable from "./table/FileTable";
 import Editor from "./common/Editor";
+import DocxViewer from "./common/DocxViewer";
 
 const {Search} = Input;
 
@@ -796,6 +797,12 @@ class FileTree extends React.Component {
 
     const ext = Setting.getExtFromPath(path);
     const url = this.state.selectedFile.url;
+
+    if (ext === "docx") {
+      // Render .docx client-side (docx-preview) so it works for local/private
+      // files; the Office Online viewer would need a publicly reachable URL.
+      return <DocxViewer key={path} url={url} height={this.getEditorHeightCss()} />;
+    }
 
     if (this.isExtForDocViewer(ext)) {
       // https://github.com/Alcumus/react-doc-viewer

--- a/web/src/common/DocxViewer.js
+++ b/web/src/common/DocxViewer.js
@@ -1,0 +1,128 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from "react";
+import {renderAsync} from "docx-preview";
+import {Spin} from "antd";
+import i18next from "i18next";
+
+// DocxViewer renders a .docx entirely in the browser (via docx-preview), so it
+// works for local/private files — unlike the Office Online viewer, which needs a
+// publicly reachable URL. The Word page is rendered at its natural width and
+// then scaled down proportionally (CSS zoom) to fit the preview box, so the
+// whole document is visible without changing its layout.
+class DocxViewer extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {loading: true, error: false};
+    this.scrollRef = React.createRef();
+    this.contentRef = React.createRef();
+    this.reqId = 0;
+    this.resizeObserver = null;
+    this.applyScale = this.applyScale.bind(this);
+  }
+
+  componentDidMount() {
+    this.load();
+    if (typeof ResizeObserver !== "undefined" && this.scrollRef.current) {
+      this.resizeObserver = new ResizeObserver(this.applyScale);
+      this.resizeObserver.observe(this.scrollRef.current);
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.url !== this.props.url) {
+      this.load();
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.resizeObserver) {
+      this.resizeObserver.disconnect();
+    }
+  }
+
+  load() {
+    const {url} = this.props;
+    const content = this.contentRef.current;
+    if (!url || !content) {
+      return;
+    }
+
+    const reqId = ++this.reqId;
+    this.setState({loading: true, error: false});
+    content.style.zoom = "1";
+    content.innerHTML = "";
+
+    fetch(url, {method: "GET", credentials: "include"})
+      .then((res) => {
+        if (!res.ok) {
+          throw new Error(`HTTP ${res.status}`);
+        }
+        return res.blob();
+      })
+      .then((blob) => renderAsync(blob, content, undefined, {inWrapper: true, breakPages: true}))
+      .then(() => {
+        if (reqId === this.reqId) {
+          this.setState({loading: false});
+          this.applyScale();
+        }
+      })
+      .catch(() => {
+        if (reqId === this.reqId) {
+          this.setState({loading: false, error: true});
+        }
+      });
+  }
+
+  // Scale the rendered Word page proportionally so the full page width fits the
+  // preview box, preserving the document's original layout.
+  applyScale() {
+    const scrollBox = this.scrollRef.current;
+    const content = this.contentRef.current;
+    if (!scrollBox || !content) {
+      return;
+    }
+    content.style.zoom = "1";
+    const page = content.querySelector("section.docx");
+    if (!page) {
+      return;
+    }
+    const pageWidth = page.offsetWidth;
+    const available = scrollBox.clientWidth - 24;
+    if (pageWidth > 0 && available > 0) {
+      content.style.zoom = String(Math.min(1, available / pageWidth));
+    }
+  }
+
+  render() {
+    return (
+      <div ref={this.scrollRef} style={{height: this.props.height, overflow: "auto", border: "1px solid rgb(242,242,242)", borderRadius: "6px", background: "rgb(250,250,250)", position: "relative"}}>
+        {this.state.loading ? (
+          <div style={{position: "absolute", inset: 0, display: "flex", justifyContent: "center", alignItems: "center"}}>
+            <Spin size="large" />
+          </div>
+        ) : null}
+        {this.state.error ? (
+          <div style={{padding: 24, textAlign: "center", color: "rgba(0,0,0,0.45)"}}>
+            {i18next.t("general:Failed to get")}
+          </div>
+        ) : null}
+        <div ref={this.contentRef} />
+      </div>
+    );
+  }
+}
+
+export default DocxViewer;

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -129,6 +129,13 @@ code {
   height: auto;
 }
 
+/* docx-preview: DocxViewer scales the wrapper (CSS zoom) to fit the box, so
+   drop the wrapper's default outer margin/background to avoid a large gap. */
+.docx-wrapper {
+  padding: 8px !important;
+  background: transparent !important;
+}
+
 /*.ant-modal-content {*/
 /*  padding: 0 !important;*/
 /*  background-color: transparent !important;*/

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -6861,6 +6861,13 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+docx-preview@^0.3.7:
+  version "0.3.7"
+  resolved "https://registry.yarnpkg.com/docx-preview/-/docx-preview-0.3.7.tgz#15181817bca67c2137f4e4d46e01d9f570db340a"
+  integrity sha512-Lav69CTA/IYZPJTsKH7oYeoZjyg96N0wEJMNslGJnZJ+dMUZK85Lt5ASC79yUlD48ecWjuv+rkcmFt6EVPV0Xg==
+  dependencies:
+    jszip ">=3.0.0"
+
 docx@^9.6.1:
   version "9.6.1"
   resolved "https://registry.yarnpkg.com/docx/-/docx-9.6.1.tgz#c3f173b46be5de455bc5a8eb108923e2e46224e3"
@@ -9990,7 +9997,7 @@ jsonpointer@^5.0.0:
     object.assign "^4.1.4"
     object.values "^1.1.6"
 
-jszip@^3.10.1:
+jszip@>=3.0.0, jszip@^3.10.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.10.1.tgz#34aee70eb18ea1faec2f589208a157d1feb091c2"
   integrity sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==


### PR DESCRIPTION
 ## Summary
  Render `.docx` files in the browser with `docx-preview` instead of react-doc-viewer's Office Online viewer.
## Why
The Office Online viewer needs a publicly reachable URL, so it shows "An error occurred" for local/private store files. docx-preview renders the document entirely client-side. The Word page is rendered at its natural width and scaled down (CSS `zoom`) to fit the preview box, re-scaling on resize.