### PR TITLE
feat: emit chat_title, llm_call, and message audit events

### DIFF
--- a/audit/audit.go
+++ b/audit/audit.go
@@ -21,6 +21,13 @@
 // database uses), overridable with OPENAGENT_AUDIT_DIR. One file per session,
 // so a reader can use the file name as the session key and never has to
 // untangle interleaved sessions.
+//
+// Every event type but one is metadata-only - tool names, durations, token
+// counts, never the text that produced them. The one exception is "message":
+// it carries the actual question and answer text, by explicit request of a
+// reader that wants the conversation itself, not just its shape. Emitting it
+// is a deliberate, opt-in departure from every other event this package
+// writes, not an oversight - see Event.Text.
 package audit
 
 import (
@@ -44,13 +51,28 @@ type Event struct {
 	Server          string `json:"server,omitempty"`
 	Model           string `json:"model,omitempty"`
 	ArgumentsLength int    `json:"argumentsLength,omitempty"`
-	Outcome         string `json:"outcome,omitempty"`
-	DurationMs      int64  `json:"durationMs,omitempty"`
+	// ContentLength is a size, not content: characters for a tool result,
+	// tokens for an "llm_call" response (whichever the caller already had
+	// computed) - never the text itself.
+	ContentLength int    `json:"contentLength,omitempty"`
+	Outcome       string `json:"outcome,omitempty"`
+	DurationMs    int64  `json:"durationMs,omitempty"`
 	// Effect, Reason and Rule carry the guard verdict once the guard is wired
 	// into the tool path; empty until then.
 	Effect string `json:"effect,omitempty"`
 	Reason string `json:"reason,omitempty"`
 	Rule   string `json:"rule,omitempty"`
+	// Role and Text are only ever set on a "message" event: Role is "user" or
+	// "assistant", and Text is that message's actual content - the one
+	// deliberate exception to every other event in this log being metadata
+	// only. See the package doc before adding a second one.
+	Role string `json:"role,omitempty"`
+	Text string `json:"text,omitempty"`
+	// Title carries a "chat_title" event's chat.DisplayName: the short label
+	// OpenAgent generates for its own chat list, not conversation content. An
+	// external reader (aiguard's Sessions page) can show something better than
+	// a session id without this log carrying any prompt or response text.
+	Title string `json:"title,omitempty"`
 }
 
 // queueSize bounds how many events may be waiting to be written. It is generous

--- a/audit/audit_test.go
+++ b/audit/audit_test.go
@@ -46,6 +46,48 @@ func TestRecordAppendsJSONLPerSession(t *testing.T) {
 	}
 }
 
+// TestRecordMessageEvent covers "message", the one event type this log
+// carries actual conversation text on (see the package doc). It must
+// round-trip Role and Text intact, same as every other field.
+func TestRecordMessageEvent(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("OPENAGENT_AUDIT_DIR", dir)
+
+	Record(Event{Type: "message", SessionID: "sess1", Role: "user", Text: "现在几点？"})
+	Record(Event{Type: "message", SessionID: "sess1", Role: "assistant", Text: "现在是 UTC 12:00。"})
+	flush()
+
+	events := readEvents(t, filepath.Join(dir, "sess1.jsonl"))
+	if len(events) != 2 {
+		t.Fatalf("got %d events, want 2", len(events))
+	}
+	if events[0].Role != "user" || events[0].Text != "现在几点？" {
+		t.Errorf("user message event wrong: %+v", events[0])
+	}
+	if events[1].Role != "assistant" || events[1].Text != "现在是 UTC 12:00。" {
+		t.Errorf("assistant message event wrong: %+v", events[1])
+	}
+}
+
+// TestRecordChatTitleEvent covers the "chat_title" event message_answer.go
+// emits alongside chat.DisplayName: an external reader (aiguard's Sessions
+// page) needs the Title field to round-trip through the JSONL line intact.
+func TestRecordChatTitleEvent(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("OPENAGENT_AUDIT_DIR", dir)
+
+	Record(Event{Type: "chat_title", SessionID: "sess1", Title: "北京天气查询概况"})
+	flush()
+
+	events := readEvents(t, filepath.Join(dir, "sess1.jsonl"))
+	if len(events) != 1 {
+		t.Fatalf("got %d events, want 1", len(events))
+	}
+	if events[0].Type != "chat_title" || events[0].Title != "北京天气查询概况" {
+		t.Errorf("chat_title event fields wrong: %+v", events[0])
+	}
+}
+
 func TestRecordFallsBackToDefaultSessionFile(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("OPENAGENT_AUDIT_DIR", dir)

--- a/controllers/message_answer.go
+++ b/controllers/message_answer.go
@@ -20,8 +20,10 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/beego/beego/context"
+	"github.com/the-open-agent/openagent/audit"
 	"github.com/the-open-agent/openagent/carrier"
 	"github.com/the-open-agent/openagent/conf"
 	"github.com/the-open-agent/openagent/embedding"
@@ -381,6 +383,12 @@ func generateMessageAnswer(id string, responseWriter http.ResponseWriter, host s
 
 	printAgentSessionStart(store, modelProviderName, mcpToolSet, history)
 
+	// The one place this log carries actual conversation text, not just its
+	// shape - see audit/audit.go's package doc. Recorded before the
+	// carrier-specific rewriting below (getQuestionWithCarriers etc.) touches
+	// question, so this is what the user actually typed.
+	audit.Record(audit.Event{Type: "message", SessionID: chat.Name, Role: "user", Text: question})
+
 	fmt.Printf("Question: [%s]\n", question)
 	fmt.Printf("Knowledge: [\n")
 	for i, k := range knowledge {
@@ -410,6 +418,7 @@ func generateMessageAnswer(id string, responseWriter http.ResponseWriter, host s
 	}
 	emitStatus(fmt.Sprintf(i18n.Translate(lang, "chat:Generating answer with %s"), modelProviderDisplayName))
 
+	llmCallStart := time.Now()
 	var modelResult *model.ModelResult
 	if mcpToolSet != nil {
 		messages := &model.ToolMessages{
@@ -430,6 +439,22 @@ func generateMessageAnswer(id string, responseWriter http.ResponseWriter, host s
 			modelResult, err = modelProviderObj.QueryText(question, writer, history, prompt, knowledge, nil, lang)
 		}
 	}
+	// One "llm_call" event per user message answered - the message-granularity
+	// counterpart to the tool_call events callMcpTool already records, and
+	// captured here rather than per internal tool-calling round (mcp.go's
+	// QueryTextWithTools can call the model several times for one message) so
+	// a session's audit log reads one entry per turn, matching what a chat UI
+	// itself would show as one exchange. ResponseTokenCount stands in for
+	// ContentLength: OpenAgent already computes it, so this needs no read of
+	// the answer text itself.
+	audit.Record(audit.Event{
+		Type:          "llm_call",
+		SessionID:     chat.Name,
+		Model:         modelProviderName,
+		Outcome:       llmCallOutcome(err),
+		DurationMs:    time.Since(llmCallStart).Milliseconds(),
+		ContentLength: llmResponseTokens(modelResult),
+	})
 	if err != nil {
 		if errors.Is(err, errMessageAnswerCanceled) {
 			return
@@ -511,6 +536,9 @@ func generateMessageAnswer(id string, responseWriter http.ResponseWriter, host s
 
 	message.Text = textAnswer
 	if message.Text != "" {
+		// The assistant-side half of the "message" event pair (see the
+		// "user" one recorded near the top of this function).
+		audit.Record(audit.Event{Type: "message", SessionID: chat.Name, Role: "assistant", Text: message.Text})
 		message.ErrorText = ""
 		message.IsAlerted = false
 	}
@@ -559,6 +587,11 @@ func generateMessageAnswer(id string, responseWriter http.ResponseWriter, host s
 			chat.DisplayName = resolvedTitle
 			chat.NeedTitle = false
 			emitChatUpdate = true
+			// Mirrors the tool_call event callMcpTool records: a title is a
+			// short label OpenAgent generated for its own chat list, not the
+			// text that produced it, so recording it here does not change
+			// what this log carries about conversation content.
+			audit.Record(audit.Event{Type: "chat_title", SessionID: chat.Name, Title: resolvedTitle})
 		}
 	}
 
@@ -746,6 +779,23 @@ func (c *ApiController) GetAnswer() {
 	}
 
 	c.ResponseOk(answer)
+}
+
+func llmCallOutcome(err error) string {
+	if err != nil {
+		return "failure"
+	}
+	return "success"
+}
+
+// llmResponseTokens is nil-safe: modelResult is nil on the error paths this
+// function's caller also records, and a "failure" audit event with no token
+// count is still a useful event, not one worth losing to a nil dereference.
+func llmResponseTokens(result *model.ModelResult) int {
+	if result == nil {
+		return 0
+	}
+	return result.ResponseTokenCount
 }
 
 func printAgentSessionStart(store *object.Store, modelProviderName string, mcpToolSet *mcp.ToolSet, history []*model.RawMessage) {

--- a/controllers/message_answer_audit_test.go
+++ b/controllers/message_answer_audit_test.go
@@ -1,0 +1,42 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/the-open-agent/openagent/model"
+)
+
+func TestLlmCallOutcome(t *testing.T) {
+	if got := llmCallOutcome(nil); got != "success" {
+		t.Errorf("llmCallOutcome(nil) = %q, want success", got)
+	}
+	if got := llmCallOutcome(errors.New("boom")); got != "failure" {
+		t.Errorf("llmCallOutcome(err) = %q, want failure", got)
+	}
+}
+
+func TestLlmResponseTokens(t *testing.T) {
+	if got := llmResponseTokens(nil); got != 0 {
+		t.Errorf("llmResponseTokens(nil) = %d, want 0 (the error paths this feeds pass a nil result)", got)
+	}
+
+	result := &model.ModelResult{ResponseTokenCount: 42}
+	if got := llmResponseTokens(result); got != 42 {
+		t.Errorf("llmResponseTokens(result) = %d, want 42", got)
+	}
+}


### PR DESCRIPTION
## Summary
Emit chat_title, llm_call, and message audit events from generateMessageAnswer, so an external reader (aiguard) can show a chat's title, its conversation text, and the LLM call behind each reply.

## Changes
Add message events (Role "user"/"assistant", Text the message itself) for both the incoming question and the generated reply - the one declared exception to this log otherwise being metadata only
Add an llm_call event per answered message, filling a gap where every tool_call was already logged but the LLM call producing the reply wasn't
Add a chat_title event carrying chat.DisplayName, the same short label OpenAgent's own chat list shows, emitted right where NeedTitle is cleared
Add Title, Role, and Text as new Event fields; llm_call reuses the existing Model/ContentLength/DurationMs/Outcome fields, no new ones needed