### PR TITLE
fix: Ollama embeddings URL + safer i18n errors

### DIFF
--- a/embedding/jina.go
+++ b/embedding/jina.go
@@ -18,11 +18,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
-
-	"github.com/the-open-agent/openagent/i18n"
 )
 
 type JinaEmbeddingProvider struct {
@@ -59,7 +56,7 @@ func (p *JinaEmbeddingProvider) calculatePrice(res *EmbeddingResult) error {
 
 func (p *JinaEmbeddingProvider) QueryVector(text string, ctx context.Context, lang string) ([]float32, *EmbeddingResult, error) {
 	if text == "" {
-		return nil, nil, fmt.Errorf(i18n.Translate(lang, "embedding:text cannot be empty"))
+		return nil, nil, newI18nError(lang, "embedding:text cannot be empty")
 	}
 
 	url := "https://api.jina.ai/v1/embeddings"
@@ -67,7 +64,7 @@ func (p *JinaEmbeddingProvider) QueryVector(text string, ctx context.Context, la
 	model := p.subType
 
 	if text == "" {
-		return nil, nil, fmt.Errorf(i18n.Translate(lang, "embedding:text can not be empty."))
+		return nil, nil, newI18nError(lang, "embedding:text can not be empty.")
 	}
 
 	payload := map[string]interface{}{
@@ -79,12 +76,12 @@ func (p *JinaEmbeddingProvider) QueryVector(text string, ctx context.Context, la
 
 	reqBody, err := json.Marshal(payload)
 	if err != nil {
-		return nil, nil, fmt.Errorf(i18n.Translate(lang, "embedding:failed to marshal payload: %v"), err)
+		return nil, nil, newI18nError(lang, "embedding:failed to marshal payload: %v", err)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(reqBody))
 	if err != nil {
-		return nil, nil, fmt.Errorf(i18n.Translate(lang, "embedding:failed to create request: %v"), err)
+		return nil, nil, newI18nError(lang, "embedding:failed to create request: %v", err)
 	}
 
 	req.Header.Set("Content-Type", "application/json")
@@ -98,12 +95,12 @@ func (p *JinaEmbeddingProvider) QueryVector(text string, ctx context.Context, la
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, nil, fmt.Errorf(i18n.Translate(lang, "embedding:failed to get valid response, status code: %d"), resp.StatusCode)
+		return nil, nil, newI18nError(lang, "embedding:failed to get valid response, status code: %d", resp.StatusCode)
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, nil, fmt.Errorf(i18n.Translate(lang, "embedding:failed to read response body: %v"), err)
+		return nil, nil, newI18nError(lang, "embedding:failed to read response body: %v", err)
 	}
 
 	var apiResponse struct {
@@ -118,11 +115,11 @@ func (p *JinaEmbeddingProvider) QueryVector(text string, ctx context.Context, la
 		} `json:"data"`
 	}
 	if err := json.Unmarshal(body, &apiResponse); err != nil {
-		return nil, nil, fmt.Errorf(i18n.Translate(lang, "embedding:failed to unmarshal response: %v"), err)
+		return nil, nil, newI18nError(lang, "embedding:failed to unmarshal response: %v", err)
 	}
 
 	if len(apiResponse.Data) == 0 {
-		return nil, nil, fmt.Errorf(i18n.Translate(lang, "embedding:no embeddings found in the response"))
+		return nil, nil, newI18nError(lang, "embedding:no embeddings found in the response")
 	}
 	embedding := apiResponse.Data[0].Embedding
 
@@ -132,7 +129,7 @@ func (p *JinaEmbeddingProvider) QueryVector(text string, ctx context.Context, la
 
 	err = p.calculatePrice(embeddingResult)
 	if err != nil {
-		return nil, nil, fmt.Errorf(i18n.Translate(lang, "embedding:failed to calculate price: %v"), err)
+		return nil, nil, newI18nError(lang, "embedding:failed to calculate price: %v", err)
 	}
 
 	return embedding, embeddingResult, nil

--- a/embedding/local.go
+++ b/embedding/local.go
@@ -37,6 +37,19 @@ type LocalEmbeddingProvider struct {
 	currency               string
 }
 
+// normalizeOllamaBaseURL ensures the URL ends with exactly "/v1",
+// regardless of whether the user typed trailing slashes or included "/v1".
+func normalizeOllamaBaseURL(rawURL string) string {
+	u := strings.TrimRight(rawURL, "/")
+	if u == "" {
+		return ""
+	}
+	if !strings.HasSuffix(u, "/v1") {
+		u += "/v1"
+	}
+	return u
+}
+
 func NewLocalEmbeddingProvider(typ string, subType string, secretKey string, providerUrl string, compatibleProvider string, pricePerThousandTokens float64, currency string) (*LocalEmbeddingProvider, error) {
 	p := &LocalEmbeddingProvider{
 		typ:                    typ,
@@ -118,7 +131,7 @@ func (p *LocalEmbeddingProvider) QueryVector(text string, ctx context.Context, l
 	if model == "custom-embedding" && p.compatibleProvider != "" {
 		model = p.compatibleProvider
 	} else if model == "custom-embedding" && p.compatibleProvider == "" {
-		return nil, nil, fmt.Errorf(i18n.Translate(lang, "embedding:no embedding provider specified"))
+		return nil, nil, newI18nError(lang, "embedding:no embedding provider specified")
 	}
 
 	resp, err := client.CreateEmbeddings(ctx, openai.EmbeddingRequest{

--- a/embedding/local_test.go
+++ b/embedding/local_test.go
@@ -1,0 +1,41 @@
+package embedding
+
+import "testing"
+
+func TestNormalizeOllamaBaseURL(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"", ""},
+		{"http://localhost:11434", "http://localhost:11434/v1"},
+		{"http://localhost:11434/", "http://localhost:11434/v1"},
+		{"http://localhost:11434/v1", "http://localhost:11434/v1"},
+		{"http://localhost:11434/v1/", "http://localhost:11434/v1"},
+	}
+
+	for _, tt := range tests {
+		if got := normalizeOllamaBaseURL(tt.in); got != tt.want {
+			t.Fatalf("normalizeOllamaBaseURL(%q)=%q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestLocalEmbeddingProviderCalculatePrice_OllamaCustomEmbedding(t *testing.T) {
+	p, err := NewLocalEmbeddingProvider("Ollama", "custom-embedding", "k", "http://localhost:11434/v1", "nomic-embed-text", 0.00042, "INR")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res := &EmbeddingResult{TokenCount: 1000}
+	if err := p.calculatePrice(res, "en"); err != nil {
+		t.Fatalf("calculatePrice() error: %v", err)
+	}
+	if res.Currency != "INR" {
+		t.Fatalf("Currency=%q, want %q", res.Currency, "INR")
+	}
+	if res.Price != 0.00042 {
+		t.Fatalf("Price=%v, want %v", res.Price, 0.00042)
+	}
+}
+

--- a/embedding/minimax.go
+++ b/embedding/minimax.go
@@ -18,11 +18,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 
-	"github.com/the-open-agent/openagent/i18n"
 )
 
 type MiniMaxEmbeddingProvider struct {
@@ -106,7 +104,7 @@ func (p *MiniMaxEmbeddingProvider) QueryVector(text string, ctx context.Context,
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return nil, nil, fmt.Errorf(i18n.Translate(lang, "embedding:request failed with status code %d: %s"), resp.StatusCode, string(body))
+		return nil, nil, newI18nError(lang, "embedding:request failed with status code %d: %s", resp.StatusCode, string(body))
 	}
 
 	body, err := io.ReadAll(resp.Body)
@@ -117,11 +115,11 @@ func (p *MiniMaxEmbeddingProvider) QueryVector(text string, ctx context.Context,
 	var embeddingResponse EmbeddingResponse
 	err = json.Unmarshal(body, &embeddingResponse)
 	if err != nil {
-		return nil, nil, fmt.Errorf(i18n.Translate(lang, "embedding:error unmarshaling response JSON: %v"), err)
+		return nil, nil, newI18nError(lang, "embedding:error unmarshaling response JSON: %v", err)
 	}
 
 	if len(embeddingResponse.Vectors) == 0 {
-		return nil, nil, fmt.Errorf(i18n.Translate(lang, "embedding:no embedding vector found in response"))
+		return nil, nil, newI18nError(lang, "embedding:no embedding vector found in response")
 	}
 
 	embeddingResult := &EmbeddingResult{

--- a/embedding/provider.go
+++ b/embedding/provider.go
@@ -46,7 +46,9 @@ func GetEmbeddingProvider(typ string, subType string, clientId string, clientSec
 	} else if typ == "Baidu Cloud" {
 		p, err = NewBaiduCloudEmbeddingProvider(subType, clientId, clientSecret)
 	} else if typ == "Ollama" {
-		p, err = NewLocalEmbeddingProvider("Custom", "custom-embedding", "randomString", providerUrl, subType, pricePerThousandTokens, currency)
+		// Ollama supports OpenAI-compatible embeddings under /v1/embeddings.
+		// Normalize the base URL so users can enter "http://localhost:11434".
+		p, err = NewLocalEmbeddingProvider("Ollama", "custom-embedding", "randomString", normalizeOllamaBaseURL(providerUrl), subType, pricePerThousandTokens, currency)
 	} else if typ == "Local" {
 		p, err = NewLocalEmbeddingProvider(typ, subType, clientSecret, providerUrl, compatibleProvider, pricePerThousandTokens, currency)
 	} else if typ == "Azure" {

--- a/embedding/tencentcloud.go
+++ b/embedding/tencentcloud.go
@@ -16,12 +16,10 @@ package embedding
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common"
 	"github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/profile"
 	hunyuan "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/hunyuan/v20230901"
-	"github.com/the-open-agent/openagent/i18n"
 )
 
 type TencentCloudEmbeddingProvider struct {
@@ -34,7 +32,7 @@ func NewTencentCloudEmbeddingProvider(clientId, clientSecret string, lang string
 	cpf := profile.NewClientProfile()
 	client, err := hunyuan.NewClient(credential, region, cpf)
 	if err != nil {
-		return nil, fmt.Errorf(i18n.Translate(lang, "embedding:failed to create client: %v"), err)
+		return nil, newI18nError(lang, "embedding:failed to create client: %v", err)
 	}
 	return &TencentCloudEmbeddingProvider{
 		client: client,
@@ -71,7 +69,7 @@ func (p *TencentCloudEmbeddingProvider) QueryVector(text string, ctx context.Con
 	}
 
 	if len(response.Response.Data) == 0 {
-		return nil, nil, fmt.Errorf(i18n.Translate(lang, "embedding:no embedding vector found in response"))
+		return nil, nil, newI18nError(lang, "embedding:no embedding vector found in response")
 	}
 
 	vector := make([]float32, len(response.Response.Data[0].Embedding))

--- a/embedding/util.go
+++ b/embedding/util.go
@@ -14,7 +14,13 @@
 
 package embedding
 
-import "math"
+import (
+	"errors"
+	"fmt"
+	"math"
+
+	"github.com/the-open-agent/openagent/i18n"
+)
 
 func getPrice(tokenCount int, pricePerThousandTokens float64) float64 {
 	res := (float64(tokenCount) / 1000.0) * pricePerThousandTokens
@@ -28,4 +34,14 @@ func float64ToFloat32(slice []float64) []float32 {
 		newSlice[i] = float32(v)
 	}
 	return newSlice
+}
+
+// newI18nError formats an i18n message safely without triggering go vet's
+// "non-constant format string" warning on fmt.Errorf.
+func newI18nError(lang string, format string, args ...any) error {
+	msg := i18n.Translate(lang, format)
+	if len(args) > 0 {
+		msg = fmt.Sprintf(msg, args...)
+	}
+	return errors.New(msg)
 }

--- a/embedding/word2vec.go
+++ b/embedding/word2vec.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/the-open-agent/openagent/i18n"
 )
 
 type Word2VecEmbeddingProvider struct {
@@ -41,7 +40,7 @@ func NewWord2VecEmbeddingProvider(typ string, subType string, lang string) (*Wor
 	// Initialize the dictionary
 	err := p.loadModel(lang)
 	if err != nil {
-		return nil, fmt.Errorf(i18n.Translate(lang, "embedding:failed to load word2vec model: %v"), err)
+		return nil, newI18nError(lang, "embedding:failed to load word2vec model: %v", err)
 	}
 
 	return p, nil
@@ -50,7 +49,7 @@ func NewWord2VecEmbeddingProvider(typ string, subType string, lang string) (*Wor
 func (p *Word2VecEmbeddingProvider) loadModel(lang string) error {
 	file, err := os.Open(p.modelPath)
 	if err != nil {
-		return fmt.Errorf(i18n.Translate(lang, "embedding:failed to open model file: %v"), err)
+		return newI18nError(lang, "embedding:failed to open model file: %v", err)
 	}
 	defer file.Close()
 
@@ -59,7 +58,7 @@ func (p *Word2VecEmbeddingProvider) loadModel(lang string) error {
 	var wordCount int
 	_, err = fmt.Fscanf(br, "%d %d\n", &wordCount, &p.dim)
 	if err != nil {
-		return fmt.Errorf(i18n.Translate(lang, "embedding:failed to read header: %v"), err)
+		return newI18nError(lang, "embedding:failed to read header: %v", err)
 	}
 
 	p.dict = make(map[string][]float32, wordCount)
@@ -67,14 +66,14 @@ func (p *Word2VecEmbeddingProvider) loadModel(lang string) error {
 	for i := 0; i < wordCount; i++ {
 		word, err := br.ReadString(' ')
 		if err != nil {
-			return fmt.Errorf(i18n.Translate(lang, "embedding:failed to read word: %v"), err)
+			return newI18nError(lang, "embedding:failed to read word: %v", err)
 		}
 		word = word[:len(word)-1] // Remove trailing space
 
 		vector := make([]float32, p.dim)
 		err = binary.Read(br, binary.LittleEndian, &vector)
 		if err != nil {
-			return fmt.Errorf(i18n.Translate(lang, "embedding:failed to read vector: %v"), err)
+			return newI18nError(lang, "embedding:failed to read vector: %v", err)
 		}
 
 		p.dict[word] = vector
@@ -93,7 +92,7 @@ func (p *Word2VecEmbeddingProvider) GetPricing() string {
 func (p *Word2VecEmbeddingProvider) QueryVector(text string, ctx context.Context, lang string) ([]float32, *EmbeddingResult, error) {
 	tokens := strings.Fields(text) // Split words by spaces
 	if len(tokens) == 0 {
-		return nil, nil, fmt.Errorf(i18n.Translate(lang, "embedding:input text is empty"))
+		return nil, nil, newI18nError(lang, "embedding:input text is empty")
 	}
 
 	vectors := make([][]float32, 0, len(tokens))
@@ -107,7 +106,7 @@ func (p *Word2VecEmbeddingProvider) QueryVector(text string, ctx context.Context
 	}
 
 	if foundCount == 0 {
-		return nil, nil, fmt.Errorf(i18n.Translate(lang, "embedding:none of the tokens were found in the vocabulary"))
+		return nil, nil, newI18nError(lang, "embedding:none of the tokens were found in the vocabulary")
 	}
 
 	// Calculate the average vector


### PR DESCRIPTION
## Summary
- Normalize Ollama embedding base URL to end with /v1 so users can enter http://localhost:11434.
- Treat Ollama embeddings as OpenAI-compatible custom embeddings (currency/pricing respected).
- Add unit tests for URL normalization and pricing.
- Replace fmt.Errorf(i18n.Translate(...)) with a safe helper to satisfy go vet.

## Test plan
```bash
go test ./embedding/...
go test -v -tags skipCi -vet=... ./...
```