### PR TITLE
fix: robust SKILL.md front-matter parsing + new Ollama skill

### DIFF
--- a/object/skill.go
+++ b/object/skill.go
@@ -88,7 +88,9 @@ func parseSkillMd(raw string) (name, description, homepage, metadata, emoji, bod
 	}
 
 	// Skip the opening "---" line
-	afterOpen := raw[strings.Index(raw, "---")+3:]
+	// Use the trimmed string for parsing so leading whitespace before the first
+	// front-matter delimiter does not break index calculations.
+	afterOpen := trimmed[strings.Index(trimmed, "---")+3:]
 	newlineIdx := strings.Index(afterOpen, "\n")
 	if newlineIdx >= 0 {
 		afterOpen = afterOpen[newlineIdx+1:]

--- a/object/skill_test.go
+++ b/object/skill_test.go
@@ -1,0 +1,47 @@
+package object
+
+import "testing"
+
+func TestParseSkillMd_AllowsLeadingWhitespaceBeforeFrontMatter(t *testing.T) {
+	raw := `
+
+    ---
+name: test-skill
+description: "hello"
+homepage: https://example.com
+metadata:
+  { "openclaw": { "emoji": "🧪" } }
+---
+# Body
+Some content
+`
+
+	name, description, homepage, metadata, emoji, body := parseSkillMd(raw)
+	if name != "test-skill" {
+		t.Fatalf("name=%q, want %q", name, "test-skill")
+	}
+	if description != "hello" {
+		t.Fatalf("description=%q, want %q", description, "hello")
+	}
+	if homepage != "https://example.com" {
+		t.Fatalf("homepage=%q, want %q", homepage, "https://example.com")
+	}
+	if emoji != "🧪" {
+		t.Fatalf("emoji=%q, want %q", emoji, "🧪")
+	}
+	if metadata == "" {
+		t.Fatalf("metadata is empty, want non-empty")
+	}
+	if body == "" || body[0] != '#' {
+		t.Fatalf("body=%q, want markdown body starting with #", body)
+	}
+}
+
+func TestParseSkillMd_NoFrontMatterReturnsBodyUnchanged(t *testing.T) {
+	raw := "Hello\nWorld\n"
+	_, _, _, _, _, body := parseSkillMd(raw)
+	if body != raw {
+		t.Fatalf("body=%q, want %q", body, raw)
+	}
+}
+

--- a/skills/ollama-models/SKILL.md
+++ b/skills/ollama-models/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: ollama-models
+description: Manage local Ollama models (pull, list, run) and wire them into OpenAgent.
+homepage: https://ollama.com/
+metadata:
+  { "openclaw": { "emoji": "🦙" } }
+---
+
+## Goal
+
+Help the user work with **local Ollama models** and configure them in OpenAgent.
+
+## What you can do
+
+- List installed models
+- Pull any model by name
+- Run a quick smoke test prompt
+- Tell the user what model name to put in the OpenAgent **Ollama provider Sub type**
+
+## Commands
+
+1) List models:
+
+```bash
+ollama list
+```
+
+2) Pull a model (examples):
+
+```bash
+ollama pull qwen2.5:7b
+ollama pull llama3.2:3b
+ollama pull deepseek-r1:7b
+```
+
+3) Run a model:
+
+```bash
+ollama run qwen2.5:7b
+```
+
+## OpenAgent wiring checklist
+
+- Ollama server URL: `http://localhost:11434`
+- Sub type: the exact name from `ollama list` (e.g. `qwen2.5:7b`)
+- If you see `404 model not found`, pull the model first (`ollama pull <name>`)
+


### PR DESCRIPTION
## Summary
- Fix SKILL.md front-matter parsing when the file starts with leading whitespace/newlines.
- Add unit tests for parseSkillMd().
- Add built-in skill: skills/ollama-models (pull/list/run + wiring tips).

## Test plan
```bash
go test -v -tags skipCi -vet=... ./...
```