### PR TITLE
feat: add tool permission guard

### DIFF
--- a/guard/casbin_guard.go
+++ b/guard/casbin_guard.go
@@ -1,0 +1,246 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package guard
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/casbin/casbin/v2"
+	casbinmodel "github.com/casbin/casbin/v2/model"
+)
+
+// modelText is the casbin model backing the guard. Every policy carries the
+// real tri-state effect in its own column while the casbin effect column (eft)
+// is always "allow"; this lets casbin do role resolution, glob matching and
+// priority ordering for us, and we read the true effect off the matched rule.
+// Rules are loaded highest-priority-first so the priority effector's
+// first-match-wins yields the highest-priority matching rule. The last policy
+// column is named "rank", not casbin's reserved "priority" token: were it
+// "priority", casbin would insertion-sort policies by ascending number as soon
+// as its field index gets built (an adapter LoadPolicy, GetFieldIndex, ...),
+// silently reversing the highest-first order we establish in Go here.
+const modelText = `
+[request_definition]
+r = sub, tool, cat, res
+
+[policy_definition]
+p = sub, tool, cat, res, effect, eft, rank, name
+
+[role_definition]
+g = _, _
+
+[policy_effect]
+e = priority(p.eft) || deny
+
+[matchers]
+m = (p.sub == "*" || g(r.sub, p.sub)) && gmatch(r.tool, p.tool) && gmatch(r.cat, p.cat) && gmatch(r.res, p.res)
+`
+
+// CasbinGuard is the casbin-backed Guard implementation.
+type CasbinGuard struct {
+	enforcer *casbin.Enforcer
+	def      Effect
+}
+
+var regexCache sync.Map // pattern string -> *regexp.Regexp
+
+// gmatch reports whether value matches a glob pattern. "*"/"" match anything;
+// a pattern without wildcards is compared for exact equality; otherwise "*"
+// and "?" are treated as glob wildcards anchored to the whole string.
+func gmatch(args ...interface{}) (interface{}, error) {
+	value, _ := args[0].(string)
+	pattern, _ := args[1].(string)
+	return globMatch(value, pattern), nil
+}
+
+func globMatch(value, pattern string) bool {
+	if pattern == "" || pattern == "*" {
+		return true
+	}
+	if !strings.ContainsAny(pattern, "*?") {
+		return value == pattern
+	}
+	re := compileGlob(pattern)
+	if re == nil {
+		return value == pattern
+	}
+	return re.MatchString(value)
+}
+
+func compileGlob(pattern string) *regexp.Regexp {
+	if cached, ok := regexCache.Load(pattern); ok {
+		return cached.(*regexp.Regexp)
+	}
+	var b strings.Builder
+	b.WriteString("^")
+	for _, r := range pattern {
+		switch r {
+		case '*':
+			b.WriteString(".*")
+		case '?':
+			b.WriteString(".")
+		default:
+			b.WriteString(regexp.QuoteMeta(string(r)))
+		}
+	}
+	b.WriteString("$")
+	re, err := regexp.Compile(b.String())
+	if err != nil {
+		return nil
+	}
+	regexCache.Store(pattern, re)
+	return re
+}
+
+func effectRank(e Effect) int {
+	switch e {
+	case EffectDeny:
+		return 3
+	case EffectAsk:
+		return 2
+	default:
+		return 1
+	}
+}
+
+// validEffect reports whether e is one of the three known effects.
+func validEffect(e Effect) bool {
+	switch e {
+	case EffectAllow, EffectAsk, EffectDeny:
+		return true
+	}
+	return false
+}
+
+// NewCasbinGuard builds a Guard from a Policy. It is safe for concurrent Check
+// calls but is immutable — rebuild it when the policy changes.
+func NewCasbinGuard(policy Policy) (*CasbinGuard, error) {
+	m, err := casbinmodel.NewModelFromString(modelText)
+	if err != nil {
+		return nil, err
+	}
+
+	e, err := casbin.NewEnforcer(m)
+	if err != nil {
+		return nil, err
+	}
+	e.AddFunction("gmatch", gmatch)
+
+	if policy.Default != "" && !validEffect(policy.Default) {
+		return nil, fmt.Errorf("guard: invalid default effect %q (want allow, ask or deny)", policy.Default)
+	}
+
+	for _, link := range policy.Roles {
+		if link.Child == "" || link.Parent == "" {
+			continue
+		}
+		if _, err := e.AddGroupingPolicy(link.Child, link.Parent); err != nil {
+			return nil, err
+		}
+	}
+
+	// Sort rules highest-priority-first; ties broken deny > ask > allow so a
+	// deny at the same priority as an allow wins.
+	rules := make([]Rule, len(policy.Rules))
+	copy(rules, policy.Rules)
+	sort.SliceStable(rules, func(i, j int) bool {
+		if rules[i].Priority != rules[j].Priority {
+			return rules[i].Priority > rules[j].Priority
+		}
+		return effectRank(rules[i].Effect) > effectRank(rules[j].Effect)
+	})
+
+	for _, rule := range rules {
+		if rule.Effect != "" && !validEffect(rule.Effect) {
+			return nil, fmt.Errorf("guard: invalid effect %q in rule %q (want allow, ask or deny)", rule.Effect, rule.Name)
+		}
+		eff := rule.Effect
+		if eff == "" {
+			eff = EffectAllow
+		}
+		_, err := e.AddPolicy(
+			orStar(rule.Subject),
+			orStar(rule.Tool),
+			orStar(rule.Category),
+			orStar(rule.Resource),
+			string(eff),
+			"allow",
+			strconv.Itoa(rule.Priority),
+			rule.Name,
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	def := policy.Default
+	if def == "" {
+		// A permission engine must not silently allow when nothing is configured;
+		// default to ask so an unconfigured host fails safe (deny is also valid).
+		def = EffectAsk
+	}
+
+	return &CasbinGuard{enforcer: e, def: def}, nil
+}
+
+func orStar(s string) string {
+	if s == "" {
+		return "*"
+	}
+	return s
+}
+
+// Check resolves the effect for a request via the casbin enforcer.
+func (g *CasbinGuard) Check(ctx context.Context, req Request) (Decision, error) {
+	ok, explains, err := g.enforcer.EnforceEx(
+		orStar(req.Subject),
+		orStar(req.Tool),
+		orStar(req.Category),
+		orStar(req.Resource),
+	)
+	if err != nil {
+		return Decision{}, err
+	}
+
+	// A matched rule always has eft "allow", so ok==true means some rule
+	// matched; explains holds that rule and column 4 is its real effect.
+	if ok && len(explains) >= 5 {
+		return Decision{
+			Effect: Effect(explains[4]),
+			Reason: fmt.Sprintf("matched rule (tool=%s, res=%s, effect=%s)", explains[1], explains[3], explains[4]),
+			Rule:   ruleName(explains),
+		}, nil
+	}
+
+	return Decision{
+		Effect: g.def,
+		Reason: "no matching rule; default effect",
+	}, nil
+}
+
+// ruleName returns the matched rule's Name (the last policy column), or "" when
+// the rule was defined without one.
+func ruleName(explains []string) string {
+	if len(explains) >= 8 {
+		return explains[7]
+	}
+	return ""
+}

--- a/guard/guard.go
+++ b/guard/guard.go
@@ -1,0 +1,120 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package guard is a standalone, host-agnostic permission engine for agent
+// tool calls. It has no dependency on OpenAgent (no object/model/beego imports)
+// so it can be reused as-is by other agents (Longxia, Hermes, ...).
+//
+// The host maps its own domain (agent, store, user, tool call)
+// into a Request, provides policy rules, and receives an Effect back. What the
+// host does with an "Ask" effect is delegated to an Approver the host supplies.
+package guard
+
+import "context"
+
+// Effect is the outcome of a permission decision.
+type Effect string
+
+const (
+	// EffectAllow lets the tool call run without interruption.
+	EffectAllow Effect = "allow"
+	// EffectAsk requires an out-of-band approval before the call may run.
+	EffectAsk Effect = "ask"
+	// EffectDeny blocks the tool call.
+	EffectDeny Effect = "deny"
+)
+
+// Category is a coarse capability class used to write broad rules without
+// enumerating every tool. Hosts tag each tool with one of these (or a custom
+// value); policies may target a category instead of a specific tool name.
+const (
+	CategoryRead      = "read"
+	CategoryWrite     = "write"
+	CategoryExec      = "exec"
+	CategoryNetwork   = "network"
+	CategorySensitive = "sensitive"
+	CategoryUnknown   = "unknown"
+)
+
+// Request describes a single tool call to be authorized. Every field is a
+// plain string so the engine stays decoupled from any host type.
+type Request struct {
+	// Subject is the caller identity/role the rules are written against
+	// (e.g. an agent id, a store name, or a role). Role hierarchy is honored.
+	Subject string
+	// Tool is the concrete tool name being invoked (e.g. "shell", "web_fetch").
+	Tool string
+	// Category is the tool's capability class (see Category* constants).
+	Category string
+	// Resource is the single most security-relevant argument of the call —
+	// the host picks it per tool (a shell command, a file path, a URL host).
+	// Rules may pattern-match against it for fine-grained control.
+	Resource string
+}
+
+// Decision is the resolved outcome plus provenance for auditing.
+type Decision struct {
+	Effect Effect
+	// Reason is a short human-readable explanation (matched rule or default).
+	Reason string
+	// Rule is the id/name of the matched policy rule, empty if defaulted.
+	Rule string
+}
+
+// Guard authorizes tool calls against a policy set.
+type Guard interface {
+	// Check resolves an Effect for the request. It never executes anything.
+	Check(ctx context.Context, req Request) (Decision, error)
+}
+
+// Approver resolves an EffectAsk decision into a concrete allow/deny. The host
+// implements the transport (prompt the user over SSE, a webhook, auto-deny in
+// headless runs, ...). Returning an error is treated by callers as a denial.
+type Approver interface {
+	RequestApproval(ctx context.Context, req Request, d Decision) (approved bool, err error)
+}
+
+// Rule is one policy entry. Pattern fields accept "*" (any), an exact string,
+// or a glob using "*"/"?" wildcards (anchored). Subject participates in role
+// hierarchy: a rule for subject "admin" also applies to roles that inherit it.
+type Rule struct {
+	// Name identifies the rule for auditing (optional); surfaced as Decision.Rule.
+	Name string
+	// Subject/Tool/Category/Resource are match patterns ("*" = any).
+	Subject  string
+	Tool     string
+	Category string
+	Resource string
+	// Effect is what to apply when this rule matches.
+	Effect Effect
+	// Priority orders rules; the highest-priority matching rule wins.
+	// By convention deny > ask > allow so denies override, but the host is
+	// free to choose. Ties are broken deterministically (deny > ask > allow).
+	Priority int
+}
+
+// RoleLink expresses "child inherits parent" for subject role hierarchy,
+// e.g. {Child: "store-x", Parent: "user"}.
+type RoleLink struct {
+	Child  string
+	Parent string
+}
+
+// Policy is the full rule set plus role hierarchy and the default effect used
+// when no rule matches.
+type Policy struct {
+	Rules   []Rule
+	Roles   []RoleLink
+	Default Effect
+}

--- a/guard/guard_test.go
+++ b/guard/guard_test.go
@@ -1,0 +1,175 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package guard
+
+import (
+	"context"
+	"testing"
+)
+
+func mustGuard(t *testing.T, p Policy) *CasbinGuard {
+	t.Helper()
+	g, err := NewCasbinGuard(p)
+	if err != nil {
+		t.Fatalf("NewCasbinGuard: %v", err)
+	}
+	return g
+}
+
+func check(t *testing.T, g *CasbinGuard, req Request) Effect {
+	t.Helper()
+	d, err := g.Check(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Check(%+v): %v", req, err)
+	}
+	return d.Effect
+}
+
+func TestDefaultEffectWhenNoRuleMatches(t *testing.T) {
+	g := mustGuard(t, Policy{Default: EffectDeny})
+	if got := check(t, g, Request{Subject: "a", Tool: "shell"}); got != EffectDeny {
+		t.Errorf("want deny, got %s", got)
+	}
+
+	g2 := mustGuard(t, Policy{Default: EffectAllow})
+	if got := check(t, g2, Request{Subject: "a", Tool: "shell"}); got != EffectAllow {
+		t.Errorf("want allow, got %s", got)
+	}
+}
+
+func TestEmptyPolicyDefaultsToAsk(t *testing.T) {
+	// An unconfigured policy must not silently allow; it defaults to ask.
+	g := mustGuard(t, Policy{})
+	if got := check(t, g, Request{Subject: "a", Tool: "shell"}); got != EffectAsk {
+		t.Errorf("empty policy should default to ask, got %s", got)
+	}
+}
+
+func TestInvalidEffectRejected(t *testing.T) {
+	if _, err := NewCasbinGuard(Policy{Rules: []Rule{{Tool: "shell", Effect: "DENY"}}}); err == nil {
+		t.Error(`rule effect "DENY" (uppercase) should be rejected, not passed through`)
+	}
+	if _, err := NewCasbinGuard(Policy{Default: "nope"}); err == nil {
+		t.Error("invalid default effect should be rejected")
+	}
+}
+
+func TestRuleNameInDecision(t *testing.T) {
+	// Decision.Rule should carry the matched rule's Name, not a joined policy row.
+	g := mustGuard(t, Policy{
+		Default: EffectAllow,
+		Rules: []Rule{
+			{Name: "no-shell", Tool: "shell", Effect: EffectDeny, Priority: 100},
+		},
+	})
+	d, err := g.Check(context.Background(), Request{Tool: "shell"})
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if d.Effect != EffectDeny {
+		t.Fatalf("want deny, got %s", d.Effect)
+	}
+	if d.Rule != "no-shell" {
+		t.Errorf("Decision.Rule = %q, want %q", d.Rule, "no-shell")
+	}
+}
+
+func TestCategoryRuleMatches(t *testing.T) {
+	g := mustGuard(t, Policy{
+		Default: EffectAsk,
+		Rules: []Rule{
+			{Category: CategoryRead, Effect: EffectAllow, Priority: 100},
+		},
+	})
+	if got := check(t, g, Request{Tool: "web_fetch", Category: CategoryRead}); got != EffectAllow {
+		t.Errorf("read should be allowed, got %s", got)
+	}
+	if got := check(t, g, Request{Tool: "shell", Category: CategoryExec}); got != EffectAsk {
+		t.Errorf("exec should fall through to default ask, got %s", got)
+	}
+}
+
+func TestDenyOverridesAllowAtSamePriority(t *testing.T) {
+	g := mustGuard(t, Policy{
+		Default: EffectAllow,
+		Rules: []Rule{
+			{Tool: "*", Effect: EffectAllow, Priority: 100},
+			{Tool: "shell", Effect: EffectDeny, Priority: 100},
+		},
+	})
+	if got := check(t, g, Request{Tool: "shell"}); got != EffectDeny {
+		t.Errorf("deny should override allow at same priority, got %s", got)
+	}
+	if got := check(t, g, Request{Tool: "web_fetch"}); got != EffectAllow {
+		t.Errorf("non-shell should be allowed, got %s", got)
+	}
+}
+
+func TestPriorityOrdering(t *testing.T) {
+	g := mustGuard(t, Policy{
+		Default: EffectDeny,
+		Rules: []Rule{
+			{Tool: "shell", Effect: EffectDeny, Priority: 10},
+			{Tool: "shell", Effect: EffectAllow, Priority: 50}, // higher wins
+		},
+	})
+	if got := check(t, g, Request{Tool: "shell"}); got != EffectAllow {
+		t.Errorf("higher priority allow should win, got %s", got)
+	}
+}
+
+func TestGlobToolMatch(t *testing.T) {
+	g := mustGuard(t, Policy{
+		Default: EffectAllow,
+		Rules: []Rule{
+			{Tool: "office_*", Effect: EffectAsk, Priority: 100},
+		},
+	})
+	if got := check(t, g, Request{Tool: "office_word"}); got != EffectAsk {
+		t.Errorf("office_word should match office_*, got %s", got)
+	}
+	if got := check(t, g, Request{Tool: "web_fetch"}); got != EffectAllow {
+		t.Errorf("web_fetch should not match office_*, got %s", got)
+	}
+}
+
+func TestResourcePatternMatch(t *testing.T) {
+	g := mustGuard(t, Policy{
+		Default: EffectAllow,
+		Rules: []Rule{
+			{Tool: "shell", Resource: "*rm -rf*", Effect: EffectDeny, Priority: 200},
+		},
+	})
+	if got := check(t, g, Request{Tool: "shell", Resource: "sudo rm -rf /"}); got != EffectDeny {
+		t.Errorf("dangerous command should be denied, got %s", got)
+	}
+	if got := check(t, g, Request{Tool: "shell", Resource: "ls -la"}); got != EffectAllow {
+		t.Errorf("safe command should be allowed, got %s", got)
+	}
+}
+
+func TestRoleHierarchy(t *testing.T) {
+	// store-x inherits "user"; a rule on "user" applies to "store-x".
+	g := mustGuard(t, Policy{
+		Default: EffectDeny,
+		Roles:   []RoleLink{{Child: "store-x", Parent: "user"}},
+		Rules: []Rule{
+			{Subject: "user", Category: CategoryRead, Effect: EffectAllow, Priority: 100},
+		},
+	})
+	if got := check(t, g, Request{Subject: "store-x", Tool: "web_fetch", Category: CategoryRead}); got != EffectAllow {
+		t.Errorf("store-x should inherit user's read allow, got %s", got)
+	}
+}

--- a/shellcmd/shellcmd.go
+++ b/shellcmd/shellcmd.go
@@ -1,0 +1,428 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package shellcmd extracts the executables a shell command line would run, so
+// a permission layer can allow/deny by program name (git, rm, sudo, ...) rather
+// than by fragile substring matching on the whole command. It is host-agnostic
+// and reusable by any agent that exposes a shell tool.
+//
+// The parser targets POSIX shell syntax (sh/bash/zsh). It does NOT understand
+// cmd.exe / PowerShell (%VAR% expansion, ^ escaping, batch "for %i ... do ...")
+// — a caller on a non-POSIX shell MUST treat results as unknown, e.g. short-
+// circuit to deny/ask by platform. The common %VAR% dynamic command form is
+// reported certain=false, but full non-POSIX coverage is out of scope.
+//
+// The parser is deliberately conservative and errs toward surfacing MORE
+// executables (command chaining, subshells, sudo/env wrappers, shell/eval -c
+// bodies, find -exec, control keywords, path prefixes) so an allow/deny check
+// that treats "any denied program" as a denial is hard to evade. For non-shell
+// interpreters (python -c, node -e, perl -e, awk 'BEGIN{system()}') it surfaces
+// the interpreter program itself but does NOT descend into its inline-script
+// argument, so gating relies on the interpreter's own name (python, node, ...).
+//
+// When it cannot resolve a command to concrete program names — a dynamic "$CMD"
+// or "%VAR%", an obfuscated command word — Executables returns certain=false so
+// a caller can fail CLOSED instead of trusting a possibly-incomplete list; a
+// security gate must never be evadable by making the parse fail. It is a
+// security aid, not a full shell grammar; redirection *targets* (file writes)
+// are out of scope — they are not executables and belong to a resource/path
+// check at the caller.
+package shellcmd
+
+import "strings"
+
+// wrappers run another program given as their argument; the wrapped program
+// must also be surfaced (e.g. "sudo rm" -> [sudo, rm]).
+var wrappers = map[string]bool{
+	"sudo": true, "doas": true, "env": true, "nohup": true, "time": true,
+	"nice": true, "ionice": true, "command": true, "builtin": true,
+	"exec": true, "xargs": true, "watch": true, "timeout": true,
+	"stdbuf": true, "setsid": true, "setarch": true,
+}
+
+// wrapperArgFlags lists, per wrapper, the short flags that consume the NEXT
+// token as their value (so it is not mistaken for the wrapped program). Unknown
+// flags are assumed valueless; GNU "--flag=value" needs no entry.
+var wrapperArgFlags = map[string]map[string]bool{
+	"sudo":    {"-u": true, "-g": true, "-h": true, "-p": true, "-C": true, "-r": true, "-t": true, "-T": true, "-U": true, "-R": true, "-c": true},
+	"env":     {"-u": true, "-C": true, "-S": true},
+	"nice":    {"-n": true},
+	"ionice":  {"-c": true, "-n": true, "-p": true},
+	"timeout": {"-s": true, "-k": true},
+	"xargs":   {"-n": true, "-I": true, "-i": true, "-P": true, "-d": true, "-E": true, "-L": true, "-s": true, "-a": true},
+	"watch":   {"-n": true, "-d": true},
+	"stdbuf":  {"-i": true, "-o": true, "-e": true},
+}
+
+// wrapperPositional lists wrappers that take fixed positional args before the
+// wrapped program (e.g. "timeout DURATION cmd").
+var wrapperPositional = map[string]int{"timeout": 1}
+
+// shells interpret a following -c argument as a nested command line.
+var shells = map[string]bool{
+	"sh": true, "bash": true, "zsh": true, "dash": true, "ash": true, "ksh": true,
+}
+
+// shellKeywords are reserved words that appear in command position but are not
+// programs; the real command follows them (e.g. "then rm ..."). Skipping them
+// surfaces the executable behind a control construct instead of the keyword.
+var shellKeywords = map[string]bool{
+	"if": true, "then": true, "elif": true, "else": true, "fi": true,
+	"for": true, "while": true, "until": true, "do": true, "done": true,
+	"case": true, "esac": true, "select": true, "function": true,
+	"in": true, "!": true, "coproc": true,
+}
+
+// Executables returns the distinct program names a command line would invoke,
+// normalized to their basename (so "/bin/rm" -> "rm"), preserving order.
+//
+// certain reports whether the command was fully understood. It is false when a
+// program name cannot be resolved statically (a dynamic "$CMD", an obfuscated
+// command word); a security check MUST treat certain==false as "unknown" and
+// fail closed rather than trust the returned (possibly incomplete) list.
+func Executables(command string) (exes []string, certain bool) {
+	seen := map[string]bool{}
+	certain = true
+	add := func(name string) {
+		if name == "" || seen[name] {
+			return
+		}
+		seen[name] = true
+		exes = append(exes, name)
+	}
+	for _, seg := range splitSegments(command) {
+		segExes, segCertain := segmentExecutables(seg)
+		if !segCertain {
+			certain = false
+		}
+		for _, exe := range segExes {
+			add(exe)
+		}
+	}
+	return exes, certain
+}
+
+// splitSegments breaks a command line into command-position segments at shell
+// control operators (; && || | & newline), subshells ( ) { }, and command
+// substitution $(...) / backticks, while respecting single/double quotes.
+func splitSegments(command string) []string {
+	var segs []string
+	var cur strings.Builder
+	inSingle, inDouble := false, false
+	flush := func() {
+		if s := strings.TrimSpace(cur.String()); s != "" {
+			segs = append(segs, s)
+		}
+		cur.Reset()
+	}
+
+	runes := []rune(command)
+	for i := 0; i < len(runes); i++ {
+		c := runes[i]
+		switch {
+		case inSingle:
+			cur.WriteRune(c)
+			if c == '\'' {
+				inSingle = false
+			}
+		case inDouble:
+			// Command substitution still executes inside double quotes.
+			if c == '$' && i+1 < len(runes) && runes[i+1] == '(' {
+				flush()
+				i++
+			} else if c == '`' {
+				flush()
+			} else {
+				cur.WriteRune(c)
+				if c == '"' {
+					inDouble = false
+				}
+			}
+		case c == '\'':
+			inSingle = true
+			cur.WriteRune(c)
+		case c == '"':
+			inDouble = true
+			cur.WriteRune(c)
+		case c == '&':
+			// '&' (background) and '&&' (and) break a segment, but the '&' inside a
+			// redirection (2>&1, >&2, &>file) does not — otherwise the redirect's
+			// fd/target ("1" in "2>&1") becomes a spurious command. Keep it inline.
+			if (i > 0 && runes[i-1] == '>') || (i+1 < len(runes) && runes[i+1] == '>') {
+				cur.WriteRune(c)
+			} else {
+				flush()
+			}
+		case c == ';' || c == '\n' || c == '|' || c == '(' || c == ')' || c == '{' || c == '}' || c == '`':
+			flush()
+		case c == '$' && i+1 < len(runes) && runes[i+1] == '(':
+			flush()
+			i++
+		default:
+			cur.WriteRune(c)
+		}
+	}
+	flush()
+	return segs
+}
+
+// segmentExecutables returns the executables of a single segment and whether
+// the parse is trustworthy: the leading program plus any programs it wraps
+// (sudo/env/... chains, shell -c and eval bodies, find -exec). certain is false
+// when the command name cannot be resolved statically (a dynamic $VAR or an
+// obfuscated program word), so callers can fail closed.
+func segmentExecutables(seg string) (exes []string, certain bool) {
+	tokens := tokenize(seg)
+	certain = true
+
+	i := 0
+	headerOnly := false
+	for i < len(tokens) && (isEnvAssign(tokens[i]) || shellKeywords[tokens[i]]) {
+		switch tokens[i] {
+		case "for", "select", "case":
+			// A loop/case header ("for x in ...") runs no command itself; any
+			// command substitution in its word list is split into its own
+			// segment, so this segment contributes no executable.
+			headerOnly = true
+		}
+		i++
+	}
+	if headerOnly {
+		return nil, true
+	}
+
+	for i < len(tokens) {
+		tok := tokens[i]
+		if isDynamic(tok) {
+			// e.g. "$CMD ...": the program that runs depends on runtime state.
+			return exes, false
+		}
+		exe := basename(tok)
+		if exe == "" {
+			break
+		}
+		exes = append(exes, exe)
+		if strings.ContainsAny(exe, " \t") {
+			// A program name with whitespace only arises from quoting or
+			// backslash-escaping the command word — treat as obfuscation.
+			certain = false
+		}
+
+		switch {
+		case exe == "eval":
+			// eval runs its concatenated arguments as a new command line.
+			inner, innerCertain := Executables(strings.Join(tokens[i+1:], " "))
+			exes = append(exes, inner...)
+			return exes, certain && innerCertain
+		case shells[exe]:
+			body, hasC := shellDashCArg(tokens[i+1:])
+			if hasC {
+				inner, innerCertain := Executables(body)
+				exes = append(exes, inner...)
+				certain = certain && innerCertain
+			} else {
+				// No -c: the shell runs commands from a script file or from
+				// stdin/a pipe (e.g. `echo rm -rf / | bash`), neither of which we
+				// can inspect. Fail closed so the caller denies.
+				certain = false
+			}
+			return exes, certain
+		case exe == "find":
+			inner, innerCertain := findExecPrograms(tokens[i+1:])
+			exes = append(exes, inner...)
+			return exes, certain && innerCertain
+		case wrappers[exe]:
+			// Advance past the wrapper's flags/args (and any positional args) to
+			// the wrapped program, then continue.
+			i = skipWrapperArgs(exe, tokens, i+1)
+		default:
+			return exes, certain
+		}
+	}
+	return exes, certain
+}
+
+// isDynamic reports whether a command-position token embeds an unresolved
+// expansion ($var, ${...}, or a Windows %VAR%) so its program name cannot be
+// known statically. Command substitution $(...) and backticks are already split
+// out upstream.
+func isDynamic(token string) bool {
+	return strings.ContainsAny(token, "$`%")
+}
+
+// findExecPrograms surfaces the programs a find(1) command runs via -exec /
+// -execdir / -ok / -okdir. certain is false when such a program is dynamic.
+func findExecPrograms(tokens []string) (exes []string, certain bool) {
+	certain = true
+	for i := 0; i < len(tokens); i++ {
+		switch tokens[i] {
+		case "-exec", "-execdir", "-ok", "-okdir":
+			if i+1 >= len(tokens) {
+				continue
+			}
+			prog := tokens[i+1]
+			if isDynamic(prog) {
+				certain = false
+				continue
+			}
+			if b := basename(prog); b != "" {
+				exes = append(exes, b)
+			}
+		}
+	}
+	return exes, certain
+}
+
+// skipWrapperArgs returns the index of the wrapped program's token, skipping a
+// wrapper's flags, flag values, env assignments and fixed positional args.
+func skipWrapperArgs(wrapper string, tokens []string, i int) int {
+	argFlags := wrapperArgFlags[wrapper]
+	for i < len(tokens) {
+		tok := tokens[i]
+		if isEnvAssign(tok) {
+			i++
+			continue
+		}
+		if strings.HasPrefix(tok, "-") {
+			i++
+			if argFlags[tok] && i < len(tokens) {
+				i++ // this flag consumes its value
+			}
+			continue
+		}
+		break
+	}
+	for n := wrapperPositional[wrapper]; n > 0 && i < len(tokens); n-- {
+		i++
+	}
+	return i
+}
+
+// shellDashCArg finds a shell's -c command body among its argument tokens. It
+// handles combined short-flag clusters where c is last (-ec, -lc, -xc → the body
+// is the next token) and inline forms (-c'cmd', -ccmd → the body is the token
+// remainder). hasC reports whether a -c option was present at all; when false the
+// shell runs a script file or stdin, which the caller cannot inspect.
+func shellDashCArg(tokens []string) (body string, hasC bool) {
+	for i, t := range tokens {
+		if len(t) < 2 || t[0] != '-' || t[1] == '-' {
+			continue // not a short-flag cluster
+		}
+		idx := strings.IndexByte(t, 'c')
+		if idx < 1 {
+			continue // no -c option in this cluster
+		}
+		if idx+1 < len(t) {
+			return unquote(t[idx+1:]), true // inline arg: -ccmd / -xc'cmd'
+		}
+		if i+1 < len(tokens) {
+			return unquote(tokens[i+1]), true // c is last: body is the next token
+		}
+		return "", true // -c with nothing after it
+	}
+	return "", false
+}
+
+// tokenize splits a segment on whitespace while keeping quoted spans together;
+// each returned token has its surrounding quotes stripped.
+func tokenize(seg string) []string {
+	var tokens []string
+	var cur strings.Builder
+	inSingle, inDouble, has := false, false, false
+	flush := func() {
+		if has {
+			tokens = append(tokens, cur.String())
+		}
+		cur.Reset()
+		has = false
+	}
+	runes := []rune(seg)
+	for i := 0; i < len(runes); i++ {
+		c := runes[i]
+		switch {
+		case inSingle:
+			// Backslash is literal inside single quotes (POSIX).
+			if c == '\'' {
+				inSingle = false
+			} else {
+				cur.WriteRune(c)
+			}
+			has = true
+		case inDouble:
+			if c == '\\' && i+1 < len(runes) {
+				i++
+				cur.WriteRune(runes[i])
+			} else if c == '"' {
+				inDouble = false
+			} else {
+				cur.WriteRune(c)
+			}
+			has = true
+		case c == '\\':
+			// Escape: the next char is literal, the backslash is dropped, so
+			// "r\m" -> "rm" and "sudo\ rm" -> the single word "sudo rm".
+			if i+1 < len(runes) {
+				i++
+				cur.WriteRune(runes[i])
+			}
+			has = true
+		case c == '\'':
+			inSingle = true
+			has = true
+		case c == '"':
+			inDouble = true
+			has = true
+		case c == ' ' || c == '\t':
+			flush()
+		default:
+			cur.WriteRune(c)
+			has = true
+		}
+	}
+	flush()
+	return tokens
+}
+
+func isEnvAssign(token string) bool {
+	eq := strings.IndexByte(token, '=')
+	if eq <= 0 {
+		return false
+	}
+	for i, r := range token[:eq] {
+		if r == '_' || (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') {
+			continue
+		}
+		if i > 0 && r >= '0' && r <= '9' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// basename strips quotes and any directory prefix from an executable token.
+func basename(token string) string {
+	t := unquote(token)
+	if t == "" {
+		return ""
+	}
+	if idx := strings.LastIndexAny(t, "/\\"); idx >= 0 {
+		t = t[idx+1:]
+	}
+	return t
+}
+
+func unquote(token string) string {
+	return strings.Trim(token, "'\"")
+}

--- a/shellcmd/shellcmd_test.go
+++ b/shellcmd/shellcmd_test.go
@@ -1,0 +1,99 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shellcmd
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestExecutables(t *testing.T) {
+	cases := []struct {
+		name        string
+		cmd         string
+		want        []string
+		wantCertain bool
+	}{
+		{"simple", "git status", []string{"git"}, true},
+		{"empty", "   ", nil, true},
+		{"rm", "rm -rf /", []string{"rm"}, true},
+		{"semicolon chain", "ls; rm -rf /", []string{"ls", "rm"}, true},
+		{"and chain", "ls && rm -rf /", []string{"ls", "rm"}, true},
+		{"or chain", "false || rm x", []string{"false", "rm"}, true},
+		{"pipe", "cat a | grep b | rm", []string{"cat", "grep", "rm"}, true},
+		{"sudo wrapper", "sudo rm -rf /", []string{"sudo", "rm"}, true},
+		{"sudo with flags", "sudo -u root rm x", []string{"sudo", "rm"}, true},
+		{"env wrapper", "FOO=bar rm x", []string{"rm"}, true},
+		{"env command", "env A=B rm x", []string{"env", "rm"}, true},
+		{"path prefix", "/bin/rm -rf /", []string{"rm"}, true},
+		{"backslash path", "\\rm -rf", []string{"rm"}, true},
+		{"quoted arg not a command", "git commit -m 'rm this now'", []string{"git"}, true},
+		{"double quoted arg", "git commit -m \"please rm it\"", []string{"git"}, true},
+		{"command substitution", "echo $(rm -rf /)", []string{"echo", "rm"}, true},
+		{"backtick substitution", "echo `rm -rf /`", []string{"echo", "rm"}, true},
+		{"subshell parens", "(cd /tmp && rm x)", []string{"cd", "rm"}, true},
+		{"bash -c", "bash -c \"rm -rf /\"", []string{"bash", "rm"}, true},
+		{"sh -c chain", "sh -c 'ls; sudo reboot'", []string{"sh", "ls", "sudo", "reboot"}, true},
+		{"dedup", "rm a; rm b", []string{"rm"}, true},
+		{"xargs wrapper", "find . | xargs rm", []string{"find", "xargs", "rm"}, true},
+
+		// fail-closed hardening: constructs that previously smuggled a program past
+		// the parser must now surface it or report certain=false so callers deny.
+		{"if/then keyword", "if true; then rm -rf /; fi", []string{"true", "rm"}, true},
+		{"for/do keyword", "for i in 1 2; do rm -rf /; done", []string{"rm"}, true},
+		{"while condition runs", "while rm lock; do sleep 1; done", []string{"rm", "sleep"}, true},
+		{"negation keyword", "! rm -rf /", []string{"rm"}, true},
+		{"eval body", "eval 'rm -rf /'", []string{"eval", "rm"}, true},
+		{"find exec", "find . -exec rm {} ;", []string{"find", "rm"}, true},
+		{"backslash mid-word", "r\\m -rf /", []string{"rm"}, true},
+		{"redirect target ignored", "echo pwned > /etc/passwd", []string{"echo"}, true},
+		{"dynamic command word", "X=rm; $X -rf /", nil, false},
+		{"dynamic wrapped program", "sudo $X", []string{"sudo"}, false},
+		{"escaped-space obfuscation", "sudo\\ rm x", []string{"sudo rm"}, false},
+
+		// combined shell flag clusters must still surface the -c body (F3)
+		{"combined flag -ec", "bash -ec 'rm -rf /'", []string{"bash", "rm"}, true},
+		{"combined flag -lc", "sh -lc 'rm x'", []string{"sh", "rm"}, true},
+		{"inline -c body", "bash -c'rm x'", []string{"bash", "rm"}, true},
+		// a shell fed from stdin/pipe or a script file can't be inspected (F4)
+		{"piped into shell", "echo 'rm -rf /' | bash", []string{"echo", "bash"}, false},
+		{"shell runs script file", "bash deploy.sh", []string{"bash"}, false},
+		{"shell reads stdin -s", "sh -s", []string{"sh"}, false},
+
+		// redirections must not be split into spurious commands (A)
+		{"redirect 2>&1", "ls -la 2>&1", []string{"ls"}, true},
+		{"redirect 2>&1 then pipe", "go build ./... 2>&1 | head", []string{"go", "head"}, true},
+		{"redirect &> file", "make &> out.log", []string{"make"}, true},
+		{"redirect >&2", "echo err >&2", []string{"echo"}, true},
+		// background/and still split
+		{"background amp", "sleep 1 & echo done", []string{"sleep", "echo"}, true},
+		// Windows %VAR% command word can't be resolved by the POSIX parser (B)
+		{"windows comspec dynamic", "%COMSPEC% /c del /s /q C:", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, certain := Executables(tc.cmd)
+			if certain != tc.wantCertain {
+				t.Errorf("Executables(%q) certain = %v, want %v", tc.cmd, certain, tc.wantCertain)
+			}
+			if len(got) == 0 && len(tc.want) == 0 {
+				return
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("Executables(%q) = %v, want %v", tc.cmd, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What
Add a standalone, host-agnostic permission engine for agent tool calls:

- `guard/` — decides allow/ask/deny for a tool call from a set of policy rules. No dependency on OpenAgent (no object/model/beego), so it can be reused as-is by other agents.
- `shellcmd/` — extracts the executables a shell command line would run, so a permission layer can allow/deny by program name (git, rm, sudo, …) instead of fragile substring matching.

Both packages ship with unit tests and are not yet wired into the tool-call path — that lands in follow-up PRs for issue #2462.

Ref: https://github.com/the-open-agent/openagent/issues/2462
