### PR TITLE
docs: add TakoAPI directory badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ Prerequisites:
 
 ```bash
 # Backend
+
+[![Listed on TakoAPI](https://takoapi.com/api/badge/the-open-agent-openagent)](https://takoapi.com/agents/the-open-agent-openagent)
+
 go build
 
 # Frontend


### PR DESCRIPTION
Hi! 👋 **openagent** is listed in the [TakoAPI](https://takoapi.com) open agent directory — a free, open catalog that helps people discover AI-agent projects ("one API to discover all agents").

Your listing: https://takoapi.com/agents/the-open-agent-openagent

This PR adds a small badge near the top of the README that links back to that listing, so visitors can find the directory entry. It's entirely optional — if you'd prefer not to include it, just close this PR (no hard feelings, and apologies for the noise).

No tracking and no obligations. Thanks for building openagent! 🙏