### PR TITLE
fix: resolve symlinks before placing the audit directory next to the binary

### DIFF
--- a/audit/audit.go
+++ b/audit/audit.go
@@ -136,7 +136,15 @@ func flush() {
 }
 
 // auditDir is <dir-of-binary>/audit, mirroring how the SQLite database is placed
-// next to the binary, unless OPENAGENT_AUDIT_DIR overrides it.
+// next to the binary, unless OPENAGENT_AUDIT_DIR overrides it. The binary path
+// is resolved through any symlink first: os.Executable() returns the path used
+// to invoke the process, which is the symlink itself when OpenAgent is started
+// through one (e.g. a package manager's ~/.local/bin/openagent link) rather
+// than the real binary it points at. An external reader has no reason to know
+// about that symlink - it locates the audit directory the same way aiguard's
+// agentmonitor.ResolveOpenAgentAuditDir does, by resolving the binary path it
+// found first - so this must resolve it too, or the two disagree on where the
+// directory is and every event silently lands somewhere nobody reads.
 func auditDir() string {
 	if override := strings.TrimSpace(os.Getenv("OPENAGENT_AUDIT_DIR")); override != "" {
 		return override
@@ -144,6 +152,15 @@ func auditDir() string {
 	exe, err := os.Executable()
 	if err != nil {
 		return "audit"
+	}
+	return auditDirFor(exe)
+}
+
+// auditDirFor is the symlink-resolving half of auditDir, split out so a test
+// can exercise it against a path it controls instead of the real executable.
+func auditDirFor(exe string) string {
+	if resolved, err := filepath.EvalSymlinks(exe); err == nil {
+		exe = resolved
 	}
 	return filepath.Join(filepath.Dir(exe), "audit")
 }

--- a/audit/audit_test.go
+++ b/audit/audit_test.go
@@ -58,6 +58,41 @@ func TestRecordFallsBackToDefaultSessionFile(t *testing.T) {
 	}
 }
 
+// TestAuditDirForResolvesSymlinks is a regression test: OpenAgent is commonly
+// invoked through a symlink (e.g. a package manager's ~/.local/bin/openagent
+// pointing at the real binary elsewhere). os.Executable() returns the symlink
+// path used to invoke the process, not the real one, so without resolving it
+// events used to land next to the symlink - a directory aiguard's
+// agentmonitor.ResolveOpenAgentAuditDir, which does resolve it, never looks
+// in, leaving the Sessions/Records page permanently showing "waiting for
+// activity" despite real events being recorded.
+func TestAuditDirForResolvesSymlinks(t *testing.T) {
+	realDir := t.TempDir()
+	realBinary := filepath.Join(realDir, "openagent")
+	if err := os.WriteFile(realBinary, []byte("stub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// t.TempDir() can itself sit behind a symlink (e.g. macOS's /tmp ->
+	// /private/tmp), so resolve realDir the same way auditDirFor resolves the
+	// binary path, or the comparison below would fail on that alone.
+	resolvedRealDir, err := filepath.EvalSymlinks(realDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	linkDir := t.TempDir()
+	symlinkBinary := filepath.Join(linkDir, "openagent")
+	if err := os.Symlink(realBinary, symlinkBinary); err != nil {
+		t.Fatal(err)
+	}
+
+	got := auditDirFor(symlinkBinary)
+	want := filepath.Join(resolvedRealDir, "audit")
+	if got != want {
+		t.Errorf("auditDirFor(%q) = %q, want %q (the real binary's directory, not the symlink's)", symlinkBinary, got, want)
+	}
+}
+
 func TestSanitizeSession(t *testing.T) {
 	tests := map[string]string{
 		"":             "openagent",


### PR DESCRIPTION
## Summary
Resolve symlinks before placing OpenAgent's audit directory next to the binary.

## Changes
Resolve the executable path through any symlink before computing the audit directory, instead of using os.Executable()'s path as-is.
Fixes events landing next to a symlink (e.g. ~/.local/bin/openagent -> the real binary elsewhere) instead of next to the real binary aiguard watches.
Matches aiguard's agentmonitor.ResolveOpenAgentAuditDir, which already resolves the same way - without this, the two disagreed and aiguard's Agents page reported "waiting for activity" indefinitely even though OpenAgent was actively recording.
Split the symlink-resolving logic into a small testable function and added a regression test.
