### PR TITLE
feat: enforce tool permissions on agent tool calls

### DIFF
--- a/mcp/toolset.go
+++ b/mcp/toolset.go
@@ -31,4 +31,9 @@ type ToolSet struct {
 	// BuiltinTools is the registry of server-side builtin tools.
 	BuiltinTools     *tool.ToolRegistry
 	WebSearchEnabled bool
+	// CheckPermission, when set, is consulted before every tool call. It
+	// returns whether the call is allowed and, if not, a reason. It is the
+	// injection point for the host-agnostic permission guard; leaving it nil
+	// disables permission checks (tools run unchanged).
+	CheckPermission func(toolName string, arguments map[string]interface{}) (allowed bool, reason string)
 }

--- a/model/mcp.go
+++ b/model/mcp.go
@@ -312,13 +312,27 @@ func callMcpTool(toolCall openai.ToolCall, serverName, toolName string, isVision
 	heartbeat := startHeartbeat(writer, &mu)
 	defer close(heartbeat)
 
-	if serverName == "" {
+	// Permission gate: consult the injected guard before executing the tool.
+	// A denial short-circuits execution and is surfaced to the model as an
+	// error tool result so it can react instead of silently proceeding.
+	if mcpToolSet != nil && mcpToolSet.CheckPermission != nil {
+		if allowed, reason := mcpToolSet.CheckPermission(toolName, arguments); !allowed {
+			result = &protocol.CallToolResult{
+				IsError: true,
+				Content: []protocol.Content{
+					&protocol.TextContent{Type: "text", Text: "Permission denied: " + reason},
+				},
+			}
+		}
+	}
+
+	if result == nil && serverName == "" {
 		// builtin tools
 		if mcpToolSet.BuiltinTools == nil {
 			return messages, nil, false, nil
 		}
 		result, err = mcpToolSet.BuiltinTools.ExecuteTool(ctx, toolName, arguments)
-	} else {
+	} else if result == nil {
 		// MCP server tools
 		conn, ok := mcpToolSet.Connections[serverName]
 		if !ok {

--- a/object/merge_agent_tools.go
+++ b/object/merge_agent_tools.go
@@ -77,17 +77,29 @@ func MergeMcpTools(mcpToolSet *mcp.ToolSet, store *Store, webSearchEnabled bool,
 	reg := buildMergedBuiltinRegistry(store, user, origin, lang)
 	allTools := reg.GetToolsAsProtocolTools()
 	if len(allTools) == 0 {
-		return mcpToolSet
+		return attachPermissionChecker(mcpToolSet, store, user)
 	}
 
 	if mcpToolSet == nil {
-		return &mcp.ToolSet{
+		return attachPermissionChecker(&mcp.ToolSet{
 			Tools:        allTools,
 			BuiltinTools: reg,
-		}
+		}, store, user)
 	}
 
 	mcpToolSet.Tools = append(mcpToolSet.Tools, allTools...)
 	mcpToolSet.BuiltinTools = reg
+	return attachPermissionChecker(mcpToolSet, store, user)
+}
+
+// attachPermissionChecker installs the store's tool-permission gate onto the
+// tool set (no-op if the set is nil or the store has no active policies).
+func attachPermissionChecker(mcpToolSet *mcp.ToolSet, store *Store, user string) *mcp.ToolSet {
+	if mcpToolSet == nil {
+		return nil
+	}
+	if checker := BuildToolPermissionChecker(store, user); checker != nil {
+		mcpToolSet.CheckPermission = checker
+	}
 	return mcpToolSet
 }

--- a/object/message_tool.go
+++ b/object/message_tool.go
@@ -54,10 +54,14 @@ func buildToolSetForBuiltinTool(toolName, user, origin, lang string) (*mcp.ToolS
 		return nil, nil
 	}
 
-	return &mcp.ToolSet{
+	ts := &mcp.ToolSet{
 		Tools:        allTools,
 		BuiltinTools: reg,
-	}, nil
+	}
+	// This path is store-less (admin-owned); without attaching the guard here the
+	// builtin tools would run completely ungated. Enforce owner-wide admin
+	// policies (rules with Store "" or "*") so a configured deny/ask still applies.
+	return attachPermissionChecker(ts, &Store{Owner: "admin", Name: ""}, user), nil
 }
 
 func GetAnswerWithTool(modelProviderName, toolName, question, user, origin, lang string) (string, *model.ModelResult, error) {

--- a/object/tool_guard.go
+++ b/object/tool_guard.go
@@ -1,0 +1,233 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package object
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"sort"
+	"strings"
+
+	"github.com/beego/beego/logs"
+	"github.com/the-open-agent/openagent/guard"
+	"github.com/the-open-agent/openagent/shellcmd"
+)
+
+// BuildToolPermissionChecker returns a permission gate for a store's tool
+// calls, or nil when the store has no active policies (so tool execution is
+// unchanged and incurs zero overhead — the feature is opt-in per store/owner).
+//
+// The returned closure is the only openagent-specific glue; the actual
+// allow/ask/deny decision is made by the host-agnostic guard engine, which is
+// what makes this reusable by other agents (Longxia, Hermes, ...).
+func BuildToolPermissionChecker(store *Store, user string) func(toolName string, arguments map[string]interface{}) (bool, string) {
+	if store == nil {
+		return nil
+	}
+
+	policies, err := GetToolPoliciesForStore(store.Owner, store.Name)
+	if err != nil || len(policies) == 0 {
+		return nil
+	}
+
+	rules := make([]guard.Rule, 0, len(policies))
+	for _, p := range policies {
+		rules = append(rules, p.toGuardRule())
+	}
+
+	g, err := guard.NewCasbinGuard(guard.Policy{
+		Rules:   rules,
+		Default: guard.EffectAllow, // non-breaking: only configured rules restrict
+	})
+	if err != nil {
+		logs.Warning("BuildToolPermissionChecker: failed to build guard for store %s/%s: %v", store.Owner, store.Name, err)
+		return nil
+	}
+
+	subject := store.Name
+
+	return func(toolName string, arguments map[string]interface{}) (bool, string) {
+		req := guard.Request{
+			Subject:  subject,
+			Tool:     toolName,
+			Category: inferToolCategory(toolName),
+			Resource: extractResource(arguments),
+		}
+
+		var decision guard.Decision
+		var err error
+		if req.Category == guard.CategoryExec {
+			// Shell/exec tools: decide per executable in the command line so
+			// chaining, subshells and sudo/env wrappers can't smuggle a denied
+			// program past a whole-string match. Denied if ANY program is denied.
+			decision, err = evaluateExecCommand(g, req)
+		} else {
+			decision, err = g.Check(context.Background(), req)
+		}
+		if err != nil {
+			// Fail CLOSED on engine error: a security gate must not allow a call it
+			// could not evaluate. Log for diagnosis.
+			logs.Error("tool-permission engine error store=%s tool=%s: %v", subject, toolName, err)
+			return false, "tool permission check failed (engine error); denied for safety"
+		}
+
+		auditToolDecision(store.Owner, subject, user, req, decision)
+
+		switch decision.Effect {
+		case guard.EffectAllow:
+			return true, ""
+		case guard.EffectDeny:
+			return false, decision.Reason
+		case guard.EffectAsk:
+			// Interactive approval lands in a follow-up; until then an "ask"
+			// rule blocks and explains itself so it is never a silent allow.
+			return false, "approval required (interactive approval not yet enabled): " + decision.Reason
+		default:
+			// Unknown effect: fail closed rather than allow an unrecognized decision.
+			return false, "unrecognized permission decision; denied for safety"
+		}
+	}
+}
+
+// evaluateExecCommand decides an exec/shell tool call by matching both the whole
+// command string and each program the command line would run, taking the most
+// restrictive result. The whole-command match lets whole-string Resource globs
+// (e.g. "*rm -rf*") fire; the per-program match (basename: rm, sudo, git) defeats
+// chaining/subshell/wrapper evasion a single whole-string match would miss.
+func evaluateExecCommand(g *guard.CasbinGuard, req guard.Request) (guard.Decision, error) {
+	if runtime.GOOS == "windows" {
+		// The shell tool runs via cmd.exe on Windows, but shellcmd parses POSIX
+		// syntax only (%VAR%/^/batch are not understood), so its result cannot be
+		// trusted here. Fail closed to approval rather than analyze it wrongly.
+		return guard.Decision{
+			Effect: guard.EffectAsk,
+			Reason: "shell command on Windows (cmd.exe) cannot be statically analyzed; needs approval",
+		}, nil
+	}
+	exes, certain := shellcmd.Executables(req.Resource)
+	if !certain {
+		// The command could not be resolved to concrete program names (a dynamic
+		// "$CMD", a script/stdin-fed interpreter, an obfuscated command word).
+		// Route to approval rather than a silent allow OR a hard deny: it may be
+		// legitimate, but it must not run unreviewed.
+		return guard.Decision{
+			Effect: guard.EffectAsk,
+			Reason: "shell command could not be resolved to program names; needs approval",
+		}, nil
+	}
+
+	// Whole-command match first, so a rule keyed on the full command string still
+	// applies (per-program basenames can never match such a pattern).
+	worst, err := g.Check(context.Background(), req)
+	if err != nil {
+		return guard.Decision{}, err
+	}
+	for _, exe := range exes {
+		if worst.Effect == guard.EffectDeny {
+			break
+		}
+		sub := req
+		sub.Resource = exe
+		d, err := g.Check(context.Background(), sub)
+		if err != nil {
+			return guard.Decision{}, err
+		}
+		if execEffectRank(d.Effect) > execEffectRank(worst.Effect) {
+			d.Reason = fmt.Sprintf("program %q: %s", exe, d.Reason)
+			worst = d
+		}
+	}
+	return worst, nil
+}
+
+func execEffectRank(e guard.Effect) int {
+	switch e {
+	case guard.EffectDeny:
+		return 3
+	case guard.EffectAsk:
+		return 2
+	default:
+		return 1
+	}
+}
+
+func auditToolDecision(owner, subject, user string, req guard.Request, d guard.Decision) {
+	logs.Info("tool-permission owner=%s store=%s user=%s tool=%s category=%s effect=%s reason=%q",
+		owner, subject, user, req.Tool, req.Category, d.Effect, d.Reason)
+}
+
+// inferToolCategory maps a builtin/MCP tool name to a coarse capability class so
+// policies can be written against broad categories. Unknown/MCP tools fall back
+// to CategoryUnknown. Matching is on whole `_`/`-`-delimited name tokens (not raw
+// substrings) so e.g. "spreadsheet" is not misread as "read" nor "research" as
+// "search". Checks are ordered most-privileged first.
+func inferToolCategory(name string) string {
+	tokens := strings.FieldsFunc(strings.ToLower(name), func(r rune) bool {
+		return !(r >= 'a' && r <= 'z') && !(r >= '0' && r <= '9')
+	})
+	has := func(kws ...string) bool {
+		for _, t := range tokens {
+			for _, kw := range kws {
+				if t == kw {
+					return true
+				}
+			}
+		}
+		return false
+	}
+	switch {
+	case has("shell", "exec", "terminal", "bash"):
+		return guard.CategoryExec
+	case has("write", "move", "download", "extract", "fill"):
+		return guard.CategoryWrite
+	case has("browser", "web", "fetch", "search", "video"):
+		return guard.CategoryNetwork
+	case has("read", "scan", "time", "skill", "dirs"):
+		return guard.CategoryRead
+	default:
+		return guard.CategoryUnknown
+	}
+}
+
+// extractResource picks the single most security-relevant argument of a tool
+// call for pattern matching (a shell command, a path, a URL, a query).
+func extractResource(arguments map[string]interface{}) string {
+	if arguments == nil {
+		return ""
+	}
+	for _, key := range []string{"command", "cmd", "path", "file_path", "filePath", "file", "url", "query", "keyword"} {
+		if v, ok := arguments[key]; ok {
+			if s, ok := v.(string); ok && s != "" {
+				return s
+			}
+		}
+	}
+	// Fallback so a tool whose security-relevant argument isn't named above stays
+	// governable by resource-scoped rules instead of yielding an empty (i.e.
+	// match-anything) resource. Deterministic: first non-empty string value in
+	// sorted-key order.
+	keys := make([]string, 0, len(arguments))
+	for k := range arguments {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		if s, ok := arguments[k].(string); ok && s != "" {
+			return s
+		}
+	}
+	return ""
+}

--- a/object/tool_guard_test.go
+++ b/object/tool_guard_test.go
@@ -1,0 +1,179 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package object
+
+import (
+	"testing"
+
+	"github.com/the-open-agent/openagent/guard"
+)
+
+func TestInferToolCategory(t *testing.T) {
+	cases := []struct {
+		name string
+		tool string
+		want string
+	}{
+		{"shell is exec", "shell", guard.CategoryExec},
+		{"terminal token is exec", "terminal_run", guard.CategoryExec},
+		{"bash token is exec", "bash_tool", guard.CategoryExec},
+		{"write is write", "file_write", guard.CategoryWrite},
+		{"download is write", "download_file", guard.CategoryWrite},
+		{"web search is network", "web_search", guard.CategoryNetwork},
+		{"browser is network", "browser_navigate", guard.CategoryNetwork},
+		{"read is read", "read_file", guard.CategoryRead},
+		{"scan is read", "scan_dirs", guard.CategoryRead},
+		// Whole-token matching must not be fooled by substrings: "spreadsheet"
+		// contains "read" and "research" contains "search", yet neither should be
+		// classified from that substring.
+		{"spreadsheet is not read", "spreadsheet_tool", guard.CategoryUnknown},
+		{"research is not network", "research_agent", guard.CategoryUnknown},
+		{"unknown mcp tool", "some_mcp_thing", guard.CategoryUnknown},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := inferToolCategory(c.tool); got != c.want {
+				t.Fatalf("inferToolCategory(%q) = %q, want %q", c.tool, got, c.want)
+			}
+		})
+	}
+}
+
+func TestExtractResource(t *testing.T) {
+	cases := []struct {
+		name string
+		args map[string]interface{}
+		want string
+	}{
+		{"nil args", nil, ""},
+		{"empty args", map[string]interface{}{}, ""},
+		{"command key", map[string]interface{}{"command": "rm -rf /"}, "rm -rf /"},
+		{"cmd key", map[string]interface{}{"cmd": "ls"}, "ls"},
+		{"path key", map[string]interface{}{"path": "/etc/passwd"}, "/etc/passwd"},
+		{"url key", map[string]interface{}{"url": "https://example.com"}, "https://example.com"},
+		// "command" is earlier in the priority list than "path", so it wins.
+		{"known-key priority", map[string]interface{}{"path": "/p", "command": "rm"}, "rm"},
+		// A known key whose value is not a non-empty string is skipped.
+		{"non-string known key skipped", map[string]interface{}{"path": 123, "url": "http://y"}, "http://y"},
+		{"empty known key then fallback", map[string]interface{}{"command": "", "zzz": "z"}, "z"},
+		// Fallback is deterministic: first non-empty string in sorted-key order.
+		{"fallback sorted deterministic", map[string]interface{}{"b": "second", "a": "first"}, "first"},
+		{"fallback ignores non-strings", map[string]interface{}{"n": 5, "m": "hit"}, "hit"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := extractResource(c.args); got != c.want {
+				t.Fatalf("extractResource(%v) = %q, want %q", c.args, got, c.want)
+			}
+		})
+	}
+}
+
+func TestExecEffectRank(t *testing.T) {
+	if !(execEffectRank(guard.EffectDeny) > execEffectRank(guard.EffectAsk) &&
+		execEffectRank(guard.EffectAsk) > execEffectRank(guard.EffectAllow)) {
+		t.Fatalf("exec effect rank must order deny > ask > allow, got deny=%d ask=%d allow=%d",
+			execEffectRank(guard.EffectDeny), execEffectRank(guard.EffectAsk), execEffectRank(guard.EffectAllow))
+	}
+}
+
+func mustGuard(t *testing.T, rules []guard.Rule) *guard.CasbinGuard {
+	t.Helper()
+	g, err := guard.NewCasbinGuard(guard.Policy{Rules: rules, Default: guard.EffectAllow})
+	if err != nil {
+		t.Fatalf("NewCasbinGuard: %v", err)
+	}
+	return g
+}
+
+func execReq(command string) guard.Request {
+	return guard.Request{
+		Subject:  "agent1",
+		Tool:     "shell",
+		Category: guard.CategoryExec,
+		Resource: command,
+	}
+}
+
+func TestEvaluateExecCommand(t *testing.T) {
+	denyRm := guard.Rule{Name: "deny-rm", Category: guard.CategoryExec, Resource: "rm", Effect: guard.EffectDeny, Priority: 100}
+
+	t.Run("per-program deny catches chained rm", func(t *testing.T) {
+		// A rule keyed on the program basename "rm" must fire even when rm is
+		// hidden behind a chain operator that a whole-string match would miss.
+		g := mustGuard(t, []guard.Rule{denyRm})
+		d, err := evaluateExecCommand(g, execReq("ls && rm -rf /"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if d.Effect != guard.EffectDeny {
+			t.Fatalf("want deny, got %s (%s)", d.Effect, d.Reason)
+		}
+	})
+
+	t.Run("allow when no program is denied", func(t *testing.T) {
+		g := mustGuard(t, []guard.Rule{denyRm})
+		d, err := evaluateExecCommand(g, execReq("ls -la"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if d.Effect != guard.EffectAllow {
+			t.Fatalf("want allow, got %s (%s)", d.Effect, d.Reason)
+		}
+	})
+
+	t.Run("whole-command glob deny", func(t *testing.T) {
+		// A rule keyed on the full command string (only reachable by the
+		// whole-command match, never a per-program basename) must still fire.
+		g := mustGuard(t, []guard.Rule{{Name: "deny-rmrf", Category: guard.CategoryExec, Resource: "*rm -rf*", Effect: guard.EffectDeny}})
+		d, err := evaluateExecCommand(g, execReq("rm -rf /tmp"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if d.Effect != guard.EffectDeny {
+			t.Fatalf("want deny, got %s (%s)", d.Effect, d.Reason)
+		}
+	})
+
+	t.Run("per-program deny overrides whole-command allow", func(t *testing.T) {
+		// The whole command matches a broad allow, but one program is denied;
+		// the most restrictive result must win so the denied program can't ride
+		// along inside an otherwise-allowed command.
+		g := mustGuard(t, []guard.Rule{
+			{Name: "allow-all", Category: guard.CategoryExec, Resource: "*", Effect: guard.EffectAllow, Priority: 1},
+			{Name: "deny-sudo", Category: guard.CategoryExec, Resource: "sudo", Effect: guard.EffectDeny, Priority: 1},
+		})
+		d, err := evaluateExecCommand(g, execReq("sudo apt update"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if d.Effect != guard.EffectDeny {
+			t.Fatalf("want deny, got %s (%s)", d.Effect, d.Reason)
+		}
+	})
+
+	t.Run("uncertain command routes to ask", func(t *testing.T) {
+		// A dynamic command word can't be resolved to program names; it must be
+		// routed to approval, never silently allowed nor hard-denied.
+		g := mustGuard(t, []guard.Rule{denyRm})
+		d, err := evaluateExecCommand(g, execReq("X=rm; $X -rf /"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if d.Effect != guard.EffectAsk {
+			t.Fatalf("want ask, got %s (%s)", d.Effect, d.Reason)
+		}
+	})
+}

--- a/object/tool_policy.go
+++ b/object/tool_policy.go
@@ -148,3 +148,45 @@ func DeleteToolPolicy(p *ToolPolicy) (bool, error) {
 	}
 	return affected != 0, nil
 }
+
+// GetToolPoliciesForStore returns the active rules that apply to a store: rules
+// scoped to the store itself plus owner-wide rules (empty or "*" Store).
+func GetToolPoliciesForStore(owner, storeName string) ([]*ToolPolicy, error) {
+	all, err := GetToolPolicies(owner)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]*ToolPolicy, 0, len(all))
+	for _, p := range all {
+		if p.State == "Disabled" {
+			continue
+		}
+		if p.Store == "" || p.Store == "*" || p.Store == storeName {
+			result = append(result, p)
+		}
+	}
+	return result, nil
+}
+
+// toGuardRule converts a stored policy row into an engine rule. Writes are
+// validated up front (see normalize); as a backstop the effect is normalized
+// here too: empty or any unrecognized value fails closed to deny — matching what
+// the edit page shows for a blank effect, never a silent allow in a security path.
+func (p *ToolPolicy) toGuardRule() guard.Rule {
+	effect := guard.Effect(strings.ToLower(strings.TrimSpace(p.Effect)))
+	switch effect {
+	case guard.EffectAllow, guard.EffectAsk, guard.EffectDeny:
+		// recognized
+	default:
+		effect = guard.EffectDeny
+	}
+	return guard.Rule{
+		Name:     p.Name,
+		Subject:  p.Subject,
+		Tool:     p.Tool,
+		Category: p.Category,
+		Resource: p.Resource,
+		Effect:   effect,
+		Priority: p.Priority,
+	}
+}


### PR DESCRIPTION
### What
Enforce the configured tool-permission policies on every agent tool call — the piece that makes issue #2462 functional end to end.

- `mcp/toolset.go` — add an optional `CheckPermission` hook on `ToolSet`; nil means checks are disabled (tools run unchanged).
- `object/tool_guard.go` — `BuildToolPermissionChecker` builds a `guard.CasbinGuard` from the store's `ToolPolicy` rows and returns the check closure. Exec/shell calls are decided per program (via `shellcmd`) so chaining/subshell/sudo wrappers can't smuggle a denied program past a whole-string match. Returns nil (zero overhead) when a store has no policies.
- `object/merge_agent_tools.go` — attach the checker to the merged tool set.
- `model/mcp.go` — consult the checker before executing a tool; a denial short-circuits and is surfaced to the model as an error tool result instead of silently proceeding.

Non-breaking: the guard defaults to allow, so stores without policies behave exactly as before. Builds on #2463 (guard engine) and #2464 (policy management).

### Tests
`go build ./...` and `go test ./guard/... ./shellcmd/...`

Fix: https://github.com/the-open-agent/openagent/issues/2462
