### PR TITLE
fix: guard CasdoorProvider against a nil client when Casdoor is unavaliable

### DIFF
--- a/storage/casdoor.go
+++ b/storage/casdoor.go
@@ -35,7 +35,20 @@ func NewCasdoorProvider(providerName string, lang string) (*CasdoorProvider, err
 	return &CasdoorProvider{providerName: providerName}, nil
 }
 
+// errCasdoorUnavailable is returned by every CasdoorProvider method instead of
+// reaching the SDK while Casdoor is not configured or not reachable: the SDK
+// client behind auth.* is never initialized in that state, and calling into
+// it nil-dereferences and crashes the process (auth/auth.go is a thin pass-
+// through with no guard of its own - see its package doc). conf.IsCasdoorAvailable
+// is the same flag every other Casdoor-backed feature already checks before a
+// call, e.g. object/message_email.go's SendEmail.
+var errCasdoorUnavailable = fmt.Errorf("casdoor storage provider is unavailable: casdoor is not configured or not reachable")
+
 func (p *CasdoorProvider) ListObjects(prefix string) ([]*Object, error) {
+	if !conf.IsCasdoorAvailable() {
+		return nil, errCasdoorUnavailable
+	}
+
 	casdoorOrganization := conf.GetConfigString("casdoorOrganization")
 	casdoorApplication := conf.GetConfigString("casdoorApplication")
 	resources, err := auth.GetResources(casdoorOrganization, casdoorApplication, "provider", p.providerName, "Direct", prefix)
@@ -56,6 +69,10 @@ func (p *CasdoorProvider) ListObjects(prefix string) ([]*Object, error) {
 }
 
 func (p *CasdoorProvider) PutObject(user string, parent string, key string, fileBuffer *bytes.Buffer) (string, error) {
+	if !conf.IsCasdoorAvailable() {
+		return "", errCasdoorUnavailable
+	}
+
 	fileUrl, _, err := auth.UploadResource(user, "OpenAgent", parent, fmt.Sprintf("Direct/%s/%s", p.providerName, key), fileBuffer.Bytes())
 	if err != nil {
 		return "", err
@@ -64,6 +81,10 @@ func (p *CasdoorProvider) PutObject(user string, parent string, key string, file
 }
 
 func (p *CasdoorProvider) DeleteObject(key string) error {
+	if !conf.IsCasdoorAvailable() {
+		return errCasdoorUnavailable
+	}
+
 	resource := auth.Resource{
 		Name: key,
 	}

--- a/storage/casdoor_test.go
+++ b/storage/casdoor_test.go
@@ -1,0 +1,51 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/the-open-agent/openagent/conf"
+)
+
+// TestCasdoorProviderReturnsErrorWhenUnavailable is a regression test for a
+// crash: with Casdoor unreachable, auth.* delegates straight into a nil
+// casdoorsdk client (see auth/auth.go), and calling any CasdoorProvider
+// method used to reach that nil-dereference instead of returning an error -
+// tryStoreRemoteImage's answer-generation path took the whole process down
+// with it. These methods must return early instead of ever reaching auth.*
+// while conf.IsCasdoorAvailable() is false.
+func TestCasdoorProviderReturnsErrorWhenUnavailable(t *testing.T) {
+	original := conf.IsCasdoorAvailable()
+	conf.SetCasdoorAvailable(false)
+	defer conf.SetCasdoorAvailable(original)
+
+	provider, err := NewCasdoorProvider("provider_storage_test", "en")
+	if err != nil {
+		t.Fatalf("NewCasdoorProvider failed: %v", err)
+	}
+
+	if _, err := provider.ListObjects(""); !errors.Is(err, errCasdoorUnavailable) {
+		t.Errorf("ListObjects: expected errCasdoorUnavailable, got %v", err)
+	}
+	if _, err := provider.PutObject("user", "parent", "key", bytes.NewBufferString("data")); !errors.Is(err, errCasdoorUnavailable) {
+		t.Errorf("PutObject: expected errCasdoorUnavailable, got %v", err)
+	}
+	if err := provider.DeleteObject("key"); !errors.Is(err, errCasdoorUnavailable) {
+		t.Errorf("DeleteObject: expected errCasdoorUnavailable, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
Guard CasdoorProvider against a nil casdoorsdk client when Casdoor isn't configured or reachable.

## Changes
Check conf.IsCasdoorAvailable() before every CasdoorProvider method calls into auth.*, matching the guard every other Casdoor-backed feature already uses
Return an error instead of letting the call nil-dereference into casdoorsdk
Fixes a crash that took down the whole process on any image-bearing answer (inline base64 or remote URL), since tryStoreRemoteImage runs at the end of generateMessageAnswer in a background goroutine Beego can't recover from
Verified the crash no longer reproduces, including with a real generated image