### PR TITLE
feat: show selected-file details on the store Overview

### DIFF
--- a/web/src/FileTree.js
+++ b/web/src/FileTree.js
@@ -384,6 +384,7 @@ class FileTree extends React.Component {
           selectedKeys: [],
           selectedFile: null,
         });
+        this.notifySelectedFile(null);
       }} />
     );
   }
@@ -411,6 +412,12 @@ class FileTree extends React.Component {
     return null;
   }
 
+  notifySelectedFile(file) {
+    if (this.props.onSelectFile) {
+      this.props.onSelectFile(file && file.isLeaf ? file : null);
+    }
+  }
+
   applyInitialSelection() {
     const {store, initialFileKey} = this.props;
 
@@ -434,6 +441,7 @@ class FileTree extends React.Component {
       selectedKeys: [file.key],
       selectedFile: file,
     });
+    this.notifySelectedFile(file);
 
     const ext = Setting.getExtFromPath(file.key);
     if (ext && file.url && !this.isExtForDocViewer(ext) && !this.isExtForFileViewer(ext)) {
@@ -499,6 +507,7 @@ class FileTree extends React.Component {
         selectedKeys: selectedKeys,
         selectedFile: info.node,
       });
+      this.notifySelectedFile(info.node);
     };
 
     const onCheck = (checkedKeys, info) => {
@@ -508,6 +517,7 @@ class FileTree extends React.Component {
         selectedKeys: [],
         selectedFile: null,
       });
+      this.notifySelectedFile(null);
     };
 
     let fileTree = Setting.getTreeWithParents(store.fileTree);
@@ -918,6 +928,9 @@ class FileTree extends React.Component {
   }
 
   renderProperties() {
+    if (this.props.showProperties === false) {
+      return null;
+    }
     if (this.state.selectedKeys.length === 0) {
       return null;
     }

--- a/web/src/StoreHubAgentDetail.js
+++ b/web/src/StoreHubAgentDetail.js
@@ -19,7 +19,7 @@ import StoreIssues from "./StoreIssues";
 import StoreSecurity from "./StoreSecurity";
 import StoreEditPage from "./StoreEditPage";
 import ChatPage from "./ChatPage";
-import {AppstoreOutlined, BarChartOutlined, BugOutlined, CommentOutlined, EyeFilled, EyeOutlined, FolderOpenOutlined, ForkOutlined, SafetyCertificateOutlined, SettingOutlined, StarFilled, StarOutlined} from "@ant-design/icons";
+import {AppstoreOutlined, BarChartOutlined, BugOutlined, CommentOutlined, EyeFilled, EyeOutlined, FileTextOutlined, FolderOpenOutlined, ForkOutlined, SafetyCertificateOutlined, SettingOutlined, StarFilled, StarOutlined} from "@ant-design/icons";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import i18next from "i18next";
@@ -199,18 +199,48 @@ function renderReadme(store) {
   );
 }
 
-function renderFiles(account, store, onStoreUpdate, onRefresh) {
+function renderFiles(account, store, onStoreUpdate, onRefresh, onSelectFile) {
   return (
     <FileTree
       account={account}
       store={store}
       onUpdateStore={onStoreUpdate}
       onRefresh={onRefresh}
+      onSelectFile={onSelectFile}
+      showProperties={!onSelectFile}
     />
   );
 }
 
-function renderOverview(account, store, onStoreUpdate, onRefresh) {
+// File details shown under the About rail on the Overview tab (the file browser
+// reports the selected file via onSelectFile instead of rendering this inline).
+function renderFileProperties(file) {
+  if (!file) {
+    return null;
+  }
+  const rows = [
+    [i18next.t("store:File size"), Setting.getFriendlyFileSize(file.size)],
+    [i18next.t("general:Created time"), file.createdTime ? new Date(file.createdTime).toLocaleString() : "—"],
+  ];
+  return (
+    <Card title={i18next.t("store:File")} size="small">
+      <div style={{display: "flex", alignItems: "center", gap: 8, minWidth: 0, overflow: "hidden", marginBottom: 12, padding: "8px 10px", background: "var(--ant-color-fill-quaternary)", borderRadius: 6}}>
+        <FileTextOutlined style={{color: "var(--ant-color-primary)", flexShrink: 0}} />
+        <Text strong ellipsis={{tooltip: file.title}} style={{minWidth: 0}}>{file.title}</Text>
+      </div>
+      <div style={{display: "grid", gap: 8}}>
+        {rows.map(([label, value]) => (
+          <div key={label} style={{display: "flex", justifyContent: "space-between", gap: 12}}>
+            <Text type="secondary" style={{flexShrink: 0}}>{label}</Text>
+            <Text style={{textAlign: "right", wordBreak: "break-word", minWidth: 0}}>{value}</Text>
+          </div>
+        ))}
+      </div>
+    </Card>
+  );
+}
+
+function renderOverview(account, store, onStoreUpdate, onRefresh, selectedFile, onSelectFile) {
   const isExternalStore = Boolean(store.endpoint || store.hubDbName);
   const areCommentsUnavailable = isExternalStore || store.publishState !== "Published";
 
@@ -219,7 +249,7 @@ function renderOverview(account, store, onStoreUpdate, onRefresh) {
       {/* The file section is clipped (overflow: hidden) so a wide preview can
           never spill over the About rail on the right. */}
       <div style={{flex: "1 1 520px", minWidth: 0, overflow: "hidden", display: "grid", gridTemplateColumns: "minmax(0, 1fr)", gap: 16}}>
-        {renderFiles(account, store, onStoreUpdate, onRefresh)}
+        {renderFiles(account, store, onStoreUpdate, onRefresh, onSelectFile)}
         {renderReadme(store)}
         <CommentArea
           account={account}
@@ -230,8 +260,9 @@ function renderOverview(account, store, onStoreUpdate, onRefresh) {
           unavailableText={isExternalStore ? i18next.t("store:Comments are unavailable for external agents") : i18next.t("store:Comments are unavailable")}
         />
       </div>
-      <div style={{flex: "0 0 280px", maxWidth: "100%"}}>
+      <div style={{flex: "0 0 280px", maxWidth: "100%", minWidth: 0, display: "grid", gridTemplateColumns: "minmax(0, 1fr)", gap: 16}}>
         {renderAbout(store, account)}
+        {renderFileProperties(selectedFile)}
       </div>
     </div>
   );
@@ -296,7 +327,7 @@ function renderChat(account, store) {
   );
 }
 
-function renderTabContent(account, store, activeTab, activeSub, activeIssueName, onStoreUpdate, onRefresh, onSubTabChange, onIssueChange, history) {
+function renderTabContent(account, store, activeTab, activeSub, activeIssueName, onStoreUpdate, onRefresh, onSubTabChange, onIssueChange, history, selectedFile, onSelectFile) {
   if (activeTab === "files") {
     return renderFiles(account, store, onStoreUpdate, onRefresh);
   }
@@ -315,10 +346,11 @@ function renderTabContent(account, store, activeTab, activeSub, activeIssueName,
   if (activeTab === "chat") {
     return renderChat(account, store);
   }
-  return renderOverview(account, store, onStoreUpdate, onRefresh);
+  return renderOverview(account, store, onStoreUpdate, onRefresh, selectedFile, onSelectFile);
 }
 
 function StoreHubAgentDetail({account, store, activeTab, activeSub, activeIssueName, canManage, onTabChange, onSubTabChange, onIssueChange, onStartChat, onFork, forking, favoriteStatus, starLoading, watchLoading, onToggleFavorite, onStoreUpdate, onRefresh, history}) {
+  const [selectedFile, setSelectedFile] = React.useState(null);
   const tabItems = [
     {key: "overview", label: <span><AppstoreOutlined /> {i18next.t("store:Overview")}</span>},
     {key: "chat", label: <span><CommentOutlined /> {i18next.t("general:Chat")}</span>},
@@ -341,7 +373,7 @@ function StoreHubAgentDetail({account, store, activeTab, activeSub, activeIssueN
         onChange={onTabChange}
         style={{marginBottom: 16}}
       />
-      {renderTabContent(account, store, activeTab, activeSub, activeIssueName, onStoreUpdate, onRefresh, onSubTabChange, onIssueChange, history)}
+      {renderTabContent(account, store, activeTab, activeSub, activeIssueName, onStoreUpdate, onRefresh, onSubTabChange, onIssueChange, history, selectedFile, setSelectedFile)}
     </div>
   );
 }


### PR DESCRIPTION
### Summary
Report the selected file from the tree and show its details — name, size and created time (in the local timezone) — in a card under the About rail, instead of an inline panel next to the preview. Long file names truncate with a tooltip and the rail keeps a fixed width so it can't collapse.