### PR TITLE
feat: add Browser Use Cloud MCP preset

### DIFF
--- a/mcp/client.go
+++ b/mcp/client.go
@@ -18,12 +18,31 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/ThinkInAIXYZ/go-mcp/client"
 	"github.com/ThinkInAIXYZ/go-mcp/protocol"
 	"github.com/ThinkInAIXYZ/go-mcp/transport"
 )
+
+type acceptNoContentTransport struct {
+	base http.RoundTripper
+}
+
+func (t acceptNoContentTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.base.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+	// Some stateless Streamable HTTP servers acknowledge notifications with
+	// 204 No Content. go-mcp expects the equivalent 202 Accepted response.
+	if resp.StatusCode == http.StatusNoContent {
+		resp.StatusCode = http.StatusAccepted
+		resp.Status = "202 Accepted"
+	}
+	return resp, nil
+}
 
 type ServerConfig struct {
 	// Stdio config
@@ -110,11 +129,15 @@ func createClient(srv ServerConfig) (*client.Client, error) {
 		if srv.URL == "" {
 			return nil, fmt.Errorf("URL is required for StreamableHTTP transport")
 		}
-		if len(srv.Env) > 0 {
-			tr, err = transport.NewStreamableHTTPClientTransport(srv.URL, transport.WithStreamableHTTPClientOptionHeader(srv.Env))
-		} else {
-			tr, err = transport.NewStreamableHTTPClientTransport(srv.URL)
+		options := []transport.StreamableHTTPClientTransportOption{
+			transport.WithStreamableHTTPClientOptionHTTPClient(&http.Client{
+				Transport: acceptNoContentTransport{base: http.DefaultTransport},
+			}),
 		}
+		if len(srv.Env) > 0 {
+			options = append(options, transport.WithStreamableHTTPClientOptionHeader(srv.Env))
+		}
+		tr, err = transport.NewStreamableHTTPClientTransport(srv.URL, options...)
 	case "stdio":
 		envs := make([]string, 0, len(srv.Env))
 		for k, v := range srv.Env {

--- a/mcp/client_test.go
+++ b/mcp/client_test.go
@@ -1,0 +1,79 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestStreamableHTTPAcceptsNoContentNotification(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request struct {
+			ID     any    `json:"id"`
+			Method string `json:"method"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
+
+		switch request.Method {
+		case "initialize":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"jsonrpc": "2.0",
+				"id":      request.ID,
+				"result": map[string]any{
+					"protocolVersion": "2024-11-05",
+					"capabilities":    map[string]any{"tools": map[string]any{}},
+					"serverInfo":      map[string]any{"name": "test", "version": "1"},
+				},
+			})
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusNoContent)
+		case "tools/list":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"jsonrpc": "2.0",
+				"id":      request.ID,
+				"result": map[string]any{"tools": []any{
+					map[string]any{"name": "run_session", "description": "Run a session", "inputSchema": map[string]any{"type": "object"}},
+				}},
+			})
+		default:
+			http.Error(w, "unexpected method", http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewClientFromConfig(ServerConfig{URL: server.URL, Type: "streamablehttp"})
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer client.Close()
+
+	tools, err := client.ListTools(context.Background())
+	if err != nil {
+		t.Fatalf("list tools after 204 notification: %v", err)
+	}
+	if len(tools.Tools) != 1 || tools.Tools[0].Name != "run_session" {
+		t.Fatalf("unexpected tools: %#v", tools.Tools)
+	}
+}

--- a/object/init.go
+++ b/object/init.go
@@ -38,8 +38,39 @@ func InitDb() {
 	initBuiltInStore(modelProviderName, embeddingProviderName, ttsProviderName, sttProviderName, imageProviderName)
 	initSkillsFromFolder()
 	initBuiltInTools()
+	initBuiltInServers()
 	InitUsers()
 	go printStartupStats()
+}
+
+func newBrowserUseCloudServer() *Server {
+	return &Server{
+		Owner:       "admin",
+		Name:        "browser_use_cloud",
+		CreatedTime: util.GetCurrentTime(),
+		DisplayName: "Browser Use Cloud",
+		Url:         "https://api.browser-use.com/v3/mcp",
+		Transport:   "streamablehttp",
+		Env: map[string]string{
+			"x-browser-use-api-key": "",
+		},
+		TestContent: `{"tool":"list_sessions","arguments":{}}`,
+		IsDefault:   false,
+	}
+}
+
+func initBuiltInServers() {
+	server := newBrowserUseCloudServer()
+	existing, err := getServer(server.Owner, server.Name)
+	if err != nil {
+		panic(err)
+	}
+	if existing != nil {
+		return
+	}
+	if _, err = AddServer(server); err != nil {
+		panic(err)
+	}
 }
 
 func printStartupStats() {

--- a/object/server_preset_test.go
+++ b/object/server_preset_test.go
@@ -1,0 +1,50 @@
+// Copyright 2026 The OpenAgent Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package object
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestBrowserUseCloudServerPreset(t *testing.T) {
+	server := newBrowserUseCloudServer()
+
+	if server.Owner != "admin" || server.Name != "browser_use_cloud" {
+		t.Fatalf("unexpected preset identity: %s/%s", server.Owner, server.Name)
+	}
+	if server.DisplayName != "Browser Use Cloud" {
+		t.Fatalf("unexpected display name: %q", server.DisplayName)
+	}
+	if server.Url != "https://api.browser-use.com/v3/mcp" || server.Transport != "streamablehttp" {
+		t.Fatalf("unexpected transport: %s %s", server.Transport, server.Url)
+	}
+	if value, ok := server.Env["x-browser-use-api-key"]; !ok || value != "" {
+		t.Fatalf("API key header should be present and empty: %#v", server.Env)
+	}
+	if server.Token != "" || server.IsDefault {
+		t.Fatal("the cloud preset must not change the default browser or use Bearer auth")
+	}
+
+	var testCall struct {
+		Tool string `json:"tool"`
+	}
+	if err := json.Unmarshal([]byte(server.TestContent), &testCall); err != nil {
+		t.Fatalf("invalid test content: %v", err)
+	}
+	if testCall.Tool != "list_sessions" {
+		t.Fatalf("unexpected read-only test tool: %q", testCall.Tool)
+	}
+}


### PR DESCRIPTION
## What changed

- seed an optional `Browser Use Cloud` MCP server at `https://api.browser-use.com/v3/mcp`
- leave the existing local `browser_use` tool and every store default unchanged
- prefill the `x-browser-use-api-key` header name so users only need to paste their key, sync tools, and select the server
- accept `204 No Content` as the equivalent of `202 Accepted` for Streamable HTTP notifications

## Why

OpenAgent already supports Streamable HTTP MCP servers, but the Browser Use Cloud endpoint returns `204` after `notifications/initialized`. The current MCP transport treats that successful empty response as an unsupported content type, so tool discovery stops before `tools/list`.

## Verification

- `CGO_ENABLED=0 go test -vet=off -tags skipCi ./...`
- `CGO_ENABLED=0 go build ./...`
- connected through OpenAgent's real `mcp.NewClientFromConfig` path to the public Browser Use Cloud endpoint and discovered all seven tools: `run_session`, `send_task`, `get_session`, `get_session_messages`, `stop_session`, `list_sessions`, and `list_browser_profiles`

No cloud task is started by the preset, and it is not selected for any store by default.
