### PR TITLE
fix: keep the file preview inside its frame on the store Overview

### DIFF
--- a/web/src/FileTree.js
+++ b/web/src/FileTree.js
@@ -517,7 +517,7 @@ class FileTree extends React.Component {
 
     return (
       <Tree
-        height={"calc(100vh - 220px)"}
+        height={this.getTreeHeightCss()}
         virtual={true}
         className="draggable-tree"
         multiple={false}
@@ -815,7 +815,7 @@ class FileTree extends React.Component {
       return (
         <DocViewer
           key={path}
-          style={{height: this.getEditorHeightCss(), border: "1px solid rgb(242,242,242)", borderRadius: "6px"}}
+          style={{width: "100%", maxWidth: "100%", height: this.getEditorHeightCss(), border: "1px solid rgb(242,242,242)", borderRadius: "6px"}}
           pluginRenderers={DocViewerRenderers}
           documents={[{uri: url}]}
           theme={{
@@ -879,6 +879,8 @@ class FileTree extends React.Component {
             key={path}
             value={this.state.text}
             fillHeight
+            fillWidth
+            lineWrapping
           />
         </div>
       );
@@ -959,6 +961,17 @@ class FileTree extends React.Component {
     return `calc(100vh - ${filePaneHeight + 136}px)`;
   }
 
+  // Height for the tree so it lines up (bottom-aligns) with the preview box:
+  // the preview height minus the search bar that sits above the tree.
+  getTreeHeightCss() {
+    let filePaneHeight = this.filePane.current?.offsetHeight;
+    if (!filePaneHeight) {
+      filePaneHeight = 0;
+    }
+
+    return `calc(100vh - ${filePaneHeight + 136 + 44}px)`;
+  }
+
   render() {
     if (this.props.store.fileTree === null) {
       if (this.props.store.error) {
@@ -982,7 +995,7 @@ class FileTree extends React.Component {
     return (
       <div>
         <Row>
-          <Col span={8}>
+          <Col span={6} style={{minWidth: 0}}>
             <Card className="content-warp-card-filetreeleft" style={{marginRight: "10px"}}>
               <div style={{margin: "-25px"}}>
                 {
@@ -994,10 +1007,10 @@ class FileTree extends React.Component {
               </div>
             </Card>
           </Col>
-          <Col span={16}>
+          <Col span={18} style={{minWidth: 0}}>
             <Card className="content-warp-card-filetreeright">
               <div style={{margin: "-25px"}}>
-                <div style={{height: this.getEditorHeightCss(), border: "1px solid rgb(242,242,242)", borderRadius: "6px"}}>
+                <div style={{height: this.getEditorHeightCss(), border: "1px solid rgb(242,242,242)", borderRadius: "6px", overflow: "hidden"}}>
                   {
                     this.renderFileViewer(this.props.store)
                   }

--- a/web/src/StoreHubAgentDetail.js
+++ b/web/src/StoreHubAgentDetail.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import React from "react";
-import {Avatar, Button, Card, Col, Row, Space, Tabs, Tag, Tooltip, Typography} from "antd";
+import {Avatar, Button, Card, Space, Tabs, Tag, Tooltip, Typography} from "antd";
 import StoreInsights from "./StoreInsights";
 import StoreIssues from "./StoreIssues";
 import StoreSecurity from "./StoreSecurity";
@@ -215,25 +215,25 @@ function renderOverview(account, store, onStoreUpdate, onRefresh) {
   const areCommentsUnavailable = isExternalStore || store.publishState !== "Published";
 
   return (
-    <Row gutter={[16, 16]}>
-      <Col xs={24} lg={18}>
-        <div style={{display: "grid", gap: 16}}>
-          {renderFiles(account, store, onStoreUpdate, onRefresh)}
-          {renderReadme(store)}
-          <CommentArea
-            account={account}
-            targetType="agenthub"
-            targetKey={`${store.owner}/${store.name}`}
-            targetOwner={store.owner}
-            disabled={areCommentsUnavailable}
-            unavailableText={isExternalStore ? i18next.t("store:Comments are unavailable for external agents") : i18next.t("store:Comments are unavailable")}
-          />
-        </div>
-      </Col>
-      <Col xs={24} lg={6}>
+    <div style={{display: "flex", gap: 16, alignItems: "flex-start", flexWrap: "wrap"}}>
+      {/* The file section is clipped (overflow: hidden) so a wide preview can
+          never spill over the About rail on the right. */}
+      <div style={{flex: "1 1 520px", minWidth: 0, overflow: "hidden", display: "grid", gridTemplateColumns: "minmax(0, 1fr)", gap: 16}}>
+        {renderFiles(account, store, onStoreUpdate, onRefresh)}
+        {renderReadme(store)}
+        <CommentArea
+          account={account}
+          targetType="agenthub"
+          targetKey={`${store.owner}/${store.name}`}
+          targetOwner={store.owner}
+          disabled={areCommentsUnavailable}
+          unavailableText={isExternalStore ? i18next.t("store:Comments are unavailable for external agents") : i18next.t("store:Comments are unavailable")}
+        />
+      </div>
+      <div style={{flex: "0 0 280px", maxWidth: "100%"}}>
         {renderAbout(store, account)}
-      </Col>
-    </Row>
+      </div>
+    </div>
   );
 }
 

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -119,7 +119,10 @@ code {
 
 .markdownContainer {
   width: 100%;
-  overflow: hidden;
+  box-sizing: border-box;
+  overflow: auto;
+  overflow-wrap: anywhere;
+  word-break: break-word;
   background-color: rgb(251,240,217);
   padding: 10px;
 }
@@ -127,6 +130,42 @@ code {
 .markdownContainer img {
   max-width: 100%;
   height: auto;
+}
+
+.markdownContainer pre,
+.markdownContainer table {
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+/* react-doc-viewer: fit the pdf page / image to the preview box width so the
+   document is fully visible (not clipped) and never spills over the About rail.
+   The root is styled-components, so target the stable renderer ids + react-pdf
+   canvas directly. */
+#pdf-renderer,
+#image-renderer,
+#msdoc-renderer,
+#proxy-renderer {
+  width: 100% !important;
+  max-width: 100% !important;
+}
+
+#pdf-renderer .react-pdf__Document,
+#pdf-renderer .react-pdf__Page {
+  max-width: 100% !important;
+}
+
+#pdf-renderer canvas,
+#pdf-renderer .react-pdf__Page__svg {
+  height: auto !important;
+  max-width: 100% !important;
+  margin: 0 auto;
+}
+
+#image-renderer img,
+#proxy-renderer img {
+  max-width: 100% !important;
+  height: auto !important;
 }
 
 /* docx-preview: DocxViewer scales the wrapper (CSS zoom) to fit the box, so


### PR DESCRIPTION
### Summary
Rework the Overview into a flex layout so a wide file preview can no longer overlap the About panel: the file section is clipped and About sits in a fixed-width right rail. Fit content to the box — the PDF/image scales to the box width and text / markdown wrap — so nothing is cut off on the right. Also align the file-tree height with the preview box.