### PR TITLE
fix: make the Office Online docx/xlsx preview fill the preview box

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -129,6 +129,15 @@ code {
   height: auto;
 }
 
+/* Make the Office Online (msdoc) docx / xlsx preview fill the preview box.
+   react-doc-viewer's #msdoc-iframe is height:100%, but its parent chain
+   (#proxy-renderer / #msdoc-renderer) had no height, so the iframe collapsed to
+   its default ~150px and only a top slice of the document was visible. */
+#proxy-renderer,
+#msdoc-renderer {
+  height: 100% !important;
+}
+
 /*.ant-modal-content {*/
 /*  padding: 0 !important;*/
 /*  background-color: transparent !important;*/


### PR DESCRIPTION
## Summary

docx / xlsx files previewed on the store Overview only showed a top slice of the document instead of filling the preview box.

## Changes

- Set `height: 100%` on `#proxy-renderer` / ss` so the Office Online docx/xlsx iframe fills the preview box instead of collapsing to a top slice.