### PR TITLE
fix: keep the PDF pages scrolling inside the preview box

### DIFF
--- a/web/src/FileTree.js
+++ b/web/src/FileTree.js
@@ -825,7 +825,7 @@ class FileTree extends React.Component {
       return (
         <DocViewer
           key={path}
-          style={{width: "100%", maxWidth: "100%", height: this.getEditorHeightCss(), border: "1px solid rgb(242,242,242)", borderRadius: "6px"}}
+          style={{width: "100%", maxWidth: "100%", height: this.getEditorHeightCss(), border: "1px solid rgb(242,242,242)", borderRadius: "6px", display: "flex", flexDirection: "column", overflow: "hidden"}}
           pluginRenderers={DocViewerRenderers}
           documents={[{uri: url}]}
           theme={{

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -150,6 +150,32 @@ code {
   max-width: 100% !important;
 }
 
+/* Keep the pages (paginated or continuous-scroll) scrolling INSIDE the fixed
+   preview box instead of growing the whole page. The DocViewer root is a flex
+   column; proxy-renderer fills the remaining height and pdf-renderer scrolls. */
+#proxy-renderer {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
+}
+
+#pdf-renderer {
+  height: 100% !important;
+  overflow-y: auto !important;
+}
+
+/* Keep the toolbar pinned while the pages scroll under it. */
+#pdf-controls {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+}
+
+#pdf-renderer #pdf-page-wrapper + #pdf-page-wrapper,
+#pdf-renderer .react-pdf__Page + .react-pdf__Page {
+  margin-top: 12px;
+}
+
 #pdf-renderer .react-pdf__Document,
 #pdf-renderer .react-pdf__Page {
   max-width: 100% !important;


### PR DESCRIPTION
### Summary
react-doc-viewer's page/scroll toggle grew the whole layout in scroll mode, so the browser page scrolled instead of the PDF. Make the DocViewer root a flex column that clips, let the renderer fill the fixed height and scroll internally, and pin the toolbar so it stays put while the pages scroll under it.