### PR TITLE
feat: preview .xlsx / .xls client-side with SheetJS

### DIFF
--- a/web/src/FileTree.js
+++ b/web/src/FileTree.js
@@ -31,6 +31,7 @@ import * as Conf from "./Conf";
 import FileTable from "./table/FileTable";
 import Editor from "./common/Editor";
 import DocxViewer from "./common/DocxViewer";
+import XlsxViewer from "./common/XlsxViewer";
 
 const {Search} = Input;
 
@@ -802,6 +803,11 @@ class FileTree extends React.Component {
       // Render .docx client-side (docx-preview) so it works for local/private
       // files; the Office Online viewer would need a publicly reachable URL.
       return <DocxViewer key={path} url={url} height={this.getEditorHeightCss()} />;
+    }
+
+    if (ext === "xlsx" || ext === "xls") {
+      // Render spreadsheets client-side (SheetJS) for the same reason.
+      return <XlsxViewer key={path} url={url} height={this.getEditorHeightCss()} />;
     }
 
     if (this.isExtForDocViewer(ext)) {

--- a/web/src/common/XlsxViewer.js
+++ b/web/src/common/XlsxViewer.js
@@ -1,0 +1,120 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from "react";
+import xlsx from "xlsx";
+import {Spin, Tabs} from "antd";
+import i18next from "i18next";
+
+// XlsxViewer renders a spreadsheet (.xlsx / .xls) in the browser with SheetJS,
+// so it works for local/private files — unlike the Office Online viewer, which
+// needs a publicly reachable URL. Each sheet is a scrollable HTML table, with
+// tabs to switch sheets.
+class XlsxViewer extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {loading: true, error: false, sheetNames: [], activeSheet: "", html: ""};
+    this.reqId = 0;
+    this.workbook = null;
+  }
+
+  componentDidMount() {
+    this.load();
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.url !== this.props.url) {
+      this.load();
+    }
+  }
+
+  load() {
+    const {url} = this.props;
+    if (!url) {
+      return;
+    }
+
+    const reqId = ++this.reqId;
+    this.setState({loading: true, error: false});
+
+    fetch(url, {method: "GET", credentials: "include"})
+      .then((res) => {
+        if (!res.ok) {
+          throw new Error(`HTTP ${res.status}`);
+        }
+        return res.arrayBuffer();
+      })
+      .then((buf) => {
+        if (reqId !== this.reqId) {
+          return;
+        }
+        this.workbook = xlsx.read(new Uint8Array(buf), {type: "array"});
+        const names = this.workbook.SheetNames || [];
+        const active = names[0] || "";
+        this.setState({loading: false, error: false, sheetNames: names, activeSheet: active, html: this.sheetToHtml(active)});
+      })
+      .catch(() => {
+        if (reqId === this.reqId) {
+          this.setState({loading: false, error: true});
+        }
+      });
+  }
+
+  sheetToHtml(name) {
+    const sheet = this.workbook && name ? this.workbook.Sheets[name] : null;
+    if (!sheet) {
+      return "";
+    }
+    return xlsx.utils.sheet_to_html(sheet, {editable: false});
+  }
+
+  onSheetChange = (name) => {
+    this.setState({activeSheet: name, html: this.sheetToHtml(name)});
+  };
+
+  render() {
+    const {loading, error, sheetNames, activeSheet, html} = this.state;
+    return (
+      <div style={{height: this.props.height, display: "flex", flexDirection: "column", border: "1px solid rgb(242,242,242)", borderRadius: "6px", overflow: "hidden", background: "#fff", position: "relative"}}>
+        {loading ? (
+          <div style={{position: "absolute", inset: 0, display: "flex", justifyContent: "center", alignItems: "center"}}>
+            <Spin size="large" />
+          </div>
+        ) : null}
+        {error ? (
+          <div style={{padding: 24, textAlign: "center", color: "rgba(0,0,0,0.45)"}}>
+            {i18next.t("general:Failed to get")}
+          </div>
+        ) : null}
+        {!loading && !error ? (
+          <React.Fragment>
+            <div className="xlsxContainer" style={{flex: 1, minHeight: 0, overflow: "auto"}} dangerouslySetInnerHTML={{__html: html}} />
+            {sheetNames.length > 1 ? (
+              <Tabs
+                size="small"
+                activeKey={activeSheet}
+                onChange={this.onSheetChange}
+                items={sheetNames.map((n) => ({key: n, label: n}))}
+                tabBarStyle={{margin: 0, padding: "0 8px"}}
+                style={{flexShrink: 0, borderTop: "1px solid rgba(0, 0, 0, 0.08)"}}
+              />
+            ) : null}
+          </React.Fragment>
+        ) : null}
+      </div>
+    );
+  }
+}
+
+export default XlsxViewer;

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -136,6 +136,28 @@ code {
   background: transparent !important;
 }
 
+/* SheetJS spreadsheet table (XlsxViewer) */
+.xlsxContainer table {
+  border-collapse: collapse;
+  font-size: 13px;
+  width: max-content;
+  min-width: 100%;
+}
+
+.xlsxContainer td {
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  padding: 4px 10px;
+  white-space: nowrap;
+  color: rgba(0, 0, 0, 0.85);
+}
+
+.xlsxContainer tr:first-child td {
+  position: sticky;
+  top: 0;
+  background: #fafafa;
+  font-weight: 600;
+  z-index: 1;
+}
 /*.ant-modal-content {*/
 /*  padding: 0 !important;*/
 /*  background-color: transparent !important;*/


### PR DESCRIPTION
## Summary

Render spreadsheets in the browser with SheetJS instead of react-doc-viewer's Office Online viewer (which needs a publicly reachable URL and errors on local files). Each sheet renders as a scrollable table with a frozen header row and tabs to switch between sheets.