### PR TITLE
fix: hide the react-pdf text layer duplicated under each PDF page

### DIFF
--- a/storage/local_file_system.go
+++ b/storage/local_file_system.go
@@ -38,7 +38,9 @@ func (p *LocalFileSystemStorageProvider) ListObjects(prefix string) ([]*Object, 
 	objects := []*Object{}
 	fullPath := filepath.Join(p.path, prefix)
 	fullPath = strings.ReplaceAll(fullPath, "\\", "/")
-	util.EnsureFolderExists(fullPath)
+	if err := util.EnsureFolderExists(fullPath); err != nil {
+		return nil, err
+	}
 
 	filepath.Walk(fullPath, func(path string, info os.FileInfo, err error) error {
 		if path == fullPath {

--- a/util/path.go
+++ b/util/path.go
@@ -44,13 +44,11 @@ func EnsureFileFolderExists(path string) {
 	}
 }
 
-func EnsureFolderExists(path string) {
+func EnsureFolderExists(path string) error {
 	if !FileExist(path) {
-		err := os.MkdirAll(path, os.ModePerm)
-		if err != nil {
-			panic(err)
-		}
+		return os.MkdirAll(path, os.ModePerm)
 	}
+	return nil
 }
 
 func RemoveExt(filename string) string {

--- a/web/src/FileTree.js
+++ b/web/src/FileTree.js
@@ -470,7 +470,7 @@ class FileTree extends React.Component {
           if (ext !== "") {
             const url = info.node.url;
 
-            if (!this.isExtForDocViewer((ext) && !this.isExtForFileViewer(ext))) {
+            if (!this.isExtForDocViewer(ext) && !this.isExtForFileViewer(ext)) {
               this.setState({
                 loading: true,
               });

--- a/web/src/FileTree.js
+++ b/web/src/FileTree.js
@@ -517,7 +517,7 @@ class FileTree extends React.Component {
 
     return (
       <Tree
-        height={"calc(100vh - 220px)"}
+        height={this.getTreeHeightCss()}
         virtual={true}
         className="draggable-tree"
         multiple={false}
@@ -815,7 +815,7 @@ class FileTree extends React.Component {
       return (
         <DocViewer
           key={path}
-          style={{height: this.getEditorHeightCss(), border: "1px solid rgb(242,242,242)", borderRadius: "6px"}}
+          style={{width: "100%", maxWidth: "100%", height: this.getEditorHeightCss(), border: "1px solid rgb(242,242,242)", borderRadius: "6px"}}
           pluginRenderers={DocViewerRenderers}
           documents={[{uri: url}]}
           theme={{
@@ -879,6 +879,8 @@ class FileTree extends React.Component {
             key={path}
             value={this.state.text}
             fillHeight
+            fillWidth
+            lineWrapping
           />
         </div>
       );
@@ -959,6 +961,17 @@ class FileTree extends React.Component {
     return `calc(100vh - ${filePaneHeight + 136}px)`;
   }
 
+  // Height for the tree so it lines up (bottom-aligns) with the preview box:
+  // the preview height minus the search bar that sits above the tree.
+  getTreeHeightCss() {
+    let filePaneHeight = this.filePane.current?.offsetHeight;
+    if (!filePaneHeight) {
+      filePaneHeight = 0;
+    }
+
+    return `calc(100vh - ${filePaneHeight + 136 + 44}px)`;
+  }
+
   render() {
     if (this.props.store.fileTree === null) {
       if (this.props.store.error) {
@@ -982,7 +995,7 @@ class FileTree extends React.Component {
     return (
       <div>
         <Row>
-          <Col span={8}>
+          <Col span={6} style={{minWidth: 0}}>
             <Card className="content-warp-card-filetreeleft" style={{marginRight: "10px"}}>
               <div style={{margin: "-25px"}}>
                 {
@@ -994,10 +1007,10 @@ class FileTree extends React.Component {
               </div>
             </Card>
           </Col>
-          <Col span={16}>
+          <Col span={18} style={{minWidth: 0}}>
             <Card className="content-warp-card-filetreeright">
               <div style={{margin: "-25px"}}>
-                <div style={{height: this.getEditorHeightCss(), border: "1px solid rgb(242,242,242)", borderRadius: "6px"}}>
+                <div style={{height: this.getEditorHeightCss(), border: "1px solid rgb(242,242,242)", borderRadius: "6px", overflow: "hidden"}}>
                   {
                     this.renderFileViewer(this.props.store)
                   }

--- a/web/src/FileTree.js
+++ b/web/src/FileTree.js
@@ -825,7 +825,7 @@ class FileTree extends React.Component {
       return (
         <DocViewer
           key={path}
-          style={{width: "100%", maxWidth: "100%", height: this.getEditorHeightCss(), border: "1px solid rgb(242,242,242)", borderRadius: "6px"}}
+          style={{width: "100%", maxWidth: "100%", height: this.getEditorHeightCss(), border: "1px solid rgb(242,242,242)", borderRadius: "6px", display: "flex", flexDirection: "column", overflow: "hidden"}}
           pluginRenderers={DocViewerRenderers}
           documents={[{uri: url}]}
           theme={{

--- a/web/src/FileTree.js
+++ b/web/src/FileTree.js
@@ -384,6 +384,7 @@ class FileTree extends React.Component {
           selectedKeys: [],
           selectedFile: null,
         });
+        this.notifySelectedFile(null);
       }} />
     );
   }
@@ -411,6 +412,12 @@ class FileTree extends React.Component {
     return null;
   }
 
+  notifySelectedFile(file) {
+    if (this.props.onSelectFile) {
+      this.props.onSelectFile(file && file.isLeaf ? file : null);
+    }
+  }
+
   applyInitialSelection() {
     const {store, initialFileKey} = this.props;
 
@@ -434,6 +441,7 @@ class FileTree extends React.Component {
       selectedKeys: [file.key],
       selectedFile: file,
     });
+    this.notifySelectedFile(file);
 
     const ext = Setting.getExtFromPath(file.key);
     if (ext && file.url && !this.isExtForDocViewer(ext) && !this.isExtForFileViewer(ext)) {
@@ -499,6 +507,7 @@ class FileTree extends React.Component {
         selectedKeys: selectedKeys,
         selectedFile: info.node,
       });
+      this.notifySelectedFile(info.node);
     };
 
     const onCheck = (checkedKeys, info) => {
@@ -508,6 +517,7 @@ class FileTree extends React.Component {
         selectedKeys: [],
         selectedFile: null,
       });
+      this.notifySelectedFile(null);
     };
 
     let fileTree = Setting.getTreeWithParents(store.fileTree);
@@ -918,6 +928,9 @@ class FileTree extends React.Component {
   }
 
   renderProperties() {
+    if (this.props.showProperties === false) {
+      return null;
+    }
     if (this.state.selectedKeys.length === 0) {
       return null;
     }

--- a/web/src/FileTree.js
+++ b/web/src/FileTree.js
@@ -829,12 +829,12 @@ class FileTree extends React.Component {
           pluginRenderers={DocViewerRenderers}
           documents={[{uri: url}]}
           theme={{
-            primary: "rgb(92,48,125)",
+            primary: "#ffffff",
             secondary: "#ffffff",
-            tertiary: "rgba(92,48,125,0.55)",
-            text_primary: "#ffffff",
-            text_secondary: "rgb(92,48,125)",
-            text_tertiary: "#00000099",
+            tertiary: "rgba(0, 0, 0, 0.05)",
+            text_primary: Setting.getThemeColor(),
+            text_secondary: Setting.getThemeColor(),
+            text_tertiary: "rgba(0, 0, 0, 0.45)",
             disableThemeScrollbar: false,
           }}
           config={{

--- a/web/src/StoreHubAgentDetail.js
+++ b/web/src/StoreHubAgentDetail.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import React from "react";
-import {Avatar, Button, Card, Col, Row, Space, Tabs, Tag, Tooltip, Typography} from "antd";
+import {Avatar, Button, Card, Space, Tabs, Tag, Tooltip, Typography} from "antd";
 import StoreInsights from "./StoreInsights";
 import StoreIssues from "./StoreIssues";
 import StoreSecurity from "./StoreSecurity";
@@ -215,25 +215,25 @@ function renderOverview(account, store, onStoreUpdate, onRefresh) {
   const areCommentsUnavailable = isExternalStore || store.publishState !== "Published";
 
   return (
-    <Row gutter={[16, 16]}>
-      <Col xs={24} lg={18}>
-        <div style={{display: "grid", gap: 16}}>
-          {renderFiles(account, store, onStoreUpdate, onRefresh)}
-          {renderReadme(store)}
-          <CommentArea
-            account={account}
-            targetType="agenthub"
-            targetKey={`${store.owner}/${store.name}`}
-            targetOwner={store.owner}
-            disabled={areCommentsUnavailable}
-            unavailableText={isExternalStore ? i18next.t("store:Comments are unavailable for external agents") : i18next.t("store:Comments are unavailable")}
-          />
-        </div>
-      </Col>
-      <Col xs={24} lg={6}>
+    <div style={{display: "flex", gap: 16, alignItems: "flex-start", flexWrap: "wrap"}}>
+      {/* The file section is clipped (overflow: hidden) so a wide preview can
+          never spill over the About rail on the right. */}
+      <div style={{flex: "1 1 520px", minWidth: 0, overflow: "hidden", display: "grid", gridTemplateColumns: "minmax(0, 1fr)", gap: 16}}>
+        {renderFiles(account, store, onStoreUpdate, onRefresh)}
+        {renderReadme(store)}
+        <CommentArea
+          account={account}
+          targetType="agenthub"
+          targetKey={`${store.owner}/${store.name}`}
+          targetOwner={store.owner}
+          disabled={areCommentsUnavailable}
+          unavailableText={isExternalStore ? i18next.t("store:Comments are unavailable for external agents") : i18next.t("store:Comments are unavailable")}
+        />
+      </div>
+      <div style={{flex: "0 0 280px", maxWidth: "100%"}}>
         {renderAbout(store, account)}
-      </Col>
-    </Row>
+      </div>
+    </div>
   );
 }
 

--- a/web/src/StoreHubAgentDetail.js
+++ b/web/src/StoreHubAgentDetail.js
@@ -19,7 +19,7 @@ import StoreIssues from "./StoreIssues";
 import StoreSecurity from "./StoreSecurity";
 import StoreEditPage from "./StoreEditPage";
 import ChatPage from "./ChatPage";
-import {AppstoreOutlined, BarChartOutlined, BugOutlined, CommentOutlined, EyeFilled, EyeOutlined, FolderOpenOutlined, ForkOutlined, SafetyCertificateOutlined, SettingOutlined, StarFilled, StarOutlined} from "@ant-design/icons";
+import {AppstoreOutlined, BarChartOutlined, BugOutlined, CommentOutlined, EyeFilled, EyeOutlined, FileTextOutlined, FolderOpenOutlined, ForkOutlined, SafetyCertificateOutlined, SettingOutlined, StarFilled, StarOutlined} from "@ant-design/icons";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import i18next from "i18next";
@@ -199,18 +199,48 @@ function renderReadme(store) {
   );
 }
 
-function renderFiles(account, store, onStoreUpdate, onRefresh) {
+function renderFiles(account, store, onStoreUpdate, onRefresh, onSelectFile) {
   return (
     <FileTree
       account={account}
       store={store}
       onUpdateStore={onStoreUpdate}
       onRefresh={onRefresh}
+      onSelectFile={onSelectFile}
+      showProperties={!onSelectFile}
     />
   );
 }
 
-function renderOverview(account, store, onStoreUpdate, onRefresh) {
+// File details shown under the About rail on the Overview tab (the file browser
+// reports the selected file via onSelectFile instead of rendering this inline).
+function renderFileProperties(file) {
+  if (!file) {
+    return null;
+  }
+  const rows = [
+    [i18next.t("store:File size"), Setting.getFriendlyFileSize(file.size)],
+    [i18next.t("general:Created time"), file.createdTime ? new Date(file.createdTime).toLocaleString() : "—"],
+  ];
+  return (
+    <Card title={i18next.t("store:File")} size="small">
+      <div style={{display: "flex", alignItems: "center", gap: 8, minWidth: 0, overflow: "hidden", marginBottom: 12, padding: "8px 10px", background: "var(--ant-color-fill-quaternary)", borderRadius: 6}}>
+        <FileTextOutlined style={{color: "var(--ant-color-primary)", flexShrink: 0}} />
+        <Text strong ellipsis={{tooltip: file.title}} style={{minWidth: 0}}>{file.title}</Text>
+      </div>
+      <div style={{display: "grid", gap: 8}}>
+        {rows.map(([label, value]) => (
+          <div key={label} style={{display: "flex", justifyContent: "space-between", gap: 12}}>
+            <Text type="secondary" style={{flexShrink: 0}}>{label}</Text>
+            <Text style={{textAlign: "right", wordBreak: "break-word", minWidth: 0}}>{value}</Text>
+          </div>
+        ))}
+      </div>
+    </Card>
+  );
+}
+
+function renderOverview(account, store, onStoreUpdate, onRefresh, selectedFile, onSelectFile) {
   const isExternalStore = Boolean(store.endpoint || store.hubDbName);
   const areCommentsUnavailable = isExternalStore || store.publishState !== "Published";
 
@@ -219,7 +249,7 @@ function renderOverview(account, store, onStoreUpdate, onRefresh) {
       {/* The file section is clipped (overflow: hidden) so a wide preview can
           never spill over the About rail on the right. */}
       <div style={{flex: "1 1 520px", minWidth: 0, overflow: "hidden", display: "grid", gridTemplateColumns: "minmax(0, 1fr)", gap: 16}}>
-        {renderFiles(account, store, onStoreUpdate, onRefresh)}
+        {renderFiles(account, store, onStoreUpdate, onRefresh, onSelectFile)}
         {renderReadme(store)}
         <CommentArea
           account={account}
@@ -230,8 +260,9 @@ function renderOverview(account, store, onStoreUpdate, onRefresh) {
           unavailableText={isExternalStore ? i18next.t("store:Comments are unavailable for external agents") : i18next.t("store:Comments are unavailable")}
         />
       </div>
-      <div style={{flex: "0 0 280px", maxWidth: "100%"}}>
+      <div style={{flex: "0 0 280px", maxWidth: "100%", minWidth: 0, display: "grid", gridTemplateColumns: "minmax(0, 1fr)", gap: 16}}>
         {renderAbout(store, account)}
+        {renderFileProperties(selectedFile)}
       </div>
     </div>
   );
@@ -296,7 +327,7 @@ function renderChat(account, store) {
   );
 }
 
-function renderTabContent(account, store, activeTab, activeSub, activeIssueName, onStoreUpdate, onRefresh, onSubTabChange, onIssueChange, history) {
+function renderTabContent(account, store, activeTab, activeSub, activeIssueName, onStoreUpdate, onRefresh, onSubTabChange, onIssueChange, history, selectedFile, onSelectFile) {
   if (activeTab === "files") {
     return renderFiles(account, store, onStoreUpdate, onRefresh);
   }
@@ -315,10 +346,11 @@ function renderTabContent(account, store, activeTab, activeSub, activeIssueName,
   if (activeTab === "chat") {
     return renderChat(account, store);
   }
-  return renderOverview(account, store, onStoreUpdate, onRefresh);
+  return renderOverview(account, store, onStoreUpdate, onRefresh, selectedFile, onSelectFile);
 }
 
 function StoreHubAgentDetail({account, store, activeTab, activeSub, activeIssueName, canManage, onTabChange, onSubTabChange, onIssueChange, onStartChat, onFork, forking, favoriteStatus, starLoading, watchLoading, onToggleFavorite, onStoreUpdate, onRefresh, history}) {
+  const [selectedFile, setSelectedFile] = React.useState(null);
   const tabItems = [
     {key: "overview", label: <span><AppstoreOutlined /> {i18next.t("store:Overview")}</span>},
     {key: "chat", label: <span><CommentOutlined /> {i18next.t("general:Chat")}</span>},
@@ -341,7 +373,7 @@ function StoreHubAgentDetail({account, store, activeTab, activeSub, activeIssueN
         onChange={onTabChange}
         style={{marginBottom: 16}}
       />
-      {renderTabContent(account, store, activeTab, activeSub, activeIssueName, onStoreUpdate, onRefresh, onSubTabChange, onIssueChange, history)}
+      {renderTabContent(account, store, activeTab, activeSub, activeIssueName, onStoreUpdate, onRefresh, onSubTabChange, onIssueChange, history, selectedFile, setSelectedFile)}
     </div>
   );
 }

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -119,7 +119,10 @@ code {
 
 .markdownContainer {
   width: 100%;
-  overflow: hidden;
+  box-sizing: border-box;
+  overflow: auto;
+  overflow-wrap: anywhere;
+  word-break: break-word;
   background-color: rgb(251,240,217);
   padding: 10px;
 }
@@ -127,6 +130,42 @@ code {
 .markdownContainer img {
   max-width: 100%;
   height: auto;
+}
+
+.markdownContainer pre,
+.markdownContainer table {
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+/* react-doc-viewer: fit the pdf page / image to the preview box width so the
+   document is fully visible (not clipped) and never spills over the About rail.
+   The root is styled-components, so target the stable renderer ids + react-pdf
+   canvas directly. */
+#pdf-renderer,
+#image-renderer,
+#msdoc-renderer,
+#proxy-renderer {
+  width: 100% !important;
+  max-width: 100% !important;
+}
+
+#pdf-renderer .react-pdf__Document,
+#pdf-renderer .react-pdf__Page {
+  max-width: 100% !important;
+}
+
+#pdf-renderer canvas,
+#pdf-renderer .react-pdf__Page__svg {
+  height: auto !important;
+  max-width: 100% !important;
+  margin: 0 auto;
+}
+
+#image-renderer img,
+#proxy-renderer img {
+  max-width: 100% !important;
+  height: auto !important;
 }
 
 /* docx-preview: DocxViewer scales the wrapper (CSS zoom) to fit the box, so

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -150,6 +150,32 @@ code {
   max-width: 100% !important;
 }
 
+/* Keep the pages (paginated or continuous-scroll) scrolling INSIDE the fixed
+   preview box instead of growing the whole page. The DocViewer root is a flex
+   column; proxy-renderer fills the remaining height and pdf-renderer scrolls. */
+#proxy-renderer {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
+}
+
+#pdf-renderer {
+  height: 100% !important;
+  overflow-y: auto !important;
+}
+
+/* Keep the toolbar pinned while the pages scroll under it. */
+#pdf-controls {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+}
+
+#pdf-renderer #pdf-page-wrapper + #pdf-page-wrapper,
+#pdf-renderer .react-pdf__Page + .react-pdf__Page {
+  margin-top: 12px;
+}
+
 #pdf-renderer .react-pdf__Document,
 #pdf-renderer .react-pdf__Page {
   max-width: 100% !important;

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -188,6 +188,16 @@ code {
   margin: 0 auto;
 }
 
+/* react-doc-viewer doesn't ship react-pdf's TextLayer.css, so the text layer
+   renders as visible extracted text under each page instead of a transparent
+   selection overlay. The canvas already shows the page — hide these layers. */
+#pdf-renderer .react-pdf__Page__textContent,
+#pdf-renderer .react-pdf__Page__annotations,
+#pdf-renderer .react-pdf__Page__structTree,
+#pdf-renderer .react-pdf__message {
+  display: none !important;
+}
+
 #image-renderer img,
 #proxy-renderer img {
   max-width: 100% !important;

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -219,6 +219,71 @@ code {
   z-index: 2;
 }
 
+/* react-doc-viewer PDF toolbar: tidy it up to match the app aesthetic — round
+   the top to match the preview box, flatten the shadow, and give the controls
+   consistent rounded hit-areas with a subtle hover. Its accent color comes from
+   the DocViewer `theme` prop (the app theme color). */
+#pdf-controls {
+  box-shadow: none !important;
+  border-radius: 6px 6px 0 0;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+  min-height: 42px !important;
+  padding: 4px 12px !important;
+  gap: 6px;
+}
+
+/* Uniform, borderless icon buttons; the icons are hardcoded black in the lib,
+   so recolor them to the theme color and size them consistently. */
+#pdf-controls button,
+#pdf-controls a#pdf-download {
+  width: 32px;
+  height: 32px;
+  min-width: 32px;
+  padding: 0 !important;
+  display: inline-flex !important;
+  align-items: center;
+  justify-content: center;
+  border: none !important;
+  background: transparent !important;
+  box-shadow: none !important;
+  border-radius: 8px !important;
+  transition: background 0.15s ease;
+}
+
+#pdf-controls button svg,
+#pdf-controls a#pdf-download svg {
+  color: var(--theme-color, #404040) !important;
+  width: 18px !important;
+  height: 18px !important;
+}
+
+#pdf-controls button:hover,
+#pdf-controls a#pdf-download:hover {
+  background: rgba(0, 0, 0, 0.06) !important;
+}
+
+#pdf-controls button:active,
+#pdf-controls a#pdf-download:active {
+  background: rgba(0, 0, 0, 0.1) !important;
+}
+
+#pdf-controls button:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+#pdf-controls button:disabled:hover {
+  background: transparent !important;
+}
+
+#pdf-pagination-info,
+#pdf-page-info {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--theme-color, #404040);
+  padding: 0 6px;
+}
+
 /*.ant-modal-content {*/
 /*  padding: 0 !important;*/
 /*  background-color: transparent !important;*/


### PR DESCRIPTION
### What
react-doc-viewer renders each PDF page as a canvas plus a react-pdf text layer, but doesn't ship react-pdf's TextLayer.css, so the text layer showed as visible extracted text below the page instead of a transparent selection overlay. Hide the text / annotation / struct layers — the canvas already renders the page.